### PR TITLE
Refine the replace regexp rule to make it more readable

### DIFF
--- a/lib/observable.js
+++ b/lib/observable.js
@@ -4,7 +4,7 @@ riot.observable = function(el) {
 
   el.on = function(events, fn) {
     if (typeof fn === "function") {
-      events.replace(/[^\s]+/g, function(name, pos) {
+      events.replace(/\S+/g, function(name, pos) {
         (callbacks[name] = callbacks[name] || []).push(fn);
         fn.typed = pos > 0;
       });
@@ -20,7 +20,7 @@ riot.observable = function(el) {
         if (cb === fn) { arr.splice(i, 1); i--; }
       }
     } else {
-      events.replace(/[^\s]+/g, function(name) {
+      events.replace(/\S+/g, function(name) {
         callbacks[name] = [];
       });
     }

--- a/riot.js
+++ b/riot.js
@@ -6,7 +6,7 @@ riot.observable = function(el) {
 
   el.on = function(events, fn) {
     if (typeof fn === "function") {
-      events.replace(/[^\s]+/g, function(name, pos) {
+      events.replace(/\S+/g, function(name, pos) {
         (callbacks[name] = callbacks[name] || []).push(fn);
         fn.typed = pos > 0;
       });
@@ -22,7 +22,7 @@ riot.observable = function(el) {
         if (cb === fn) { arr.splice(i, 1); i--; }
       }
     } else {
-      events.replace(/[^\s]+/g, function(name) {
+      events.replace(/\S+/g, function(name) {
         callbacks[name] = [];
       });
     }


### PR DESCRIPTION
/[^\s]+/g equals to /\S+/g, but the former is hard to understand. Just like #122, but also changed the lib/observable.js. The riot.js is produced by make riot.
