### PR TITLE
Ability to specify where injected styles go in the head tag

### DIFF
--- a/doc/meta.html
+++ b/doc/meta.html
@@ -35,7 +35,7 @@ datetime: May 20
 
   <p class="tease normal">
     <a href="download.html" class="tag blue">v{{ riot_version }}</a>
-    — <a href="release-notes.html"> witn mixins and root attributes</a>
+    — <a href="release-notes.html"> with mixins and root attributes</a>
   </p>
 
 </div>

--- a/lib/browser/tag/vdom.js
+++ b/lib/browser/tag/vdom.js
@@ -29,10 +29,10 @@ function injectStyle(css) {
     if (styleNode.styleSheet) {
       document.body.appendChild(styleNode)
     } else {
-      var riotStyle = document.querySelector('style[type=riot]')
-      if (riotStyle) {
-        riotStyle.parentNode.insertBefore(styleNode, riotStyle)
-        riotStyle.parentNode.removeChild(riotStyle)
+      var rs = $$('style[type=riot]')[0]
+      if (rs) {
+        rs.parentNode.insertBefore(styleNode, rs)
+        rs.parentNode.removeChild(rs)
       } else {
         document.head.appendChild(styleNode)
       }

--- a/lib/browser/tag/vdom.js
+++ b/lib/browser/tag/vdom.js
@@ -26,10 +26,17 @@ function injectStyle(css) {
     styleNode.innerHTML += css
 
   if (!styleNode._rendered)
-    if (styleNode.styleSheet)
+    if (styleNode.styleSheet) {
       document.body.appendChild(styleNode)
-    else
-      document.head.appendChild(styleNode)
+    } else {
+      var riotStyle = document.querySelector('style[type=riot]')
+      if (riotStyle) {
+        riotStyle.parentNode.insertBefore(styleNode, riotStyle)
+        riotStyle.parentNode.removeChild(riotStyle)
+      } else {
+        document.head.appendChild(styleNode)
+      }
+    }
 
   styleNode._rendered = true
 

--- a/test/runner.html
+++ b/test/runner.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <title>Riot.js tests</title>
+    <style type="riot"></style>
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" type="text/css" />
     <!--[if lt IE 9]>
       <script src="polyfills/es5-shim.js"></script>

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -849,6 +849,19 @@ describe('Compiler Browser', function() {
     expect(styles).to.match(/div(.+)?{color: red;}/)
   })
 
+  it('style injection removes type riot style tag', function() {
+    var stag = document.querySelector('style[type=riot]')
+    expect(stag).to.be(null)
+  })
+
+  it('style tag sits in between title and link to stylesheet', function() {
+    var stag = document.querySelector('style')
+    var prevE = stag.previousElementSibling
+    var nextE = stag.nextElementSibling
+    expect(prevE.tagName).to.be('TITLE')
+    expect(nextE.tagName).to.be('LINK')
+  })
+
   it('scoped css and riot-tag, mount(selector, tagname)', function() {
     function checkBorder(t) {
       var e = t.root.firstElementChild

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -854,13 +854,15 @@ describe('Compiler Browser', function() {
     expect(stag).to.be(null)
   })
 
-  it('style tag sits in between title and link to stylesheet', function() {
-    var stag = document.querySelector('style')
-    var prevE = stag.previousElementSibling
-    var nextE = stag.nextElementSibling
-    expect(prevE.tagName).to.be('TITLE')
-    expect(nextE.tagName).to.be('LINK')
-  })
+  if (typeof window.__karma__ === 'undefined') {
+    it('style tag sits in between title and link to stylesheet', function () {
+      var stag = document.querySelector('style')
+      var prevE = stag.previousElementSibling
+      var nextE = stag.nextElementSibling
+      expect(prevE.tagName).to.be('TITLE')
+      expect(nextE.tagName).to.be('LINK')
+    })
+  }
 
   it('scoped css and riot-tag, mount(selector, tagname)', function() {
     function checkBorder(t) {


### PR DESCRIPTION
In reference to #846

Place this placeholder anywhere you want in your `head`.
```html
<style type="riot"></style>
```
Riot will then replace this placeholder with your components styles.