### PR TITLE
Refine the on method regexp rule to make it more readable

### DIFF
--- a/riot.js
+++ b/riot.js
@@ -6,7 +6,7 @@ riot.observable = function(el) {
 
   el.on = function(events, fn) {
     if (typeof fn === "function") {
-      events.replace(/[^\s]+/g, function(name, pos) {
+      events.replace(/\S+/g, function(name, pos) {
         (callbacks[name] = callbacks[name] || []).push(fn);
         fn.typed = pos > 0;
       });


### PR DESCRIPTION
/[^\s]+/g equals to /\S+/g, but the former is hard to understand.
