### PR TITLE
Add package.json and dev dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ init:
 	bower install
 
 jshint:
-	jshint lib/*.js
+	./node_modules/jshint/bin/jshint lib/*.js
 
 riot:
 	@ cat license.js > riot.js
@@ -11,7 +11,7 @@ riot:
 	@ echo '})(typeof top == "object" ? window.$$ || (window.$$ = {}) : exports);' >> riot.js
 
 min: riot
-	uglifyjs riot.js --comments --mangle -o riot.min.js
+	./node_modules/uglify-js/bin/uglifyjs riot.js --comments --mangle -o riot.min.js
 
 test: min
 	node test/node.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "riotjs",
+  "version": "0.9.8",
+  "description": "Riot is an incredibly fast and powerful yet tiny client side library for building large scale web applications.",
+  "keywords": [
+    "MVP",
+    "MVC",
+    "framework",
+    "library"
+  ],
+  "main": "riot.js",
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "uglifyjs": "~2.3.6",
+    "jshint": "~2.4.3"
+  },
+  "devDependencies": {
+    "jshint": "~2.4.3",
+    "uglify-js": "~2.4.12"
+  },
+  "scripts": {
+    "test": "make test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/moot/riotjs.git"
+  },
+  "author": "Tero Piirainen",
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "gitHead": "aee612dbaef2cb3f7bfe477218d04b1ec5c21513"
+}


### PR DESCRIPTION
Now to run make's `test` and `jshint` tasks you can install dependencies using `npm install`.
