### PR TITLE
Reduce Vulnerability to XSS

### DIFF
--- a/ext/render.js
+++ b/ext/render.js
@@ -14,7 +14,7 @@
         .replace(/\n/g, "\\n")
         .replace(/\r/g, "\\r")
         .replace(/'/g, "\\'")
-        .replace(/\{\s*(\w+)\s*\}/g, "' + (_.$1 ? (_.$1 + '').replace(/</g, '&lt;').replace(/>/g, '&gt;') : (_.$1 === 0 ? 0 : '')) + '") +
+        .replace(/\{\s*(\w+)\s*\}/g, "' + (_.$1 ? (_.$1 + '').replace(/&/g, '&amp;').replace(/\"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : (_.$1 === 0 ? 0 : '')) + '") +
       "'"
     ))(data);
   }


### PR DESCRIPTION
Although fixing XSS completely is [quite difficult](http://www.coverity.com/srl/a-guide-to-fixing-xss-for-devs.html), this simple fix should at least fix the super obvious and useful case when you are using your model's properties to fill the contents of HTML elements or as attributes.

If you were to do, say, `<a href="{some_user_defined_property}"></a>`, this won't escape `javascript:` links there, but in that case escaping the data is likely to just cause more frustration than it solves (chances are, if you're going this route, you might be generating those yourself, and escaping in this case would just be a massive pain).

This _will_ catch something like `<a href="/users/{user.id}">{user.name}</a>`, which is the 99% case.
