### PR TITLE
Fix bug with multiple equal callbacks not being removed with 'off' call

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -19,7 +19,7 @@ riot.observable = function(el) {
     else if (fn) {
       var arr = callbacks[events];
       for (var i = 0, cb; (cb = arr && arr[i]); ++i) {
-        if (cb === fn) arr.splice(i, 1);
+        if (cb === fn) { arr.splice(i, 1); i--; }
       }
     } else {
       events.replace(/[^\s]+/g, function(name) {

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -92,6 +92,19 @@ describe("Observable", function() {
 
   });
 
+  it("Removes duplicate callbacks on 'off' for specific handler", function() {
+
+    var counter = 0;
+
+    function fn() {
+      counter++;
+    }
+
+    el.on("a1", fn).on("a1", fn).trigger("a1").off("a1", fn).trigger("a1");
+
+    assert.equal(counter, 2);
+  });
+
   it("does not call trigger infinitely", function() {
     var counter = 0,
       otherEl = riot.observable({});


### PR DESCRIPTION
This fixes a problem with adding multiple identical callbacks and then removing them with an "off" call, expecting all to be removed.
