### PR TITLE
Strip leading and trailing whitespace from templates

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -16,7 +16,7 @@
    // Render a template with data
    $.render = function(template, data) {
       return (FN[template] = FN[template] || Function("_", "return '" +
-         template.replace(/\n/g, "").replace(/\{([^\}]+)\}/g, "'+_.$1+'") + "'")
+         template.replace(/^\s+|\n|\s+$/g, "").replace(/\{([^\}]+)\}/g, "'+_.$1+'") + "'")
       )(data);
    }
 


### PR DESCRIPTION
This allows jQuery to parse the rendered template as HTML, since the first
character of the template needs to be a '<'.
