### PR TITLE
input type=number and riot-tag as expression

### DIFF
--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -101,7 +101,7 @@ function update(expressions, tag, item) {
       dom.value = value
 
     // <img src="{ expr }">
-    } else if (attrName.slice(0, 5) == 'riot-') {
+    } else if (attrName.slice(0, 5) == 'riot-' && attrName != 'riot-tag') {
       attrName = attrName.slice(5)
       value ? dom.setAttribute(attrName, value) : remAttr(dom, attrName)
 

--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -26,7 +26,8 @@ var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,contr
   HTML_COMMENT = /<!--.*?-->/g,
   CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
   LINE_COMMENT = /^\s*\/\/.*$/gm,
-  JS_COMMENT = /\/\*[^\x00]*?\*\//gm
+  JS_COMMENT = /\/\*[^\x00]*?\*\//gm,
+  INPUT_NUMBER = /(<input.+?)(type)=('|")number('|")/gm
 
 function mktag(name, html, css, attrs, js) {
   return 'riot.tag(\''
@@ -49,6 +50,9 @@ function compileHTML(html, opts, type) {
 
   // strip comments
   html = html.trim().replace(HTML_COMMENT, '')
+
+  // input type=numbr
+  html = html.replace(INPUT_NUMBER, '$1riot-type={"number"}') // fake expression
 
   // alter special attribute names
   html = html.replace(SET_ATTR, function(full, name, _, expr) {

--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -52,7 +52,7 @@ function compileHTML(html, opts, type) {
   html = html.trim().replace(HTML_COMMENT, '')
 
   // input type=numbr
-  html = html.replace(INPUT_NUMBER, '$1riot-type={"number"}') // fake expression
+  html = html.replace(INPUT_NUMBER, '$1riot-type='+brackets(0)+'"number"'+brackets(1)) // fake expression
 
   // alter special attribute names
   html = html.replace(SET_ATTR, function(full, name, _, expr) {

--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -27,7 +27,7 @@ var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,contr
   CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
   LINE_COMMENT = /^\s*\/\/.*$/gm,
   JS_COMMENT = /\/\*[^\x00]*?\*\//gm,
-  INPUT_NUMBER = /(<input.+?)(type)=('|")number('|")/gm
+  INPUT_NUMBER = /(<input\s[^>]*?)type=['"]number['"]/gm
 
 function mktag(name, html, css, attrs, js) {
   return 'riot.tag(\''

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -328,7 +328,15 @@ describe('Compiler Browser', function() {
 
           // Don't trigger mount for conditional tags
           '<script type=\"riot\/tag\" src=\"tag\/if-mount.tag\"><\/script>',
-          '<if-mount><\/if-mount>'
+          '<if-mount><\/if-mount>',
+
+          // input type=number
+          '<script type=\"riot\/tag\" src=\"tag\/input-number.tag\"><\/script>',
+          '<input-number><\/input-number>',
+
+          // input type=number
+          '<script type=\"riot\/tag\" src=\"tag\/nested-riot.tag\"><\/script>',
+          '<container-riot><\/container-riot>'
 
     ].join('\r'),
       tags = [],
@@ -1026,6 +1034,21 @@ describe('Compiler Browser', function() {
       expect(tag.checks[2].value).to.be('three')
     })
 
+    tags.push(tag)
+  })
+
+  it('input type=number', function() {
+    var tag = riot.mount('input-number', {num: 123})[0]
+    var inp = tag.root.getElementsByTagName('input')[0]
+    expect(inp.getAttribute('type')).to.be('number')
+    expect(inp.value).to.be('123')
+    tags.push(tag)
+  })
+
+  it('riot-tag as expression', function() {
+    var tag = riot.mount('container-riot')[0]
+    var div = tag.root.getElementsByTagName('div')[0]
+    expect(div.getAttribute('riot-tag')).to.be('nested-riot')
     tags.push(tag)
   })
 

--- a/test/tag/input-number.tag
+++ b/test/tag/input-number.tag
@@ -1,0 +1,3 @@
+<input-number>
+  <input value="{opts.num}" type="number" />
+</input-number>

--- a/test/tag/nested-riot.tag
+++ b/test/tag/nested-riot.tag
@@ -1,0 +1,8 @@
+<nested-riot>
+  <p>hello</p>
+</nested-riot>
+
+<container-riot>
+  <div riot-tag="{ show }"></div>
+  this.show = "nested-riot"
+</container-riot>


### PR DESCRIPTION
#817 and #827 

My original approach to the number issue was to change the type at compile and set attributes on mount, but the server side code does not support querySelectorAll, so I came up with the fake expression approach.  I don't think this will be an issue, it would be an edge case where there were enough input type=number on a page to effect performance, even then it would be minimal since the fake expression is a string literal.  Checked in ie [here](http://plnkr.co/edit/gU1RrEjWacrhbKsjMIf9?p=preview)