### PR TITLE
Escape escape chars in templates

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -16,7 +16,7 @@
    // Render a template with data
    $.render = function(template, data) {
       return (FN[template] = FN[template] || Function("_", "return '" +
-         $.trim(template).replace(/\n/g, "").replace(/\{([^\}]+)\}/g, "'+_.$1+'") + "'")
+         $.trim(template).replace(/\\/g, '\\\\').replace(/\n/g, "").replace(/\{([^\}]+)\}/g, "'+_.$1+'") + "'")
       )(data);
    }
 


### PR DESCRIPTION
Allows a template like: `Escaping in JS looks like: <code>'I said, \'Hello.\'';</code>`
