### PR TITLE
Allow riotjs to be installed using Bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.gitmodules
 *~
 
+bower_components
 Thumbs.db
 ehthumbs.db
 Desktop.ini

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "riotjs",
+  "version": "0.9.1",
+  "homepage": "https://moot.it/riotjs",
+  "authors": [
+    "Tero Piirainen",
+    "Moot Inc.",
+    "other contributors"
+  ],
+  "description": "The 1kb client side MVP framework",
+  "main": "riot.js",
+  "keywords": [
+    "MVP",
+    "MVC",
+    "framework"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "todomvc",
+    "compare",
+    "lib"
+  ],
+  "dependencies": {
+    "jquery": "~2.0.3"
+  }
+}


### PR DESCRIPTION
This will allow riotjs to be installed and managed by http://bower.io/.
