### PR TITLE
Overhauls render() for clarity and support for optional escaping

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -15,10 +15,10 @@
    // functions injected into the compiled template.
    var templateFunctions = {
       // minifiers will not alter object keys
-      raw: function (string) { // raw
+      raw: function (string) {
          return string;
       },
-      html: function (string) { // HTML escaped
+      html: function (string) {
          return string.replace(/[&<>"']/g, function (m) { return '&' + m.charCodeAt() + ';'; });
       }
    };


### PR DESCRIPTION
E.g. {name} or {r:name} are not escaped, but {e:name} is HTML escaped. Organization makes it trivial to add different models of escaping or change the default.

FWIW I would probably suggest changing the default to HTML escaped and having users use {r:key} to bypass escaping.

Whitespace does not match the project, but if you like the idea I'll fix that.
