### PR TITLE
Riot is not longer 3.5kb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![Riot logo](doc/logo/riot480x.png)](https://muut.com/riotjs/)
 
-## A React- like, 3.5KB UI lib
+## A React- like, 12.75kb UI lib
 
 [![Build Status][travis-image]][travis-url]
 [![Riot Forum][riot-forum-image]][riot-forum-url]
@@ -14,6 +14,16 @@
 
 
 [![Sauce Test Status][saucelabs-image]][saucelabs-url]
+
+### Framework Size Comparison
+
+| Framework              | Version    | Minified Size |
+|------------------------|------------|---------------|
+| Ember                  | 1.13.3     | 493.3kb       |
+| Angular                | 1.4.2      | 145.5kb       |
+| React                  | 0.13.3     | 121.7kb       |
+| Web Components Polyfill| 0.7.5      | 117.1kb       |
+| Riot                   | 2.2.2-beta | 12.75kb       |
 
 
 ### Custom tags • Concise syntax • Virtual DOM • Full stack • IE8


### PR DESCRIPTION
It's still 1/10th the size of react which is awesome, so I've included a table of comparisons

but when I first began moving towards riot, it was based on 3.5kb not 12.75kb