### PR TITLE
add CommonJS and AMD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ riot:
 	@ cat license.js > riot.js
 	@ echo '(function(riot) { "use strict";' >> riot.js
 	@ cat lib/* >> riot.js
-	@ echo '})(typeof window !== "undefined" ? window.riot = {} : exports);' >> riot.js
+	@ cat loaders.js >> riot.js
+	@ echo '})(typeof window !== "undefined" ? window : global);' >> riot.js
 
 min: riot
 	./node_modules/uglify-js/bin/uglifyjs riot.js --comments --mangle -o riot.min.js --source-map=riot.min.js.map

--- a/loaders.js
+++ b/loaders.js
@@ -1,0 +1,11 @@
+if (typeof exports === 'object') {
+  // CommonJS support
+  module.exports = riot;
+} else if (typeof define === 'function' && define.amd) {
+  // AMD support
+  define(function() { return riot; });
+} else {
+  // browser support
+  this.riot = riot;
+}
+

--- a/riot.js
+++ b/riot.js
@@ -115,4 +115,15 @@ riot.render = function(tmpl, data, escape_fn) {
 
   };
 })();
-})(typeof window !== "undefined" ? window.riot = {} : exports);
+if (typeof exports === 'object') {
+  // CommonJS support
+  module.exports = riot;
+} else if (typeof define === 'function' && define.amd) {
+  // AMD support
+  define(function() { return riot; });
+} else {
+  // browser support
+  this.riot = riot;
+}
+
+})(typeof window !== "undefined" ? window : global);


### PR DESCRIPTION
using RiotJS as a node module feels weird now

```
require('riotjs')
var riot = window.riot
```

this fixes it to

```
var riot = require('riotjs')
```
