### PR TITLE
Fix rendering issue when rendered property is a boolean at false

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -29,7 +29,7 @@ $.render = function(template, data) {
         function(escape) { return ESCAPING_MAP[escape]; }
       ).replace(
         /\{\s*([\.\w]+)\s*\}/g,
-        "'+(function(){try{return(_.$1?(_.$1+'').replace(/[&\"<>]/g,function(e){return E[e];}):(_.$1===0?0:''))}catch(e){return ''}})()+'"
+        "'+(function(){try{return(typeof(_.$1)!=='undefined'?(_.$1+'').replace(/[&\"<>]/g,function(e){return E[e];}):'')}catch(e){return ''}})()+'"
       )+"'"
   );
 


### PR DESCRIPTION
There's a bug when the property to render is a boolean set to false. I guess the aim is to provide detection for non-existent properties, hence the 2nd check for 0 values. I propose to use `typeof` instead, which also removes the need for additional checks for false-equivalent values.
