### PR TITLE
Fixes #9: Limits placeholders to valid ASCII JavaScript identifiers

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -16,7 +16,7 @@
    // Render a template with data
    $.render = function(template, data) {
       return (FN[template] = FN[template] || Function("_", "return '" +
-         $.trim(template).replace(/\n/g, "").replace(/\{([^\{\}]+)\}/g, "'+_.$1+'") + "'")
+         $.trim(template).replace(/\n/g, "").replace(/\{([a-zA-Z_$][0-9a-zA-Z_$]*)\}/g, "'+_.$1+'") + "'")
       )(data);
    }
 


### PR DESCRIPTION
You probably don't need to support full Unicode identifiers.
