### PR TITLE
"use strict" must be inside closure

### DIFF
--- a/jquery.riot.js
+++ b/jquery.riot.js
@@ -2,8 +2,8 @@
   Riot.js 0.9.3 | moot.it/riotjs | @license MIT
   (c) 2013 Tero Piirainen, Moot Inc and other contributors.
  */
-"use strict";
 (function() {
+  "use strict";
 
   // avoid multiple execution. popstate should be fired only once etc.
   if ($.riot) return;


### PR DESCRIPTION
Global strict pragma can cause many issues in future. Check it out http://www.nczonline.net/blog/2012/03/13/its-time-to-start-using-javascript-strict-mode/
