### PR TITLE
I think  the events parameter should be trimed

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -6,7 +6,7 @@ $.observable = function(el) {
 
   el.on = function(events, fn) {
     if (typeof fn === "function") {
-      events.replace(/[^\s]+/g, function(name, pos) {
+      events.trim().replace(/[^\s]+/g, function(name, pos) {
         (callbacks[name] = callbacks[name] || []).push(fn);
         fn.typed = pos > 0;
       });


### PR DESCRIPTION
I think  the events parameter should be trimed in case that user use " \* " by mistake
