### PR TITLE
fix e.item bug

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -171,6 +171,14 @@ You can put a `style` tag inside. Riot.js automatically takes it out and injects
 
 This happens once, no matter how many times the tag is initialized.
 
+To make it easier to override the CSS you can specify where in the `<head>` Riot should inject tag styles:
+
+```html
+<style type="riot"></style>
+```
+
+Example use case would be to insert tag styles from a component library after normalize.css but before your website's theme CSS allowing you to override the library's default styling.
+
 ## Mounting
 
 Once a tag is created you can mount it on the page as follows:

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -3,7 +3,7 @@ function setEventHandler(name, handler, dom, tag, item, isLoop) {
 
   dom[name] = function(e) {
 
-    var item = tag.item || item
+    item = tag.item || item
 
     // cross browser event fix
     e = e || window.event


### PR DESCRIPTION
using `var item = tag.item || item` ,  item will be undefined when (!tag.item)