### PR TITLE
Use riot instead of this to share globally a mixing

### DIFF
--- a/doc/guide/index.md
+++ b/doc/guide/index.md
@@ -316,7 +316,7 @@ To load the mixin to the tag, use `mixin()` method with the key.
 <my-tag>
     <h1>{ opts.title }</h1>
 
-    this.mixin('mixinName')
+    riot.mixin('mixinName')
 </my-tag>
 ```
 


### PR DESCRIPTION
`this.mixin('mixinName')` does not work, but it's ok with `riot.mixin('mixinName')` 

```html
<my-tag>
    <h1>{ opts.title }</h1>

    riot.mixin('mixinName')
</my-tag>
```