### PR TITLE
tmpl.js - complete rewrite (2)

### DIFF
--- a/lib/browser/tmpl.js
+++ b/lib/browser/tmpl.js
@@ -309,8 +309,8 @@ var tmpl = (function () {
 
   function skipBracketedPart(str, opench, chpos, qskip) {
 
-    var recch = opench === '(' ? /[\(\)]/g :
-                opench === '[' ? /[\[\]]/g : /[{}]/g,
+    var recch = opench === '(' ? /(\(|\))/g :
+                opench === '[' ? /(\[|\])/g : /({|})/g,
         match,
         level = 1
 
@@ -323,11 +323,11 @@ var tmpl = (function () {
 
     while (level && (match = recch.exec(str))) {
 
-      if (match[0].length < 2)
-         (match[0] !== opench ? --level : qskip ? (qskip = 0) : ++level)
+      if (match[1])
+        match[1] !== opench ? --level : qskip ? (qskip = 0) : ++level
     }
 
-    return match ? recch.lastIndex : str.length
+    return level ? str.length : recch.lastIndex
 
   }
 

--- a/lib/browser/tmpl.js
+++ b/lib/browser/tmpl.js
@@ -194,9 +194,7 @@ var tmpl = (function (/*DEBUG*/) {
       RE_COMMENTS.source + '|' +      // skips comments
       RE_QSTRINGS.source + '|' +      // $1: left quote. skips strings
       '(/(?:\\\\?.|\\s)+?/)',         // $2: regexp (prefix with `//|` to omit '//')
-      'g'),
-
-    EMPTYSTR = '""'
+      'g')
 
 
   // Private function
@@ -207,7 +205,7 @@ var tmpl = (function (/*DEBUG*/) {
     // You can drop debugging blocks in your minimized version by using uglify
     // conditional compilation options: `-c -d DEBUG=false`
 
-    //if (DEBUG) { if (console && console.info) console.info('recv: \'' +
+    //if (DEBUG) { if (console && console.info) console.info(' in: \'' +
     //str.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t') + '\'') }
 
     // Empty strings never get here. This function is only called from _tmpl,
@@ -265,7 +263,7 @@ var tmpl = (function (/*DEBUG*/) {
 
       expr = j > 1 ?                            // optimize code for 0-1 parts
              '[' + list.join(',') + '].join("")' :
-             j ? '""+' + list[0] : EMPTYSTR
+             j ? '""+' + list[0] : '""'
 
     }
     else {
@@ -284,7 +282,7 @@ var tmpl = (function (/*DEBUG*/) {
       expr = expr.replace(ICH_REGEXP, rex[i])
     }
 
-    //if (DEBUG) { if (console && console.info) console.info(' OUT: ' +
+    //if (DEBUG) { if (console && console.info) console.info('OUT: ' +
     //expr.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t')) }
 
     // Now, we can create the function to return by calling the Function constructor.
@@ -759,7 +757,7 @@ var tmpl = (function (/*DEBUG*/) {
         mvar = match[2]
 
         if (JS_FALSY[mvar])
-          ss.push(astxt ? EMPTYSTR : mvar)            // mode 1 (text) returns ''
+          ss.push(astxt ? '""' : mvar)                // mode 1 (text) returns ''
 
         else {
           ss.push(mvar in JS_FALSY ? mvar : ('("' + mvar + VAR_CONTEXT + mvar))
@@ -773,7 +771,7 @@ var tmpl = (function (/*DEBUG*/) {
 
       if (wrap)
         expr = '(function(v){try{v=' + expr +
-                '}catch(e){}return ' + WRAP_RETVAL[astxt] + '}).call(D)'
+                '}finally{return ' + WRAP_RETVAL[astxt] + '}}).call(D)'
 
       //else if (astxt)
       //  expr = '((v=' + expr + ')||v===0v:"")'
@@ -800,5 +798,5 @@ var tmpl = (function (/*DEBUG*/) {
   return _tmpl        // the exposed function
 
 
-})(0)
+})()
 // end of IIFE for tmpl

--- a/lib/browser/tmpl.js
+++ b/lib/browser/tmpl.js
@@ -36,6 +36,14 @@ tmpl('{ undefined } - { false } - { null } - { 0 }', {})
 
 */
 
+var REGLOB = 'g'
+
+function newRegExp(restr, opts) {
+
+  return new RegExp(restr, opts)
+
+}
+
 var brackets = (function (defaults) {
 
   var cachedBrackets,
@@ -49,16 +57,14 @@ var brackets = (function (defaults) {
 
     pairs[4] = brackets(/\\({|})/g)
 
-    pairs[5] = new RegExp(
-        '(\\\\?)(?='       +
-        '([{\\[\\(])|'     +
-          pairs[2] + '|'   +
+    s = '(\\\\?)('
+
+    pairs[5] = newRegExp(s + pairs[2] + ')', REGLOB)
+
+    pairs[6] = s           +
+        '?:([{\\[\\(])|('  +
           pairs[3]         +
-        ')(?:('            +
-          pairs[2] + ')|(' +
-          pairs[3]         +
-        ')|.)?',
-        'g')
+        '))'
   }
 
   return function _brackets(reOrIdx) {
@@ -72,9 +78,9 @@ var brackets = (function (defaults) {
       return s === defaults ?
         reOrIdx :
 
-        new RegExp(
-          reOrIdx.source.replace(/{|}/g, function (b) { return pairs[(b === '}') + 2] }),
-          reOrIdx.global && 'g'
+        newRegExp(
+          reOrIdx.source.replace(/[{}]/g, function (b) { return pairs[(b === '}') + 2] }),
+          reOrIdx.global && REGLOB
         )
     }
 
@@ -86,7 +92,15 @@ var brackets = (function (defaults) {
 
 var tmpl = (function () {
 
-  var cache = {}
+  var cache = {},
+
+      ICH_QSTRING = '\uFFF1',
+
+      RE_QSMARKER = /@(\d+)\uFFF1/g,
+
+      RE_QBLOCKS =
+      /("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*')|\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/|((?:^|[-\+\*%~^&\|!=><\?:{\(\[,;]|\/\s)\s*)(\/(?!\/)(?:\[[^\]]*\]|\\.|[^/\[\\]+)*\/)/g
+      // $1: string - big regexp but secure and fast!     | Comments (not captured)        | $2 matches valid token before regexp      | $3 the regexp
 
   function _tmpl(str, data) {
 
@@ -94,31 +108,32 @@ var tmpl = (function () {
 
   }
 
-  var
-
-    ICH_QSTRING = '\uFFF1',
-
-    RE_QSMARKER = /@(\d+)\uFFF1/g,
-
-    RE_QSTRINGS = /('|")(?:[^\\]|\\.)*?\1/g,
-
-    RE_COMMENTS = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g,
-
-    RE_REGEXPS = /\/(?!\/|\*)((?:\[(?:[^\]\\]|\\.)*|[^/\\]|\\.)+\/)/,
-
-    RE_PREREGS = /(?:^|[-\+\*%~^&\|!=><\?:{\(\[,;]|\/\s)\s*$/
-
   function create(str) {
 
-    var hqs = [],
+    var hqb = [],
         expr,
+        i,
 
-        parts = splitByPairs(str, hqs)
+        parts = splitByPairs(str)
+
+    for (i = 1; i < parts.length; i += 2) {
+
+      parts[i] = parts[i].replace(RE_QBLOCKS, function (match, qstr, prere, regex) {
+
+        if (match.length > 2) {
+
+          match = (qstr || regex) ?
+            (prere || '') + '@' + (hqb.push(regex || match) -1) + ICH_QSTRING :
+            ' '
+        }
+
+        return match
+      })
+    }
 
     if (parts.length > 2 || parts[0]) {
 
       var list = [],
-          i,
           j
 
       for (i = j = 0; i < parts.length; ++i) {
@@ -129,7 +144,7 @@ var tmpl = (function () {
 
               i & 1 ?
 
-              parseExpr(expr, 1, hqs) :
+              parseExpr(expr, 1, hqb) :
 
               '"' + expr
                 .replace(/\r?\n|\r/g, '\\n')
@@ -147,12 +162,12 @@ var tmpl = (function () {
     }
     else {
 
-      expr = parseExpr(parts[1], 0, hqs)
+      expr = parseExpr(parts[1], 0, hqb)
 
     }
 
     expr = expr.replace(RE_QSMARKER, function (_, pos) {
-            return hqs[pos | 0]
+            return hqb[pos | 0]
               .replace(/\n/g, '\\n')
               .replace(/\r/g, '\\r')
           })
@@ -161,27 +176,19 @@ var tmpl = (function () {
 
   }
 
-  var RE_QBLOCKS = newRegExp(
-      RE_QSTRINGS.source + '|' +
-      RE_COMMENTS.source + '|' +
-      RE_REGEXPS.source,
-      'g'
-    )
+  function splitByPairs(str) {
 
-  function splitByPairs(str, hqs) {
-
-    var eb = brackets(4),
-        re = brackets(5),
-        parts = [],
+    var parts = [],
         start,
         match,
         pos,
         isexpr,
+        eb  = brackets(4),
+        re  = brackets(5),
 
-        qposLt = -1,
-        qmatch
+        REs = [re, newRegExp(brackets(6) + '|' + RE_QBLOCKS.source, REGLOB)]
 
-    re.lastIndex = start = isexpr = 0
+    start = isexpr = 0
 
     while ((match = re.exec(str))) {
 
@@ -189,89 +196,33 @@ var tmpl = (function () {
 
       if (isexpr) {
 
-        if (haveQBlock(re, pos))
-          continue
-
         if (match[2]) {
 
-          re.lastIndex = skipBracketedPart(str, match[2], !!match[1] + pos, haveQBlock)
+          re.lastIndex = skipBracketedPart(str, match[2], !!match[1] + pos, 1)
           continue
         }
+
+        if (!match[3])
+          continue
       }
 
-      if (match[isexpr +3] && !match[1]) {
+      if (!match[1]) {
 
-        unescapeStr(parts, str.slice(start, pos))
+        unescapeStr(str.slice(start, pos))
 
         start = re.lastIndex
-        isexpr ^= 1
+        re = REs[isexpr ^= 1]
+        re.lastIndex = start
       }
     }
 
     if (start < str.length)
-      unescapeStr(parts, str.slice(start))
+      unescapeStr(str.slice(start))
 
     return parts
 
-    function unescapeStr(arr, str) {
-
-      arr.push(str && str.replace(eb, '$1'))
-
-    }
-
-    function haveQBlock(re, pos) {
-
-      var qblock,
-          qposRt,
-          marker
-
-      while (qposLt <= pos) {
-
-        if (qposLt < start) qposRt = start
-
-        else {
-
-          qposRt = RE_QBLOCKS.lastIndex
-
-          if ((qblock = qmatch[0]).length > 2) {
-
-            marker = qmatch[1] ?
-              '@' + hqs.length + ICH_QSTRING :
-              ' '
-
-            unescapeStr(hqs, qblock)
-
-            str = str.slice(0, qposLt) + marker + str.slice(qposRt)
-
-            re.lastIndex = qposRt = qposLt + marker.length
-
-            pos = -1
-
-          }
-        }
-
-        do {
-
-          RE_QBLOCKS.lastIndex = qposRt++
-          qmatch = RE_QBLOCKS.exec(str)
-
-          if (qmatch) {
-            qposLt = qmatch.index
-
-            if (qmatch[2]) {
-              if (!RE_PREREGS.test(str.slice(start, qposLt)))
-                qposLt = 0
-              qmatch[1] = '/'
-            }
-          }
-          else qposLt = str.length
-
-        } while (!qposLt)
-
-      }
-
-      return pos < 1
-
+    function unescapeStr(str) {
+      parts.push(str && str.replace(eb, '$1'))
     }
 
   }
@@ -294,11 +245,10 @@ var tmpl = (function () {
 
     cslist = csinfo.map(function (kv) {
 
-      if (kv[0]) {
+      if (kv[0])
         kv[1] = qstr[kv[0] | 0]
           .slice(1, -1)
-          .replace(/[ \r\n\t]+/g, ' ').trim()
-      }
+          .replace(/\s+/g, ' ').trim()
 
       return '(' +
           wrapExpr(kv[2], 0) +
@@ -317,12 +267,11 @@ var tmpl = (function () {
       CSNAME_PART = newRegExp(
         '^(' +
         RE_QSMARKER.source +
-        '|-?[_A-Za-z\xA0-\xFF][-\\w\xA0-\xFF]*' +
-
+        '|-?[_A-Za-z][-\\w]*' +
         '):'
       ),
 
-      CSPART_END = /([\[{\(])|,|$/g
+      CSPART_END = /,|([\[{\(])|$/g
 
   function extractCSList(str, list) {
 
@@ -342,9 +291,7 @@ var tmpl = (function () {
       CSPART_END.lastIndex = 0
 
       while ((end = CSPART_END.exec(str)) && (ch = end[1])) {
-
         CSPART_END.lastIndex = skipBracketedPart(str, ch, end.index)
-
       }
 
       list[n++] = [
@@ -356,33 +303,28 @@ var tmpl = (function () {
       str = gre.rightContext
     }
 
-    if (n && str)
-        throw new SyntaxError('Cannot parse ... ' + str + '}')
-
     return n
 
   }
 
-  var JS_BRACKETS = {
-        '{': /\{|\}/g,
-        '[': /\[|\]/g,
-        '(': /\(|\)/g
-      }
+  function skipBracketedPart(str, opench, chpos, qskip) {
 
-  function skipBracketedPart(str, opench, chpos, sqcb) {
-
-    var recch = JS_BRACKETS[opench],
+    var recch = opench === '(' ? /[\(\)]/g :
+                opench === '[' ? /[\[\]]/g : /[{}]/g,
         match,
         level = 1
 
-    recch.lastIndex = chpos + 1
+    if (qskip)
+      recch = newRegExp(recch.source + '|' + RE_QBLOCKS.source, REGLOB)
+    else
+      chpos++
+
+    recch.lastIndex = chpos
 
     while (level && (match = recch.exec(str))) {
 
-      if (sqcb && sqcb(recch, match.index))
-        return chpos
-
-      match[0] === opench ? ++level : --level
+      if (match[0].length < 2)
+         (match[0] !== opench ? --level : qskip ? (qskip = 0) : ++level)
     }
 
     return match ? recch.lastIndex : str.length
@@ -392,17 +334,12 @@ var tmpl = (function () {
   var
 
       VAR_CONTEXT = '"in D?D:' + (typeof window === T_OBJECT ? 'window' : 'global') + ').',
-      WRAP_RETVAL = [
-          'v',
-          'v||v===0?v:""'
-        ],
 
-      SRE_VARNAME = '[$_A-Za-z\xA0-\xFF][$\\w\xA0-\xFF]*',
+      SRE_VARNAME = '[$_A-Za-z][$\\w]*',
 
       JS_VARSTART = newRegExp(
-          '(?:^ ?|' +
-          '(?![$\\w\xA0-\xFF\\.])(.))' +
-          '(?!(?:typeof|in|instanceof|void|true|new|function)\\b)' +
+          '(^ *|[^$\\w\\.])' +
+          '(?!(?:typeof|in|instanceof|void|true|new|function)[^$\\w])' +
 
           '(' + SRE_VARNAME + ')'
         ),
@@ -410,21 +347,21 @@ var tmpl = (function () {
       JS_OBJKEYS = newRegExp(
           '(?=[,{]'   +
           SRE_VARNAME +
-          '?:)(.)',
-          'g'
+          ':)(.)',
+          REGLOB
         ),
 
       JS_FALSY = {
         'this': 0,
-        'global': 0,
         'window': 0,
+        'global': 0,
         'undefined': 1,
         'false': 1,
         'null': 1,
         'NaN': 1
-      }
+        }
 
-  function wrapExpr(expr, astxt) {
+  function wrapExpr(expr, txt) {
 
     var okeys = ~expr.indexOf('{')
     if (okeys)
@@ -445,12 +382,12 @@ var tmpl = (function () {
         mvar = match[2]
 
         if (JS_FALSY[mvar])
-          ss.push(astxt ? '""' : mvar)
+          ss.push(txt ? '""' : mvar)
 
         else {
-          ss.push(mvar in JS_FALSY ? mvar : ('("' + mvar + VAR_CONTEXT + mvar))
+          ss.push(mvar in JS_FALSY ? mvar : '("' + mvar + VAR_CONTEXT + mvar)
 
-          wrap = wrap || astxt || /^[\[\(\.]/.test(expr)
+          wrap = wrap || txt || /^[\[\(\.]/.test(expr)
         }
 
       } while ((match = expr.match(JS_VARSTART)))
@@ -459,7 +396,7 @@ var tmpl = (function () {
 
       if (wrap)
         expr = '(function(v){try{v=' + expr +
-                '}finally{return ' + WRAP_RETVAL[astxt] + '}}).call(D)'
+                '}catch(e){}return ' + (txt ? 'v||v===0?v:""' : 'v') + '}).call(D)'
 
     }
 
@@ -467,13 +404,6 @@ var tmpl = (function () {
 
   }
 
-  function newRegExp(restr, opts) {
-
-    return new RegExp(restr, opts)
-
-  }
-
   return _tmpl
 
 })()
-

--- a/lib/browser/tmpl.js
+++ b/lib/browser/tmpl.js
@@ -37,215 +37,768 @@ tmpl('{ undefined } - { false } - { null } - { 0 }', {})
 */
 
 
-var brackets = (function(orig) {
+//// ------------------------------------------------------------------------------------
+//// brackets() function
+//// ------------------------------------------------------------------------------------
 
-  var cachedBrackets,
-      r,
-      b,
-      re = /[{}]/g
+// Low level function for track changes to the brackets.
+// Parameter can be one of:
+//
+// RegExp - If the current brackets are the defaults, returns the original regexp, else
+//          returns a new regexp with the default brackets replaced by the custom ones.
+//          WARNING: new custom regexp discards the /i and /m flags.
+// number - If number is...
+//          0,1 -returns the current left (0) or right (1) brackets characters
+//          2,3 -returns the current left (3) or right (4) escaped brackets characters
+//          4   -returns regexp based on /\\({|})/g for match escaped brackets
+//          5   -returns regexp based on /(\\?)(?=([{\[\(])|{|})(?:({)|(})|.)?/g for
+//               match opening riot and js brackets
 
-  return function(x) {
+// IIFE
+var brackets = (function (defaults) {
 
-    // make sure we use the current setting
-    var s = riot.settings.brackets || orig
+  // Cache on closure, initialized on first use and on bracket changes
 
-    // recreate cached vars if needed
-    if (cachedBrackets !== s) {
-      cachedBrackets = s
-      b = s.split(' ')
-      r = b.map(function (e) { return e.replace(/(?=.)/g, '\\') })
+  var cachedBrackets,     // full brackets string in use, for change detection
+      pairs               // cache for raw and escaped brackets and regexps
+
+  // Helper function
+  // Recreate the cache for the current brackets
+
+  function updateCache(s) {
+    cachedBrackets = s
+
+    // Save the new unescaped / escaped brackets pairs (only escape chars that require it,
+    // a backslash that is not part of a replacement string token is a literal backslash)
+
+    pairs = s.split(' ')
+            .concat(s.replace(/(?=[$\.\?\+\*\[\(\)\|^\\])/g, '\\').split(' '))
+
+    // [4] and [5] are RegExps used by splitByPairs()
+
+    pairs[4] = brackets(/\\({|})/g)         // match one escaped bracket
+
+    // [5] is for both bracket sequences. It matches opening js brackets too, to provide
+    // unescaped insertion of these characters in expressions.
+    // This regexp use positive lookahead to capture (in $2) js brackets.
+
+    // Why so complicated? We can use two regexps in splitByPairs and swap them in mode
+    // changes, but we must deal with lastIndex reassignments also change regexp itself.
+    // In simple /(\\?{)|(\\?})|({|\(|\[)/, the first brace character eats the second.
+    // pairs[5] give us matches for js _and_ riot brackets without regexp changes and,
+    // contrary to what seems, is relatively efficient.
+
+    // TODO: test in old browsers (working in latest ie, ff, and chrome)
+    // base: /(\\?)(?=([{\[\(])|{|})(?:({)|(})|.)?/g
+    pairs[5] = new RegExp(
+        '(\\\\?)(?='       +                // $1: optional escape, start lookahead for
+        '([{\\[\\(])|'     +                // $2: open js bracket, first, or
+          pairs[2] + '|'   +                //     look for riot opening or
+          pairs[3]         +                //     closing bracket.
+        ')(?:('            +                // close lookahead, now capture the riot...
+          pairs[2] + ')|(' +                // $3: opening bracket and
+          pairs[3]         +                // $4: closing bracket
+        ')|.)?',                            // match any js bracket (already captured)
+        'g')
+  }
+  // end of updateCache()
+
+
+  // Exposed brackets() function, with name for easy debugging and error ubication
+
+  return function _brackets(reOrIdx) {
+
+    var s = riot.settings.brackets || defaults    // make sure we use the current setting
+
+    if (cachedBrackets !== s) updateCache(s)      // recreate the cache if needed
+
+    if (reOrIdx instanceof RegExp) {              // for regexp...
+
+      return s === defaults ?                     // if the current brackets are the
+        reOrIdx :                                 // defaults, returns regexp as-is
+
+        // Rewrite regexp with the default brackets replaced with the custom ones.
+        // Let the user choose whether to double escape characters.
+        new RegExp(
+          reOrIdx.source.replace(/{|}/g, function (b) { return pairs[(b === '}') + 2] }),
+          reOrIdx.global && 'g'
+        )
     }
 
-    // if regexp given, rewrite it with current brackets (only if differ from default)
-    return x instanceof RegExp ? (
-        s === orig ? x :
-        new RegExp(x.source.replace(re, function(b) { return r[~~(b === '}')] }), x.global ? 'g' : '')
-      ) :
-      // else, get specific bracket
-      b[x]
+    // `reOrIdx` is not a regexp, assume it is an index to the desired cached element
+    return pairs[reOrIdx]
+
   }
+  // end of _brackets() [entry point]
+
 })('{ }')
+// end of IIFE for brackets
 
 
-var tmpl = (function() {
+//// ------------------------------------------------------------------------------------
+//// tmpl() function
+//// ------------------------------------------------------------------------------------
 
-  var cache = {},
-      reVars = /(['"\/]).*?[^\\]\1|\.\w*|\w*:|\b(?:(?:new|typeof|in|instanceof) |(?:this|true|false|null|undefined)\b|function *\()|([a-z_$]\w*)/gi
-              // [ 1               ][ 2  ][ 3 ][ 4                                                                                  ][ 5       ]
-              // find variable names:
-              // 1. skip quoted strings and regexps: "a b", 'a b', 'a \'b\'', /a b/
-              // 2. skip object properties: .name
-              // 3. skip object literals: name:
-              // 4. skip javascript keywords
-              // 5. match var name
+// IIFE for tmpl()
+var tmpl = (function (/*DEBUG*/) {
 
-  // build a template (or get it from cache), render with data
-  return function(str, data) {
-    return str && (cache[str] = cache[str] || tmpl(str))(data)
-  }
+  ////------------------------------------------------------------------------
+  //// PUBLIC ENTRY POINT
+  ////------------------------------------------------------------------------
 
+  // Exposed tmpl() function.
+  // Build a template (or get it from cache), render with data
 
-  // create a template instance
+  // NOTE: Nested expressions are not supported. Yo don't need escape inner brackets
+  //       in expressions, except very specific cases.
 
-  function tmpl(s, p) {
+  // NOTE: There are only two contexts accesible to the returned function: `this`,
+  //       asigned to the 'data' parameter received by tmpl, and the global context
+  //       `global` (for node.js) or `window` (on browsers)
 
-    // default template string to {}
-    s = (s || (brackets(0) + brackets(1)))
+  var cache = {}
 
-      // temporarily convert \{ and \} to a non-character
-      .replace(brackets(/\\{/g), '\uFFF0')
-      .replace(brackets(/\\}/g), '\uFFF1')
+  function _tmpl(str, data) {
 
-    // split string to expression and non-expresion parts
-    p = split(s, extract(s, brackets(/{/), brackets(/}/)))
+    // by using .call(data,data) there's no need to wrap `this`
 
-    return new Function('d', 'return ' + (
-
-      // is it a single expression or a template? i.e. {x} or <b>{x}</b>
-      !p[0] && !p[2] && !p[3]
-
-        // if expression, evaluate it
-        ? expr(p[1])
-
-        // if template, evaluate all expressions in it
-        : '[' + p.map(function(s, i) {
-
-            // is it an expression or a string (every second part is an expression)
-          return i % 2
-
-              // evaluate the expressions
-              ? expr(s, true)
-
-              // process string parts of the template:
-              : '"' + s
-
-                  // preserve new lines
-                  .replace(/\n/g, '\\n')
-
-                  // escape quotes
-                  .replace(/"/g, '\\"')
-
-                + '"'
-
-        }).join(',') + '].join("")'
-      )
-
-      // bring escaped { and } back
-      .replace(/\uFFF0/g, brackets(0))
-      .replace(/\uFFF1/g, brackets(1))
-
-    + ';')
+    return str && (cache[str] || (cache[str] = create(str))).call(data, data)
 
   }
+  // end of _tmpl() [entry point]
 
 
-  // parse { ... } expression
+  ////-----------------------------------------------------------------------------------
+  //// GETTER CREATION
+  ////-----------------------------------------------------------------------------------
 
-  function expr(s, n) {
-    s = s
+  var
+    // Invalid Unicode code points (ICH_) used for hide some parts of the expression
+    ICH_REGEXP  = '\uFFF0',
+    ICH_QSTRING = '\uFFF1',
 
-      // convert new lines to spaces
-      .replace(/\n/g, ' ')
+    // Match a hidden quoted string marker, $1 capture the index to the qstring in the
+    // hqs array of create (it is the qstring index in the whole template string, too).
+    RE_QSMARKER = /@(\d+)\uFFF1/g,
 
-      // trim whitespace, brackets, strip comments
-      .replace(brackets(/^[{ ]+|[ }]+$|\/\*.+?\*\//g), '')
+    // Matches single or double quoted strings, including empty ones and strings with
+    // embedded escaped quotes and whitespace. $1 is the left quote (for back ref).
+    RE_QSTRINGS = /('|")(?:\\.|[\s\S])*?\1/g,
 
-    // is it an object literal? i.e. { key : value }
-    return /^\s*[\w- "']+ *:/.test(s)
+    // Matches valid comments in (almost) all of its forms, including empty comments
+    // and nested opening sequences. (old: /\/\*[^*]*\*+(?:[^\/*][^*]*\*+)*\//)
+    RE_COMMENTS = /\/\*(?:(?!\*\/).|\s)*?\*\//g,
 
-      // if object literal, return trueish keys
-      // e.g.: { show: isOpen(), done: item.done } -> "show done"
-      ? '[' +
+    // Matches true RegExps (not in comments or quoted strings)
+    RE_REGEXPS = newRegExp(
+      RE_COMMENTS.source + '|' +      // skips comments
+      RE_QSTRINGS.source + '|' +      // $1: left quote. skips strings
+      '(/(?:\\\\?.|\\s)+?/)',         // $2: regexp (prefix with `//|` to omit '//')
+      'g'),
 
-          // extract key:val pairs, ignoring any nested objects
-          extract(s,
+    EMPTYSTR = '""'
 
-              // name part: name:, "name":, 'name':, name :
-              /["' ]*[\w- ]+["' ]*:/,
 
-              // expression part: everything upto a comma followed by a name (see above) or end of line
-              /,(?=["' ]*[\w- ]+["' ]*:)|}|$/
-              ).map(function(pair) {
+  // Private function
+  // Creates a function instance for get a value from the received template string.
 
-                // get key, val parts
-                return pair.replace(/^[ "']*(.+?)[ "']*: *(.+?),? *$/, function(_, k, v) {
+  function create(str) {
 
-                  // wrap all conditional parts to ignore errors
-                  return v.replace(/[^&|=!><]+/g, wrap) + '?"' + k + '":"",'
+    // You can drop debugging blocks in your minimized version by using uglify
+    // conditional compilation options: `-c -d DEBUG=false`
 
-                })
+    //if (DEBUG) { if (console && console.info) console.info('recv: \'' +
+    //str.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t') + '\'') }
 
-              }).join('')
+    // Empty strings never get here. This function is only called from _tmpl,
+    // and _tmpl returns falsy values before calling here.
 
-        + '].join(" ").trim()'
+    var rex = [],                     // holds the hidden, literal regexps
+        hqs = [],                     // saved (non empty) literal strings
+        i,
 
-      // if js expression, evaluate as javascript
-      : wrap(s, n)
+        // Hiding regexps here avoids complications through all the code, and does not
+        // affect the logic, but be carefull and don't touch comments or qstrings yet.
+
+        expr = str.replace(RE_REGEXPS, function (s, _, r) {
+
+          if (!r) return s            // if is a comment or string, preserve
+          rex.push(escapeStr(r))      // if is a regexp, save it
+          return ICH_REGEXP           // replace it with a invalid char
+        }),
+
+        // sliptByParts will...
+        // - Split the received string into its ttext / expressions parts
+        // - Save and hide non empty quoted strings in expressions
+        // - Convert comments _in expressions_ to spaces
+        // - Unescape escaped brackets
+
+        parts = splitByPairs(expr, hqs)
+
+    // Generates the js expression to return a value within the returned function.
+    // Single expressions return raw values, template/shorthands returns strings.
+
+    if (parts.length > 2 || parts[0]) {
+
+      var list = [],
+          j
+
+      for (i = j = 0; i < parts.length; ++i) {
+
+        expr = parts[i]
+
+        if (expr && (expr =
+
+              i & 1 ?                           // every odd element is an expression
+
+              parseExpr(expr, 1, hqs) :         // mode 1 convert falsy values to "",
+                                                // except zero
+
+              '"' + expr                        // ttext: convert to js literal string
+                .replace(/\r?\n|\r/g, '\\n')    // normalize and preserve EOLs
+                .replace(/"/g, '\\"') +         // escape inner double quotes
+              '"'                               // enclose double quotes
+
+          )) list[j++] = expr
+
+      }
+
+      expr = j > 1 ?                            // optimize code for 0-1 parts
+             '[' + list.join(',') + '].join("")' :
+             j ? '""+' + list[0] : EMPTYSTR
+
+    }
+    else {
+
+      expr = parseExpr(parts[1], 0, hqs)        // single expressions as raw value
+
+    }
+
+    // Restore hidden literals. First, quoted strings; last, regexps
+
+    expr = expr.replace(RE_QSMARKER, function (_, pos) {
+            return escapeStr(hqs[pos | 0])    // get the original string by index
+          })
+
+    for (i = 0; i < rex.length; ++i) {
+      expr = expr.replace(ICH_REGEXP, rex[i])
+    }
+
+    //if (DEBUG) { if (console && console.info) console.info(' OUT: ' +
+    //expr.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t')) }
+
+    // Now, we can create the function to return by calling the Function constructor.
+    // It'll throw an exception if the generated code has errors (i.e. SyntaxError)
+    // The parameter `D` is received by _tmpl, which uses it to evaluate the function.
+
+    return new Function('D', 'return ' + expr + ';')
+
+    // Escape the '\n' and '\r' chars, since these breaks the Function ctor
+
+    function escapeStr(s) {
+      return s.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
+    }
 
   }
+  // end of create()
 
 
-  // execute js w/o breaking on errors or undefined vars
+  ////-----------------------------------------------------------------------------------
+  //// PARSERS
+  ////-----------------------------------------------------------------------------------
 
-  function wrap(s, nonull) {
-    s = s.trim()
-    return !s ? '' : '(function(v){try{v='
+  // Private function
+  // Splits the received string in its template text and expression parts.
 
-        // prefix vars (name => data.name)
-        + (s.replace(reVars, function(s, _, v) { return v ? '(d.'+v+'===undefined?'+(typeof window == 'undefined' ? 'global.' : 'window.')+v+':d.'+v+')' : s })
+  // Search one by one the next expression in str, and save each result by pairs as
+  // `[ttext], [expression]` in the returned array.
+  // So, if str have one unique expression, the result is `['', expression]`, for
+  // text without expressions, the result is `[ttext]`
 
-          // break the expression if its empty (resulting in undefined value)
-          || 'x')
-      + '}catch(e){'
-      + '}finally{return '
+  // Matches quoted strings or comments (qblocks)
+  var RE_QBLOCKS = newRegExp(
+      RE_QSTRINGS.source + '|' +
+      RE_COMMENTS.source,
+      'g'
+    )
 
-        // default to empty string for falsy values except zero
-        + (nonull === true ? '!v&&v!==0?"":v' : 'v')
+  function splitByPairs(str, hqs) {
 
-      + '}}).call(d)'
+    //$IF(!str, 'falsy str in _tmpl.create!!!')
+
+    /*
+      About inner unescaped (and unbalanced) brackets detection
+
+      Template text is easy: closing brackets are ignored, all we have to do is find
+      the first unescaped bracket. The real work is in the expressions...
+
+      Expressions are not so easy. We can already ignore opening brackets, but finding
+      the correct closing bracket is tricky.
+      Think about literal strings and regexps, they can contain almost any combination
+      of characters. We can't deal with these complexity with our regexps, so let's
+      hide and ignore these*. From there, all we need is to detect the bracketed parts
+      and skip them, as they contains most of common chars used by riot brackets.
+      With that, we have a 90% reliability in the detections, although (hope few) some
+      custom brackets still requires to be escaped (e.g. `<< x \\>> 1 >>`) :(
+
+      * The template comes with regexps hidden, and haveQBlock hides qstrings here.
+    */
+
+    var eb = brackets(4),           // regexp, matches current escaped riot brackets
+        re = brackets(5),           // regexp, for (riot or js) brackets detection
+        parts = [],                 // holds the resulting parts
+        start,                      // start position of current template or expression
+        match,                      // reused by both outer and nested searches
+        pos,                        // current position (exec() result)
+        isexpr,                     // we are in ttext (0) or expression (1)
+                                    // --- q* vars used by haveQBlock:
+        qposLt = -1,                // start position of the current qblock
+        qmatch                      // resulting match in the closure
+
+    re.lastIndex = start = isexpr = 0
+
+    while ((match = re.exec(str))) {
+
+      pos = match.index
+
+      // $1: optional escape character
+      // $2: opening js bracket `{[(`
+      // $3: opening riot bracket
+      // $4: closing riot bracket
+
+      if (isexpr) {
+
+        // We are in expression.
+        // Brackets inside qblocks and js braces by pairs, are ignored.
+        // This works even if the opening bracket of riot is the same as a js bracket,
+        // because we already skipped the first (that switched to expression mode).
+
+        if (haveQBlock(re, pos))                // skip any char within quotes
+          continue
+
+        if (match[2]) {                         // js opening bracket?
+
+          // Skip bracketed block. Send str, bracket, pos (shifted by escapeChar.length),
+          // and haveQBlock as callback, and expect a new position as return value.
+
+          re.lastIndex = skipBracketedPart(str, match[2], !!match[1] + pos, haveQBlock)
+          continue
+        }
+      }
+
+      // At this point, we expect only a _unescaped_ bracket in $2 for text mode,
+      // or in $3 for expression. If so, save the part and switch the mode.
+
+      if (match[isexpr +3] && !match[1]) {      // is the expected, unescaped bracket?
+                                                // push part, even if empty
+        unescapeStr(parts, str.slice(start, pos))
+
+        start = re.lastIndex                    // next position is the new start
+        isexpr ^= 1                             // switch mode
+      }
+    }
+
+    if (start < str.length)                     // push remaining part, if we have one
+      unescapeStr(parts, str.slice(start))
+
+    return parts                                // and we are done!
+
+
+    //// ----------------------
+    //// Inner Helper Functions
+
+    // Unescape escaped brackets and store the qstring in the given array.
+    // eb is /\\?({|})/g, so $1 excludes the escape character
+
+    function unescapeStr(arr, str) {
+
+      arr.push(str && str.replace(eb, '$1'))
+
+    }
+    // end of unescapeStr()
+
+
+    // Converts comments in spaces, saves and hides quoted strings, updates the outer
+    // (re.)lastIndex, and returns true if the `pos` position is inside a comment or
+    // quoted string.
+
+    function haveQBlock(re, pos) {
+
+      var qblock,                 // holds the original comment or qstring
+          qposRt,
+          marker
+
+      // Keep current qblock at right side of pos (current position on the outer loop)
+
+      while (qposLt <= pos) {     // exit if pos == -1 (pos inside the current qblock)
+
+        // If the start of qblock (qposLt) is at left of the beginning of the expression,
+        // this has changed, and we need reset the RE_QBLOCKS offset and start a new
+        // search after saving any qstring that is in qmatch, since we are sure now this
+        // previous qstring belongs to an expression.
+
+        if (qposLt < start) qposRt = start            // reset offset on expression change
+
+        else {
+
+          // qblock is in the current expression, so qmatch is still valid and not null.
+          // Test len>2 because empty qstrings min length is 2, and for comments is 4.
+          // It's safe to bypass empty strings ...they cann't contain dangerous chars :)
+
+          qposRt = RE_QBLOCKS.lastIndex               // track pointer for next search
+
+          if ((qblock = qmatch[0]).length > 2) {      // comment or non-empty qblock?
+
+            // Replace comment with space or qstring with a marker that includes its
+            // original position as an index into the array of replaced qstrings.
+            // (qmatch[1] has a quote if it is a qstring)
+
+            marker = qmatch[1] ?                      // quote found? it's a qstring,
+              '@' + hqs.length + ICH_QSTRING :        // create marker for qstring
+              ' '                                     // else replace comment w/space
+
+            unescapeStr(hqs, qblock)                  // unescape brackets here, too
+                                                      // @(backward compatible)
+                                                      // replace qblock
+            str = str.slice(0, qposLt) + marker + str.slice(qposRt)
+                                                      // skip qblock
+            re.lastIndex = qposRt = qposLt + marker.length
+
+            pos = -1                                  // signal to reset outer search
+                                                      // since str was modified
+          }
+        }
+
+        // Any qblock found remains unhidden until we're sure it belongs to an expression.
+        // If no qblock is found, set qposLt to the end of string (beyond `pos` value)
+
+        RE_QBLOCKS.lastIndex = qposRt                 // begin searching at own offset
+
+        qposLt = (qmatch = RE_QBLOCKS.exec(str)) ?
+          qmatch.index :                              // this is the start of qblock
+          str.length                                  // avoid entering here again
+
+      } // end while qposLt <= pos
+
+      return pos < 1    // true if str has changed
+
+    }
+    // end of haveQBlock()
+
   }
+  // end of splitByPairs()
 
 
-  // split string by an array of substrings
+  // Private function
+  // Parse `{ expression }` or `{ name: expression, ... }`
 
-  function split(str, substrings) {
-    var parts = []
-    substrings.map(function(sub, i) {
+  // For simplicity, and due to RegExp limitations, riot supports a limited subset (closer
+  // to CSS1 that CSS2) of the full w3c/html specs for non-quoted identifiers of shorthand
+  // names. This simplified regexp is used for the recognition:
+  //
+  //      `/-?[_A-Za-z\xA0-\xFF][-\w\xA0-\xFF]*/`
+  //
+  // The regexp accept all ISO-8859-1 characters that are valid within an html identifier.
+  // The names must begin with one underscore (\x5F), one alphabetic ascii (A-Z, a-z),
+  // or one ISO-8859-1 character in the range 160 to 255, optionally prefixed with one
+  // dash (\x2D).
+  //
+  // NOTE: Although you can use Unicode code points beyond \u00FF by quoting the names
+  //       (not recommended), only use whitespace as separators since, within names,
+  //       riot converts these into spaces.
+  //
+  // See: http://www.w3.org/TR/CSS21/grammar.html#scanner
+  //      http://www.w3.org/TR/CSS21/syndata.html#tokenization
 
-      // push matched expression and part before it
-      i = str.indexOf(sub)
-      parts.push(str.slice(0, i), sub)
-      str = str.slice(i + sub.length)
+  function parseExpr(expr, mode, qstr) {
+
+    // Convert inner whitespace to compact spaces and trims the space surrounding the
+    // expression and various tokens, mainly brackets and separators.
+    // We need convert embedded '\r' and '\n' as these chars breaks js code evaluation.
+    // replacement is secure, expr already lacks strings, regexp, and comments.
+
+    // WARNING:
+    //      Trim and compact is not strictly necessary, but it allows optimized regexps.
+    //      e.g. we can use /:/ instead /\s*:\s*/
+    //      Many regexps in tmpl code depend on this, so do not touch the next line
+    //      until you know how, and which, regexps are affected.
+
+    expr = expr
+          .replace(/\s+/g, ' ')
+          .replace(/^ | ?([\(\[{},\?\.:]) ?| $/g, '$1')
+
+    if (!expr) return ''
+
+    // Expression only:   mode == 0 -- nonull == false
+    // Text + expression: mode == 1 -- nonull == true
+
+    // Detect class shorthands, csinfo is filled with [qstring-idx, name, expr] els
+    var csinfo = [],
+        cslist
+
+    if (!extractCSList(expr, csinfo)) {
+
+      // `expr` does not begin with "name:", let's assume js expression.
+      // Here, the "mode" parameter itself is significant
+
+      return wrapExpr(expr, mode)
+    }
+
+    // We have a class shorthand list, something that looks like a literal js object, in
+    // the format '{ name: expr, ... }', but with HTML/CSS identifiers as names, and its
+    // surrounding brackets already removed by the caller.
+    // At runtime, the code generated here returns a space-delimited list of the names
+    // for those expressions with trueish values.
+    // E.g.: `{ show: isOpen(), done: item.done }` --> "show done"
+
+    cslist = csinfo.map(function (kv) {
+
+      // Be carefull, the `name` element can be a hidden quoted string marker. We must
+      // check this for replacing the marker with the original string here, 'cause the
+      // processing of whitespace and quote chars on names (HTML identifiers) differs
+      // to that of the other strings on the expressions (js code).
+      // Once replaced, the marker will not be available anymore. This is desired, as
+      // well as the restoration of the strings does not overwrite these names.
+
+      if (kv[0]) {                              // is name a quoted string marker?
+        kv[1] = qstr[kv[0] | 0]                 // retrieve string by index
+          .slice(1, -1)                         //  and unquote
+          .replace(/[ \r\n\t]+/g, ' ').trim()   // compact whitespace between names
+      }
+
+      return '(' +                              // wrap all parts to ignore errors.
+          wrapExpr(kv[2], 0) +                  // use raw mode
+          ')?"'  + kv[1]  + '":""'              // all error/falsy values returns ""
+
     })
 
-    // push the remaining part
-    return parts.concat(str)
+    return cslist.length < 2 ?                  // optimize 'one element' cases
+       cslist[0] :
+      '[' + cslist.join(',') + '].join(" ").trim()'
+
+  }
+  // end of parseExpr()
+
+
+  // Private function - Helper for parseExpr()
+  // If `str` is a shorthand list, return an array with its parts, or falsy if is not.
+  // This function cares about nested commas.
+
+  var
+      // Matches the `name:` part of a class shorthand
+      CSNAME_PART = newRegExp(
+        '^(' +                            // always at 0, we are searching rightContext
+        RE_QSMARKER.source +              // $1: qstring marker + $2: str index, or...
+        '|-?[_A-Za-z\xA0-\xFF][-\\w\xA0-\xFF]*' +
+                                          // $1: literal w3c indentifier (almost)
+        '):'                              // skip colon, expression follows
+      ),
+
+      // Matches open js brackets, comma outside brackets, or the end of str
+      CSPART_END = /([\[{\(])|,|$/g       // $1: js bracket
+
+  function extractCSList(str, list) {
+
+    var match,                    // CSNAME_PART results
+        end,                      // CSPART_END results
+        gre,                      // global RegExp object
+        ch,                       // js bracket, or empty for comma or end of str
+        n = 0                     // count of extracted shorthands
+
+    // Try to match the first name testing `match !== null && match.index === 0`
+
+    while (str &&                               // search in the ramaining substring
+          (match = str.match(CSNAME_PART)) &&   // null match or
+          !match.index                          // start > 0 means error
+      ) {
+
+      gre = RegExp
+      str = gre.rightContext                    // skip the `name:` part
+      CSPART_END.lastIndex = 0                  // reset lastIndex for exec
+
+      // Search the next comma, outside brackets, or the end of str.
+      // If js bracket is found ($1), skip the bracketed part.
+
+      while ((end = CSPART_END.exec(str)) && (ch = end[1])) {
+
+        CSPART_END.lastIndex = skipBracketedPart(str, ch, end.index)
+
+      }
+
+      list[n++] = [                             // match still valid, push...
+          match[2],                             // 0: hidden qstring index
+          match[1],                             // 1: unquoted name
+          str.slice(0, end.index)               // 2: expression
+        ]
+
+      str = gre.rightContext
+    }
+
+    // Explicit error detection for easy debugging.
+    // If str (rightContext) is not empty, we have a comma after the previous pair,
+    // so this must begin with a name. if not, we have a syntax error.
+    // This is consistent with the literal objects notation (of js), if the user
+    // wants a comma operator, must use parentheses.
+
+    if (n && str)
+        throw new SyntaxError('Cannot parse ... ' + str + '}')
+
+    return n
+
+  }
+  // end of extractCSList()
+
+
+  // Private function - Helper for splitByPairs & extractCSList.
+  // Skips a bracketed block, ignoring any nested brackets, and returns the next
+  // position following the closing bracket for the `opench` character.
+  // sqcb is a callback for hide qstrings (haveQBlock) returning -1 if str has
+  // changed, in which case this function returns the received original position.
+
+  // Matches js brackets. Used by splitByPairs.skipBracketedPart and skipBrackets
+  var JS_BRACKETS = {
+        '{': /\{|\}/g,  // eslint-disable-line no-dupe-keys
+        '[': /\[|\]/g,
+        '(': /\(|\)/g
+      }
+
+  function skipBracketedPart(str, opench, chpos, sqcb) {
+
+    var recch = JS_BRACKETS[opench],            // we are using recch for sqcb(), too
+        match,
+        level = 1                               // when level drops to 0, will have
+                                                // found our right bracket.
+    recch.lastIndex = chpos + 1                 // skip opench
+
+    while (level && (match = recch.exec(str))) {
+
+      if (sqcb && sqcb(recch, match.index))     // stop on quoted bracket, since str
+        return chpos                            // has changed. return previous pos
+
+      match[0] === opench ? ++level : --level
+    }
+
+    return match ? recch.lastIndex : str.length
+
   }
 
+  ////-----------------------------------------------------------------------------------
+  //// WRAPPERS
+  ////-----------------------------------------------------------------------------------
 
-  // match strings between opening and closing regexp, skipping any inner/nested matches
+  // Private function
+  // Generates js code to get an expression value, wrapped in a try..finally block
+  // to avoid break on errors or undefined vars.
+  // The generated code will be inserted in an array, returned by parseExpr()
 
-  function extract(str, open, close) {
+  var
+      // Strings used by wrapExpr()
+      VAR_CONTEXT = '"in D?D:' + (typeof window === T_OBJECT ? 'window' : 'global') + ').',
+      WRAP_RETVAL = [
+          'v',                // raw mode
+          'v||v===0?v:""'     // text mode
+        ],
 
-    var start,
-        level = 0,
-        matches = [],
-        re = new RegExp('('+open.source+')|('+close.source+')', 'g')
+      // String for RegExp, matches full iso-8859-1 var names
+      SRE_VARNAME = '[$_A-Za-z\xA0-\xFF][$\\w\xA0-\xFF]*',
 
-    str.replace(re, function(_, open, close, pos) {
+      // Matches a var name alone. Used by wrapExpr with successive string.match
+      // Note:  We are using negative lookahead to exclude properties without capture, so
+      //        it works fine with test() or match(). Gotcha is that we are left with a
+      //        dangling character in $1. prefixVar() returns it to the str.
+      // base: /(?:^ ?|(?![$\w\xA0-ÿ\.])(.))(?!(?:typeof|in|instanceof|void|true|function)\b)(?:(new[ \(])?([$_A-Za-z\xA0-ÿ][$\w\xA0-ÿ]*))/
+      JS_VARSTART = newRegExp(
+          '(?:^ ?|' +                       // begin in 0, skip optional space (can be one here)
+          '(?![$\\w\xA0-\xFF\\.])(.))' +    // $1: non var name nor dot char, w/ negative lookahead. dot|name follows?
+          '(?!(?:typeof|in|instanceof|void|true|new|function)\\b)' +
+                                            // negative lookahead on previous one, fail the match on some js keywords
+          '(' + SRE_VARNAME + ')'           // $2: var name or falsy primitive (JS_FALY)
+        ),
 
-      // if outer inner bracket, mark position
-      if (!level && open) start = pos
+      // Matches key names of literal objects
+      JS_OBJKEYS = newRegExp(
+          '(?=[,{]'   +                     // lookehead for start or separator of k:v pair
+          SRE_VARNAME +                     // match a name, but only
+          '?:)(.)',                         // $1: capture the bracket or separator
+          'g'                               // needed, this is for replace()
+        ),
 
-      // in(de)crease bracket level
-      level += open ? 1 : -1
+      // For optimization of falsy values with nonull=true (JS_VARSTART let pass these)
+      JS_FALSY = {
+        'this': 0,
+        'global': 0,
+        'window': 0,
+        'undefined': 1,
+        'false': 1,
+        'null': 1,
+        'NaN': 1
+      }
 
-      // if outer closing bracket, grab the match
-      if (!level && close != null) matches.push(str.slice(start, pos+close.length))
+  function wrapExpr(expr, astxt) {
 
-    })
+    var okeys = ~expr.indexOf('{')
+    if (okeys)
+      expr = expr.replace(JS_OBJKEYS, '$1\uFFF30')
 
-    return matches
+    var match = expr.match(JS_VARSTART)
+    if (match) {                            // how much is wrap nedeed?
+                                            // wrap vars in expression
+      var ss = [],
+          mvar,
+          wrap = 0,
+          gre = RegExp
+
+      do {
+
+        // string.match() with regexp without the global flag returns submatches
+        // $1: character not part of the var name, must be pushed before wrap
+        // $2: var name
+
+        ss.push(gre.leftContext + (match[1] || ''))   // save left part & dangling char
+        expr = gre.rightContext                       // expr to be processed later
+        mvar = match[2]
+
+        if (JS_FALSY[mvar])
+          ss.push(astxt ? EMPTYSTR : mvar)            // mode 1 (text) returns ''
+
+        else {
+          ss.push(mvar in JS_FALSY ? mvar : ('("' + mvar + VAR_CONTEXT + mvar))
+
+          wrap = wrap || astxt || /^[\[\(\.]/.test(expr)
+        }
+
+      } while ((match = expr.match(JS_VARSTART)))
+
+      expr = (ss.join('') + expr).trim()              // don't trim inner spaces here
+
+      if (wrap)
+        expr = '(function(v){try{v=' + expr +
+                '}catch(e){}return ' + WRAP_RETVAL[astxt] + '}).call(D)'
+
+      //else if (astxt)
+      //  expr = '((v=' + expr + ')||v===0v:"")'
+
+    } // if match
+
+    return okeys ? expr.replace(/\uFFF30/g, '') : expr
+
   }
+  // end of wrapExpr()
 
-})()
+
+  // Private function - Common helper
+  // Creates a new regexp (uglify save some bytes with this)
+
+  function newRegExp(restr, opts) {
+
+    return new RegExp(restr, opts)
+
+  }
+  // end of newRegExp()
+
+
+  return _tmpl        // the exposed function
+
+
+})(0)
+// end of IIFE for tmpl

--- a/lib/browser/tmpl.js
+++ b/lib/browser/tmpl.js
@@ -36,209 +36,89 @@ tmpl('{ undefined } - { false } - { null } - { 0 }', {})
 
 */
 
-
-//// ------------------------------------------------------------------------------------
-//// brackets() function
-//// ------------------------------------------------------------------------------------
-
-// Low level function for track changes to the brackets.
-// Parameter can be one of:
-//
-// RegExp - If the current brackets are the defaults, returns the original regexp, else
-//          returns a new regexp with the default brackets replaced by the custom ones.
-//          WARNING: new custom regexp discards the /i and /m flags.
-// number - If number is...
-//          0,1 -returns the current left (0) or right (1) brackets characters
-//          2,3 -returns the current left (3) or right (4) escaped brackets characters
-//          4   -returns regexp based on /\\({|})/g for match escaped brackets
-//          5   -returns regexp based on /(\\?)(?=([{\[\(])|{|})(?:({)|(})|.)?/g for
-//               match opening riot and js brackets
-
-// IIFE
 var brackets = (function (defaults) {
 
-  // Cache on closure, initialized on first use and on bracket changes
-
-  var cachedBrackets,     // full brackets string in use, for change detection
-      pairs               // cache for raw and escaped brackets and regexps
-
-  // Helper function
-  // Recreate the cache for the current brackets
+  var cachedBrackets,
+      pairs
 
   function updateCache(s) {
     cachedBrackets = s
 
-    // Save the new unescaped / escaped brackets pairs (only escape chars that require it,
-    // a backslash that is not part of a replacement string token is a literal backslash)
-
     pairs = s.split(' ')
             .concat(s.replace(/(?=[$\.\?\+\*\[\(\)\|^\\])/g, '\\').split(' '))
 
-    // [4] and [5] are RegExps used by splitByPairs()
+    pairs[4] = brackets(/\\({|})/g)
 
-    pairs[4] = brackets(/\\({|})/g)         // match one escaped bracket
-
-    // [5] is for both bracket sequences. It matches opening js brackets too, to provide
-    // unescaped insertion of these characters in expressions.
-    // This regexp use positive lookahead to capture (in $2) js brackets.
-
-    // Why so complicated? We can use two regexps in splitByPairs and swap them in mode
-    // changes, but we must deal with lastIndex reassignments also change regexp itself.
-    // In simple /(\\?{)|(\\?})|({|\(|\[)/, the first brace character eats the second.
-    // pairs[5] give us matches for js _and_ riot brackets without regexp changes and,
-    // contrary to what seems, is relatively efficient.
-
-    // TODO: test in old browsers (working in latest ie, ff, and chrome)
-    // base: /(\\?)(?=([{\[\(])|{|})(?:({)|(})|.)?/g
     pairs[5] = new RegExp(
-        '(\\\\?)(?='       +                // $1: optional escape, start lookahead for
-        '([{\\[\\(])|'     +                // $2: open js bracket, first, or
-          pairs[2] + '|'   +                //     look for riot opening or
-          pairs[3]         +                //     closing bracket.
-        ')(?:('            +                // close lookahead, now capture the riot...
-          pairs[2] + ')|(' +                // $3: opening bracket and
-          pairs[3]         +                // $4: closing bracket
-        ')|.)?',                            // match any js bracket (already captured)
+        '(\\\\?)(?='       +
+        '([{\\[\\(])|'     +
+          pairs[2] + '|'   +
+          pairs[3]         +
+        ')(?:('            +
+          pairs[2] + ')|(' +
+          pairs[3]         +
+        ')|.)?',
         'g')
   }
-  // end of updateCache()
-
-
-  // Exposed brackets() function, with name for easy debugging and error ubication
 
   return function _brackets(reOrIdx) {
 
-    var s = riot.settings.brackets || defaults    // make sure we use the current setting
+    var s = riot.settings.brackets || defaults
 
-    if (cachedBrackets !== s) updateCache(s)      // recreate the cache if needed
+    if (cachedBrackets !== s) updateCache(s)
 
-    if (reOrIdx instanceof RegExp) {              // for regexp...
+    if (reOrIdx instanceof RegExp) {
 
-      return s === defaults ?                     // if the current brackets are the
-        reOrIdx :                                 // defaults, returns regexp as-is
+      return s === defaults ?
+        reOrIdx :
 
-        // Rewrite regexp with the default brackets replaced with the custom ones.
-        // Let the user choose whether to double escape characters.
         new RegExp(
           reOrIdx.source.replace(/{|}/g, function (b) { return pairs[(b === '}') + 2] }),
           reOrIdx.global && 'g'
         )
     }
 
-    // `reOrIdx` is not a regexp, assume it is an index to the desired cached element
     return pairs[reOrIdx]
 
   }
-  // end of _brackets() [entry point]
 
 })('{ }')
-// end of IIFE for brackets
 
-
-//// ------------------------------------------------------------------------------------
-//// tmpl() function
-//// ------------------------------------------------------------------------------------
-
-// IIFE for tmpl()
-var tmpl = (function (/*DEBUG*/) {
-
-  ////------------------------------------------------------------------------
-  //// PUBLIC ENTRY POINT
-  ////------------------------------------------------------------------------
-
-  // Exposed tmpl() function.
-  // Build a template (or get it from cache), render with data
-
-  // NOTE: Nested expressions are not supported. Yo don't need escape inner brackets
-  //       in expressions, except very specific cases.
-
-  // NOTE: There are only two contexts accesible to the returned function: `this`,
-  //       asigned to the 'data' parameter received by tmpl, and the global context
-  //       `global` (for node.js) or `window` (on browsers)
+var tmpl = (function () {
 
   var cache = {}
 
   function _tmpl(str, data) {
 
-    // by using .call(data,data) there's no need to wrap `this`
-
     return str && (cache[str] || (cache[str] = create(str))).call(data, data)
 
   }
-  // end of _tmpl() [entry point]
-
-
-  ////-----------------------------------------------------------------------------------
-  //// GETTER CREATION
-  ////-----------------------------------------------------------------------------------
 
   var
-    // Invalid Unicode code points (ICH_) used for hide some parts of the expression
-    ICH_REGEXP  = '\uFFF0',
+
     ICH_QSTRING = '\uFFF1',
 
-    // Match a hidden quoted string marker, $1 capture the index to the qstring in the
-    // hqs array of create (it is the qstring index in the whole template string, too).
     RE_QSMARKER = /@(\d+)\uFFF1/g,
 
-    // Matches single or double quoted strings, including empty ones and strings with
-    // embedded escaped quotes and whitespace. $1 is the left quote (for back ref).
-    RE_QSTRINGS = /('|")(?:\\.|[\s\S])*?\1/g,
+    RE_QSTRINGS = /('|")(?:[^\\]|\\.)*?\1/g,
 
-    // Matches valid comments in (almost) all of its forms, including empty comments
-    // and nested opening sequences. (old: /\/\*[^*]*\*+(?:[^\/*][^*]*\*+)*\//)
-    RE_COMMENTS = /\/\*(?:(?!\*\/).|\s)*?\*\//g,
+    RE_COMMENTS = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g,
 
-    // Matches true RegExps (not in comments or quoted strings)
-    RE_REGEXPS = newRegExp(
-      RE_COMMENTS.source + '|' +      // skips comments
-      RE_QSTRINGS.source + '|' +      // $1: left quote. skips strings
-      '(/(?:\\\\?.|\\s)+?/)',         // $2: regexp (prefix with `//|` to omit '//')
-      'g')
+    RE_REGEXPS = /\/(?!\/|\*)((?:\[(?:[^\]\\]|\\.)*|[^/\\]|\\.)+\/)/,
 
-
-  // Private function
-  // Creates a function instance for get a value from the received template string.
+    RE_PREREGS = /(?:^|[-\+\*%~^&\|!=><\?:{\(\[,;]|\/\s)\s*$/
 
   function create(str) {
 
-    // You can drop debugging blocks in your minimized version by using uglify
-    // conditional compilation options: `-c -d DEBUG=false`
+    var hqs = [],
+        expr,
 
-    //if (DEBUG) { if (console && console.info) console.info(' in: \'' +
-    //str.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t') + '\'') }
-
-    // Empty strings never get here. This function is only called from _tmpl,
-    // and _tmpl returns falsy values before calling here.
-
-    var rex = [],                     // holds the hidden, literal regexps
-        hqs = [],                     // saved (non empty) literal strings
-        i,
-
-        // Hiding regexps here avoids complications through all the code, and does not
-        // affect the logic, but be carefull and don't touch comments or qstrings yet.
-
-        expr = str.replace(RE_REGEXPS, function (s, _, r) {
-
-          if (!r) return s            // if is a comment or string, preserve
-          rex.push(escapeStr(r))      // if is a regexp, save it
-          return ICH_REGEXP           // replace it with a invalid char
-        }),
-
-        // sliptByParts will...
-        // - Split the received string into its ttext / expressions parts
-        // - Save and hide non empty quoted strings in expressions
-        // - Convert comments _in expressions_ to spaces
-        // - Unescape escaped brackets
-
-        parts = splitByPairs(expr, hqs)
-
-    // Generates the js expression to return a value within the returned function.
-    // Single expressions return raw values, template/shorthands returns strings.
+        parts = splitByPairs(str, hqs)
 
     if (parts.length > 2 || parts[0]) {
 
       var list = [],
+          i,
           j
 
       for (i = j = 0; i < parts.length; ++i) {
@@ -247,111 +127,59 @@ var tmpl = (function (/*DEBUG*/) {
 
         if (expr && (expr =
 
-              i & 1 ?                           // every odd element is an expression
+              i & 1 ?
 
-              parseExpr(expr, 1, hqs) :         // mode 1 convert falsy values to "",
-                                                // except zero
+              parseExpr(expr, 1, hqs) :
 
-              '"' + expr                        // ttext: convert to js literal string
-                .replace(/\r?\n|\r/g, '\\n')    // normalize and preserve EOLs
-                .replace(/"/g, '\\"') +         // escape inner double quotes
-              '"'                               // enclose double quotes
+              '"' + expr
+                .replace(/\r?\n|\r/g, '\\n')
+                .replace(/"/g, '\\"') +
+              '"'
 
           )) list[j++] = expr
 
       }
 
-      expr = j > 1 ?                            // optimize code for 0-1 parts
+      expr = j > 1 ?
              '[' + list.join(',') + '].join("")' :
              j ? '""+' + list[0] : '""'
 
     }
     else {
 
-      expr = parseExpr(parts[1], 0, hqs)        // single expressions as raw value
+      expr = parseExpr(parts[1], 0, hqs)
 
     }
-
-    // Restore hidden literals. First, quoted strings; last, regexps
 
     expr = expr.replace(RE_QSMARKER, function (_, pos) {
-            return escapeStr(hqs[pos | 0])    // get the original string by index
+            return hqs[pos | 0]
+              .replace(/\n/g, '\\n')
+              .replace(/\r/g, '\\r')
           })
-
-    for (i = 0; i < rex.length; ++i) {
-      expr = expr.replace(ICH_REGEXP, rex[i])
-    }
-
-    //if (DEBUG) { if (console && console.info) console.info('OUT: ' +
-    //expr.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t')) }
-
-    // Now, we can create the function to return by calling the Function constructor.
-    // It'll throw an exception if the generated code has errors (i.e. SyntaxError)
-    // The parameter `D` is received by _tmpl, which uses it to evaluate the function.
 
     return new Function('D', 'return ' + expr + ';')
 
-    // Escape the '\n' and '\r' chars, since these breaks the Function ctor
-
-    function escapeStr(s) {
-      return s.replace(/\n/g, '\\n').replace(/\r/g, '\\r')
-    }
-
   }
-  // end of create()
 
-
-  ////-----------------------------------------------------------------------------------
-  //// PARSERS
-  ////-----------------------------------------------------------------------------------
-
-  // Private function
-  // Splits the received string in its template text and expression parts.
-
-  // Search one by one the next expression in str, and save each result by pairs as
-  // `[ttext], [expression]` in the returned array.
-  // So, if str have one unique expression, the result is `['', expression]`, for
-  // text without expressions, the result is `[ttext]`
-
-  // Matches quoted strings or comments (qblocks)
   var RE_QBLOCKS = newRegExp(
       RE_QSTRINGS.source + '|' +
-      RE_COMMENTS.source,
+      RE_COMMENTS.source + '|' +
+      RE_REGEXPS.source,
       'g'
     )
 
   function splitByPairs(str, hqs) {
 
-    //$IF(!str, 'falsy str in _tmpl.create!!!')
+    var eb = brackets(4),
+        re = brackets(5),
+        parts = [],
+        start,
+        match,
+        pos,
+        isexpr,
 
-    /*
-      About inner unescaped (and unbalanced) brackets detection
-
-      Template text is easy: closing brackets are ignored, all we have to do is find
-      the first unescaped bracket. The real work is in the expressions...
-
-      Expressions are not so easy. We can already ignore opening brackets, but finding
-      the correct closing bracket is tricky.
-      Think about literal strings and regexps, they can contain almost any combination
-      of characters. We can't deal with these complexity with our regexps, so let's
-      hide and ignore these*. From there, all we need is to detect the bracketed parts
-      and skip them, as they contains most of common chars used by riot brackets.
-      With that, we have a 90% reliability in the detections, although (hope few) some
-      custom brackets still requires to be escaped (e.g. `<< x \\>> 1 >>`) :(
-
-      * The template comes with regexps hidden, and haveQBlock hides qstrings here.
-    */
-
-    var eb = brackets(4),           // regexp, matches current escaped riot brackets
-        re = brackets(5),           // regexp, for (riot or js) brackets detection
-        parts = [],                 // holds the resulting parts
-        start,                      // start position of current template or expression
-        match,                      // reused by both outer and nested searches
-        pos,                        // current position (exec() result)
-        isexpr,                     // we are in ttext (0) or expression (1)
-                                    // --- q* vars used by haveQBlock:
-        qposLt = -1,                // start position of the current qblock
-        qmatch                      // resulting match in the closure
+        qposLt = -1,
+        qmatch
 
     re.lastIndex = start = isexpr = 0
 
@@ -359,167 +187,96 @@ var tmpl = (function (/*DEBUG*/) {
 
       pos = match.index
 
-      // $1: optional escape character
-      // $2: opening js bracket `{[(`
-      // $3: opening riot bracket
-      // $4: closing riot bracket
-
       if (isexpr) {
 
-        // We are in expression.
-        // Brackets inside qblocks and js braces by pairs, are ignored.
-        // This works even if the opening bracket of riot is the same as a js bracket,
-        // because we already skipped the first (that switched to expression mode).
-
-        if (haveQBlock(re, pos))                // skip any char within quotes
+        if (haveQBlock(re, pos))
           continue
 
-        if (match[2]) {                         // js opening bracket?
-
-          // Skip bracketed block. Send str, bracket, pos (shifted by escapeChar.length),
-          // and haveQBlock as callback, and expect a new position as return value.
+        if (match[2]) {
 
           re.lastIndex = skipBracketedPart(str, match[2], !!match[1] + pos, haveQBlock)
           continue
         }
       }
 
-      // At this point, we expect only a _unescaped_ bracket in $2 for text mode,
-      // or in $3 for expression. If so, save the part and switch the mode.
+      if (match[isexpr +3] && !match[1]) {
 
-      if (match[isexpr +3] && !match[1]) {      // is the expected, unescaped bracket?
-                                                // push part, even if empty
         unescapeStr(parts, str.slice(start, pos))
 
-        start = re.lastIndex                    // next position is the new start
-        isexpr ^= 1                             // switch mode
+        start = re.lastIndex
+        isexpr ^= 1
       }
     }
 
-    if (start < str.length)                     // push remaining part, if we have one
+    if (start < str.length)
       unescapeStr(parts, str.slice(start))
 
-    return parts                                // and we are done!
-
-
-    //// ----------------------
-    //// Inner Helper Functions
-
-    // Unescape escaped brackets and store the qstring in the given array.
-    // eb is /\\?({|})/g, so $1 excludes the escape character
+    return parts
 
     function unescapeStr(arr, str) {
 
       arr.push(str && str.replace(eb, '$1'))
 
     }
-    // end of unescapeStr()
-
-
-    // Converts comments in spaces, saves and hides quoted strings, updates the outer
-    // (re.)lastIndex, and returns true if the `pos` position is inside a comment or
-    // quoted string.
 
     function haveQBlock(re, pos) {
 
-      var qblock,                 // holds the original comment or qstring
+      var qblock,
           qposRt,
           marker
 
-      // Keep current qblock at right side of pos (current position on the outer loop)
+      while (qposLt <= pos) {
 
-      while (qposLt <= pos) {     // exit if pos == -1 (pos inside the current qblock)
-
-        // If the start of qblock (qposLt) is at left of the beginning of the expression,
-        // this has changed, and we need reset the RE_QBLOCKS offset and start a new
-        // search after saving any qstring that is in qmatch, since we are sure now this
-        // previous qstring belongs to an expression.
-
-        if (qposLt < start) qposRt = start            // reset offset on expression change
+        if (qposLt < start) qposRt = start
 
         else {
 
-          // qblock is in the current expression, so qmatch is still valid and not null.
-          // Test len>2 because empty qstrings min length is 2, and for comments is 4.
-          // It's safe to bypass empty strings ...they cann't contain dangerous chars :)
+          qposRt = RE_QBLOCKS.lastIndex
 
-          qposRt = RE_QBLOCKS.lastIndex               // track pointer for next search
+          if ((qblock = qmatch[0]).length > 2) {
 
-          if ((qblock = qmatch[0]).length > 2) {      // comment or non-empty qblock?
+            marker = qmatch[1] ?
+              '@' + hqs.length + ICH_QSTRING :
+              ' '
 
-            // Replace comment with space or qstring with a marker that includes its
-            // original position as an index into the array of replaced qstrings.
-            // (qmatch[1] has a quote if it is a qstring)
+            unescapeStr(hqs, qblock)
 
-            marker = qmatch[1] ?                      // quote found? it's a qstring,
-              '@' + hqs.length + ICH_QSTRING :        // create marker for qstring
-              ' '                                     // else replace comment w/space
-
-            unescapeStr(hqs, qblock)                  // unescape brackets here, too
-                                                      // @(backward compatible)
-                                                      // replace qblock
             str = str.slice(0, qposLt) + marker + str.slice(qposRt)
-                                                      // skip qblock
+
             re.lastIndex = qposRt = qposLt + marker.length
 
-            pos = -1                                  // signal to reset outer search
-                                                      // since str was modified
+            pos = -1
+
           }
         }
 
-        // Any qblock found remains unhidden until we're sure it belongs to an expression.
-        // If no qblock is found, set qposLt to the end of string (beyond `pos` value)
+        do {
 
-        RE_QBLOCKS.lastIndex = qposRt                 // begin searching at own offset
+          RE_QBLOCKS.lastIndex = qposRt++
+          qmatch = RE_QBLOCKS.exec(str)
 
-        qposLt = (qmatch = RE_QBLOCKS.exec(str)) ?
-          qmatch.index :                              // this is the start of qblock
-          str.length                                  // avoid entering here again
+          if (qmatch) {
+            qposLt = qmatch.index
 
-      } // end while qposLt <= pos
+            if (qmatch[2]) {
+              if (!RE_PREREGS.test(str.slice(start, qposLt)))
+                qposLt = 0
+              qmatch[1] = '/'
+            }
+          }
+          else qposLt = str.length
 
-      return pos < 1    // true if str has changed
+        } while (!qposLt)
+
+      }
+
+      return pos < 1
 
     }
-    // end of haveQBlock()
 
   }
-  // end of splitByPairs()
-
-
-  // Private function
-  // Parse `{ expression }` or `{ name: expression, ... }`
-
-  // For simplicity, and due to RegExp limitations, riot supports a limited subset (closer
-  // to CSS1 that CSS2) of the full w3c/html specs for non-quoted identifiers of shorthand
-  // names. This simplified regexp is used for the recognition:
-  //
-  //      `/-?[_A-Za-z\xA0-\xFF][-\w\xA0-\xFF]*/`
-  //
-  // The regexp accept all ISO-8859-1 characters that are valid within an html identifier.
-  // The names must begin with one underscore (\x5F), one alphabetic ascii (A-Z, a-z),
-  // or one ISO-8859-1 character in the range 160 to 255, optionally prefixed with one
-  // dash (\x2D).
-  //
-  // NOTE: Although you can use Unicode code points beyond \u00FF by quoting the names
-  //       (not recommended), only use whitespace as separators since, within names,
-  //       riot converts these into spaces.
-  //
-  // See: http://www.w3.org/TR/CSS21/grammar.html#scanner
-  //      http://www.w3.org/TR/CSS21/syndata.html#tokenization
 
   function parseExpr(expr, mode, qstr) {
-
-    // Convert inner whitespace to compact spaces and trims the space surrounding the
-    // expression and various tokens, mainly brackets and separators.
-    // We need convert embedded '\r' and '\n' as these chars breaks js code evaluation.
-    // replacement is secure, expr already lacks strings, regexp, and comments.
-
-    // WARNING:
-    //      Trim and compact is not strictly necessary, but it allows optimized regexps.
-    //      e.g. we can use /:/ instead /\s*:\s*/
-    //      Many regexps in tmpl code depend on this, so do not touch the next line
-    //      until you know how, and which, regexps are affected.
 
     expr = expr
           .replace(/\s+/g, ' ')
@@ -527,95 +284,62 @@ var tmpl = (function (/*DEBUG*/) {
 
     if (!expr) return ''
 
-    // Expression only:   mode == 0 -- nonull == false
-    // Text + expression: mode == 1 -- nonull == true
-
-    // Detect class shorthands, csinfo is filled with [qstring-idx, name, expr] els
     var csinfo = [],
         cslist
 
     if (!extractCSList(expr, csinfo)) {
 
-      // `expr` does not begin with "name:", let's assume js expression.
-      // Here, the "mode" parameter itself is significant
-
       return wrapExpr(expr, mode)
     }
 
-    // We have a class shorthand list, something that looks like a literal js object, in
-    // the format '{ name: expr, ... }', but with HTML/CSS identifiers as names, and its
-    // surrounding brackets already removed by the caller.
-    // At runtime, the code generated here returns a space-delimited list of the names
-    // for those expressions with trueish values.
-    // E.g.: `{ show: isOpen(), done: item.done }` --> "show done"
-
     cslist = csinfo.map(function (kv) {
 
-      // Be carefull, the `name` element can be a hidden quoted string marker. We must
-      // check this for replacing the marker with the original string here, 'cause the
-      // processing of whitespace and quote chars on names (HTML identifiers) differs
-      // to that of the other strings on the expressions (js code).
-      // Once replaced, the marker will not be available anymore. This is desired, as
-      // well as the restoration of the strings does not overwrite these names.
-
-      if (kv[0]) {                              // is name a quoted string marker?
-        kv[1] = qstr[kv[0] | 0]                 // retrieve string by index
-          .slice(1, -1)                         //  and unquote
-          .replace(/[ \r\n\t]+/g, ' ').trim()   // compact whitespace between names
+      if (kv[0]) {
+        kv[1] = qstr[kv[0] | 0]
+          .slice(1, -1)
+          .replace(/[ \r\n\t]+/g, ' ').trim()
       }
 
-      return '(' +                              // wrap all parts to ignore errors.
-          wrapExpr(kv[2], 0) +                  // use raw mode
-          ')?"'  + kv[1]  + '":""'              // all error/falsy values returns ""
+      return '(' +
+          wrapExpr(kv[2], 0) +
+          ')?"'  + kv[1]  + '":""'
 
     })
 
-    return cslist.length < 2 ?                  // optimize 'one element' cases
+    return cslist.length < 2 ?
        cslist[0] :
       '[' + cslist.join(',') + '].join(" ").trim()'
 
   }
-  // end of parseExpr()
-
-
-  // Private function - Helper for parseExpr()
-  // If `str` is a shorthand list, return an array with its parts, or falsy if is not.
-  // This function cares about nested commas.
 
   var
-      // Matches the `name:` part of a class shorthand
+
       CSNAME_PART = newRegExp(
-        '^(' +                            // always at 0, we are searching rightContext
-        RE_QSMARKER.source +              // $1: qstring marker + $2: str index, or...
+        '^(' +
+        RE_QSMARKER.source +
         '|-?[_A-Za-z\xA0-\xFF][-\\w\xA0-\xFF]*' +
-                                          // $1: literal w3c indentifier (almost)
-        '):'                              // skip colon, expression follows
+
+        '):'
       ),
 
-      // Matches open js brackets, comma outside brackets, or the end of str
-      CSPART_END = /([\[{\(])|,|$/g       // $1: js bracket
+      CSPART_END = /([\[{\(])|,|$/g
 
   function extractCSList(str, list) {
 
-    var match,                    // CSNAME_PART results
-        end,                      // CSPART_END results
-        gre,                      // global RegExp object
-        ch,                       // js bracket, or empty for comma or end of str
-        n = 0                     // count of extracted shorthands
+    var match,
+        end,
+        gre,
+        ch,
+        n = 0
 
-    // Try to match the first name testing `match !== null && match.index === 0`
-
-    while (str &&                               // search in the ramaining substring
-          (match = str.match(CSNAME_PART)) &&   // null match or
-          !match.index                          // start > 0 means error
+    while (str &&
+          (match = str.match(CSNAME_PART)) &&
+          !match.index
       ) {
 
       gre = RegExp
-      str = gre.rightContext                    // skip the `name:` part
-      CSPART_END.lastIndex = 0                  // reset lastIndex for exec
-
-      // Search the next comma, outside brackets, or the end of str.
-      // If js bracket is found ($1), skip the bracketed part.
+      str = gre.rightContext
+      CSPART_END.lastIndex = 0
 
       while ((end = CSPART_END.exec(str)) && (ch = end[1])) {
 
@@ -623,20 +347,14 @@ var tmpl = (function (/*DEBUG*/) {
 
       }
 
-      list[n++] = [                             // match still valid, push...
-          match[2],                             // 0: hidden qstring index
-          match[1],                             // 1: unquoted name
-          str.slice(0, end.index)               // 2: expression
+      list[n++] = [
+          match[2],
+          match[1],
+          str.slice(0, end.index)
         ]
 
       str = gre.rightContext
     }
-
-    // Explicit error detection for easy debugging.
-    // If str (rightContext) is not empty, we have a comma after the previous pair,
-    // so this must begin with a name. if not, we have a syntax error.
-    // This is consistent with the literal objects notation (of js), if the user
-    // wants a comma operator, must use parentheses.
 
     if (n && str)
         throw new SyntaxError('Cannot parse ... ' + str + '}')
@@ -644,34 +362,25 @@ var tmpl = (function (/*DEBUG*/) {
     return n
 
   }
-  // end of extractCSList()
 
-
-  // Private function - Helper for splitByPairs & extractCSList.
-  // Skips a bracketed block, ignoring any nested brackets, and returns the next
-  // position following the closing bracket for the `opench` character.
-  // sqcb is a callback for hide qstrings (haveQBlock) returning -1 if str has
-  // changed, in which case this function returns the received original position.
-
-  // Matches js brackets. Used by splitByPairs.skipBracketedPart and skipBrackets
   var JS_BRACKETS = {
-        '{': /\{|\}/g,  // eslint-disable-line no-dupe-keys
+        '{': /\{|\}/g,
         '[': /\[|\]/g,
         '(': /\(|\)/g
       }
 
   function skipBracketedPart(str, opench, chpos, sqcb) {
 
-    var recch = JS_BRACKETS[opench],            // we are using recch for sqcb(), too
+    var recch = JS_BRACKETS[opench],
         match,
-        level = 1                               // when level drops to 0, will have
-                                                // found our right bracket.
-    recch.lastIndex = chpos + 1                 // skip opench
+        level = 1
+
+    recch.lastIndex = chpos + 1
 
     while (level && (match = recch.exec(str))) {
 
-      if (sqcb && sqcb(recch, match.index))     // stop on quoted bracket, since str
-        return chpos                            // has changed. return previous pos
+      if (sqcb && sqcb(recch, match.index))
+        return chpos
 
       match[0] === opench ? ++level : --level
     }
@@ -680,48 +389,31 @@ var tmpl = (function (/*DEBUG*/) {
 
   }
 
-  ////-----------------------------------------------------------------------------------
-  //// WRAPPERS
-  ////-----------------------------------------------------------------------------------
-
-  // Private function
-  // Generates js code to get an expression value, wrapped in a try..finally block
-  // to avoid break on errors or undefined vars.
-  // The generated code will be inserted in an array, returned by parseExpr()
-
   var
-      // Strings used by wrapExpr()
+
       VAR_CONTEXT = '"in D?D:' + (typeof window === T_OBJECT ? 'window' : 'global') + ').',
       WRAP_RETVAL = [
-          'v',                // raw mode
-          'v||v===0?v:""'     // text mode
+          'v',
+          'v||v===0?v:""'
         ],
 
-      // String for RegExp, matches full iso-8859-1 var names
       SRE_VARNAME = '[$_A-Za-z\xA0-\xFF][$\\w\xA0-\xFF]*',
 
-      // Matches a var name alone. Used by wrapExpr with successive string.match
-      // Note:  We are using negative lookahead to exclude properties without capture, so
-      //        it works fine with test() or match(). Gotcha is that we are left with a
-      //        dangling character in $1. prefixVar() returns it to the str.
-      // base: /(?:^ ?|(?![$\w\xA0-ÿ\.])(.))(?!(?:typeof|in|instanceof|void|true|function)\b)(?:(new[ \(])?([$_A-Za-z\xA0-ÿ][$\w\xA0-ÿ]*))/
       JS_VARSTART = newRegExp(
-          '(?:^ ?|' +                       // begin in 0, skip optional space (can be one here)
-          '(?![$\\w\xA0-\xFF\\.])(.))' +    // $1: non var name nor dot char, w/ negative lookahead. dot|name follows?
+          '(?:^ ?|' +
+          '(?![$\\w\xA0-\xFF\\.])(.))' +
           '(?!(?:typeof|in|instanceof|void|true|new|function)\\b)' +
-                                            // negative lookahead on previous one, fail the match on some js keywords
-          '(' + SRE_VARNAME + ')'           // $2: var name or falsy primitive (JS_FALY)
+
+          '(' + SRE_VARNAME + ')'
         ),
 
-      // Matches key names of literal objects
       JS_OBJKEYS = newRegExp(
-          '(?=[,{]'   +                     // lookehead for start or separator of k:v pair
-          SRE_VARNAME +                     // match a name, but only
-          '?:)(.)',                         // $1: capture the bracket or separator
-          'g'                               // needed, this is for replace()
+          '(?=[,{]'   +
+          SRE_VARNAME +
+          '?:)(.)',
+          'g'
         ),
 
-      // For optimization of falsy values with nonull=true (JS_VARSTART let pass these)
       JS_FALSY = {
         'this': 0,
         'global': 0,
@@ -739,8 +431,8 @@ var tmpl = (function (/*DEBUG*/) {
       expr = expr.replace(JS_OBJKEYS, '$1\uFFF30')
 
     var match = expr.match(JS_VARSTART)
-    if (match) {                            // how much is wrap nedeed?
-                                            // wrap vars in expression
+    if (match) {
+
       var ss = [],
           mvar,
           wrap = 0,
@@ -748,16 +440,12 @@ var tmpl = (function (/*DEBUG*/) {
 
       do {
 
-        // string.match() with regexp without the global flag returns submatches
-        // $1: character not part of the var name, must be pushed before wrap
-        // $2: var name
-
-        ss.push(gre.leftContext + (match[1] || ''))   // save left part & dangling char
-        expr = gre.rightContext                       // expr to be processed later
+        ss.push(gre.leftContext + (match[1] || ''))
+        expr = gre.rightContext
         mvar = match[2]
 
         if (JS_FALSY[mvar])
-          ss.push(astxt ? '""' : mvar)                // mode 1 (text) returns ''
+          ss.push(astxt ? '""' : mvar)
 
         else {
           ss.push(mvar in JS_FALSY ? mvar : ('("' + mvar + VAR_CONTEXT + mvar))
@@ -767,36 +455,25 @@ var tmpl = (function (/*DEBUG*/) {
 
       } while ((match = expr.match(JS_VARSTART)))
 
-      expr = (ss.join('') + expr).trim()              // don't trim inner spaces here
+      expr = (ss.join('') + expr).trim()
 
       if (wrap)
         expr = '(function(v){try{v=' + expr +
                 '}finally{return ' + WRAP_RETVAL[astxt] + '}}).call(D)'
 
-      //else if (astxt)
-      //  expr = '((v=' + expr + ')||v===0v:"")'
-
-    } // if match
+    }
 
     return okeys ? expr.replace(/\uFFF30/g, '') : expr
 
   }
-  // end of wrapExpr()
-
-
-  // Private function - Common helper
-  // Creates a new regexp (uglify save some bytes with this)
 
   function newRegExp(restr, opts) {
 
     return new RegExp(restr, opts)
 
   }
-  // end of newRegExp()
 
-
-  return _tmpl        // the exposed function
-
+  return _tmpl
 
 })()
-// end of IIFE for tmpl
+

--- a/test/specs/tmpl.js
+++ b/test/specs/tmpl.js
@@ -290,6 +290,15 @@ describe('Tmpl', function() {
     expect(render('{ ok: /"\'/.test("\\\"\'") }')).to.be('ok')
     expect(render('str = "/\\\\\"\'/"')).to.be('str = "/\\\"\'/"')
 
+    // no confusion with operators
+    data.x = 2
+    expect(render('{ 10 /x+10/ 1 }')).to.be(15)
+    expect(render('{ x /2+x/ 1 }')).to.be(3)
+    expect(render('{ x /2+"abc".search(/c/) }')).to.be(3)
+
+    // in expressions, there's no ASI support
+    expect(render('{ x\n /2+x/ 1 }')).to.be(3)
+
   //// Better recognition of comments, including empty ones.
 
     // comments within expresions are converted to spaces, in concordance with js specs

--- a/test/specs/tmpl.js
+++ b/test/specs/tmpl.js
@@ -21,7 +21,7 @@ describe('Tmpl', function() {
 
   it('compiles specs', function() {
 
-    this.timeout(5000)
+    //this.timeout(5000)
     //// return values
 
     // expressions always return a raw value
@@ -128,7 +128,8 @@ describe('Tmpl', function() {
     expect(render('{ "a b": yes }')).to.equal('a b')
 
     // errors in expressions are silently catched allowing shorter expressions
-    expect(render('{ loading: !nonExistingVar.length }')).to.equal('loading')
+//  expect(render('{ loading: !nonExistingVar.length }')).to.equal('loading')   //@not compatible
+    expect(render('{ loading: !nonExistingVar.length }')).to.equal('')
 
     // expressions are just regular JavaScript
     expect(render('{ a: !no, b: yes }')).to.equal('a b')
@@ -198,6 +199,218 @@ describe('Tmpl', function() {
     riot.settings.brackets = '${ }'
     expect(render('a${ "b{c\\}d" }e')).to.equal('ab{c}de')
     riot.settings.brackets = null
+
+  })
+
+  it('compiles specs - 2015-07-10 tmpl update', function() {
+
+    riot.settings.brackets = null
+
+  //// Fewer errors in recognizing complex expressions, even in class shorthands.
+
+    data.$a = 0
+    data.$b = 0
+    data.parent = { selectedId: 0 }
+
+    // FIX #784 - The shorthand syntax for class names doesn't support parentheses
+    expect(render('{ primary: (parent.selectedId === $a)  }')).to.be('primary')
+
+    // a bit more of complexity. note: using the comma operator requires parentheses
+    expect(render('{ ok: ($b++, ($a > 0) || ($b & 1)) }')).to.be('ok')
+
+  //// Unprotected keywords `void`, `window` and `global`, in addition to `this`.
+
+    globalVar = 5
+    data.$a = 5
+    expect(render('{' + (typeof window === 'object' ? 'window' : 'global') +'.globalVar }')).to.be(5)
+    expect(render('{ this.$a }')).to.be(5)
+    expect(render('{ void 0 }')).to.be(undefined)
+
+    // without unprefixed global/window, default convertion to `new (D).Date()` throws here
+    data.Date = '?'
+    if (typeof window !== 'object')
+      expect(render('{ +new global.Date() }')).to.be.a('number')
+    else
+      expect(render('{ +new window.Date() }')).to.be.a('number')
+
+  //// Better recognition of nested brackets, escaping is almost unnecessary.
+
+    // inner brackets don't need to be escaped
+    expect(render('{{ str: "s" }}')).to.eql({ str: 's' })
+    expect(render(' {{str: {}}}+{{}}')).to.be(' [object Object]+[object Object]')
+    expect(render('{ "{}}" }')).to.be('{}}')
+
+    // inner custom brackets
+    riot.settings.brackets = '[ ]'
+    expect(render('[ str[0] ]')).to.be('x')
+    expect(render('[ [1].pop() ]')).to.be(1)
+    expect(render('a,[["b", "c"]],d')).to.be('a,b,c,d')
+
+    riot.settings.brackets = '<% %>'
+    expect(render('<% "%><% %>" %>')).to.be('%><% %>')
+
+    // multi character brackets
+    riot.settings.brackets = '(( ))'
+    expect(render('((({})))')).to.eql({})
+    expect(render('(((("o"))))="o"')).to.be('o="o"')
+    expect(render('((( ("o") )))="o"')).to.be('o="o"')
+
+    // brackets inside strings, even unbalanced, are ignored
+    riot.settings.brackets = null
+    expect(render('a{ "b{cd" }e')).to.be('ab{cde')
+    expect(render('a{ "b}cd" }e')).to.be('ab}cde')
+
+    // asymmetric custom brackets
+    riot.settings.brackets = '${ }'
+    expect(render('a${ "b${c}d" }e')).to.be('ab${c}de')
+
+    // silly brackets?
+    riot.settings.brackets = '[ ]]'
+    expect(render('a[ "[]]"]]b')).to.be('a[]]b')
+    expect(render('[[[]]]]')).to.eql([[]])
+
+    riot.settings.brackets = '( ))'
+    expect(render('a( "b))" ))c')).to.be('ab))c')
+    expect(render('a( (("bc))")) ))')).to.be('abc))')
+    expect(render('a( ("(((b))") ))c')).to.be('a(((b))c')
+    expect(render('a( ("b" + (")c" ))))')).to.be('ab)c')    // test skipBracketedPart()
+
+    riot.settings.brackets = null
+
+  //// Better recognition of literal regexps inside template and expressions.
+
+    expect(render('{ /{}\\/\\n/.source }')).to.be('{}\\/\\n')
+    expect(render('{ ok: /{}\\/\\n/.test("{}\\/\\n") }')).to.be('ok')
+
+    // in quoted text, left bracket and backslashes need to be escaped!
+    expect(render('str = "/\\{}\\\\/\\\\n/"')).to.be('str = "/{}\\/\\n/"')
+
+    // handling quotes in regexp is not so complicated :)
+    expect(render('{ /"\'/.source }')).to.be('"\'')
+    expect(render('{ ok: /"\'/.test("\\\"\'") }')).to.be('ok')
+    expect(render('str = "/\\\\\"\'/"')).to.be('str = "/\\\"\'/"')
+
+  //// Better recognition of comments, including empty ones.
+
+    // comments within expresions are converted to spaces, in concordance with js specs
+    expect(render('{ typeof/**/str === "string" }')).to.be(true)
+    expect(render('{ 1+/* */+2 }')).to.be(3)
+
+    // comments in template text is preserved
+    expect(render(' /*/* *\/ /**/ ')).to.be(' /*/* *\/ /**/ ')
+    expect(render('/*/* "note" /**/')).to.be('/*/* "note" /**/')
+
+    // riot parse correctamente empty and exotic comments
+    expect(render('{ /**/ }')).to.be(undefined)               // empty comment
+    expect(render('{ /*/* *\/ /**/ }')).to.be(undefined)      // nested comment sequences
+
+    // there's no problem in shorthands
+    expect(render('{ ok: 0+ /*{no: 1}*/ 1 }')).to.be('ok')
+    expect(render('{ ok: 1 /*, no: 1*/ }')).to.be('ok')
+    expect(render('{ ok/**/: 1 }')).to.be('ok')
+
+    // nor in the template text, comments inside strings are preserved
+    expect(render('{ "/* ok */" }')).to.be('/* ok */')
+    expect(render('{ "/*/* *\/ /**/" }')).to.be('/*/* *\/ /**/')
+    expect(render('{ "/* \\"comment\\" */" }')).to.be('/* "comment" */')
+
+  //// Support for full ISO-8859-1 charset in js var and class names
+
+    expect(render('{ neón: 1 }')).to.be('neón')
+    expect(render('{ -ä: 1 }')).to.be('-ä')                   // '-ä' is a valid class name
+    expect(render('{ ä: 1 }')).to.be('ä')
+    expect(render('{ (this["neón"] = 0, ++neón) }')).to.be(1)
+    expect(render('{ (this["_ä"] = 1, _ä) }')).to.be(1)       // '-ä'' is not a var name
+    expect(render('{ (this["ä"] = 1, ä) }')).to.be(1)
+
+    // but you can include almost anything in quoted names
+    expect(render('{ "_\u221A": 1 }')).to.be('_\u221A')
+    expect(render('{ (this["\u221A"] = 1, this["\u221A"]) }')).to.be(1)
+
+  //// Mac/Win EOL's normalization avoids unexpected results with some editors.
+
+    // win eols are normalized in template text
+    expect(render('\r\n \n \r \n\r')).to.be('\n \n \n \n\n')
+    expect(render('\r\n { 0 } \r\n')).to.be('\n 0 \n')
+
+    // ...even in their quoted parts
+    expect(render('style="\rtop:0\r\n"')).to.be('style="\ntop:0\n"')
+
+    // whitespace are compacted in expressions (see generated code)
+    expect(render(' { yes ?\n\t2 : 4} ')).to.be(' 2 ')
+    expect(render('{ \t \nyes !== no\r\n }')).to.be(true)
+
+    // ...but is preserved in js quoted strings
+    expect(render('{ "\r\n \n \r" }')).to.be('\r\n \n \r')
+    expect(render('{ ok: "\r\n".charCodeAt(0) === 13 }')).to.be('ok')
+
+    // in shorthand names, whitespace will be compacted.
+    expect(render('{ " \ta\n \r \r\nb\n ": yes }')).to.be('a b')
+
+  //// Extra tests
+
+    // correct handling of quotes
+    expect(render('{ "House \\"Atrides\\" wins" }')).to.be('House "Atrides" wins')
+    expect(render('{ "Leto\'s house" }')).to.be("Leto's house")
+    expect(render(" In '{ \"Leto\\\\\\\'s house\" }' ")).to.be(" In 'Leto\\\'s house' ")  // « In '{ "Leto\\\'s house" }' » --> In 'Leto\'s house'
+    expect(render(' In "{ "Leto\'s house" }" ')).to.be(' In "Leto\'s house" ')            // « In "{ "Leto's house" }"    » --> In "Leto's house"
+    expect(render(' In "{ \'Leto\\\'s house\' }" ')).to.be(' In "Leto\'s house" ')        // « In "{ 'Leto\'s house' }"   » --> In "Leto's house"
+
+  //// Consistency?
+
+    // the main inconsistence between expressions and class shorthands
+    expect(render('{ !nonExistingVar.foo ? "ok" : "" }')).to.equal(undefined) // ok
+    expect(render('{ !nonExistingVar.foo ? "ok" : "" } ')).to.equal(' ')      // ok
+  //expect(render('{ ok: !nonExistingVar.foo }')).to.equal('ok')              // what?
+    expect(render('{ ok: !nonExistingVar.foo }')).to.equal('')                // ok ;)
+
+  //// Custom brackets
+
+    // brackets RegEx generation and info, discards /im, escape each char in regexp
+    !(function testBrackets(brfn) {
+
+      var vals = [
+      // source     brackets(2) + brackets(3)
+        ['<% %>',   '<% %>'    ],
+        ['[! !]',   '\\[! !]'  ],
+        ['·ʃ< ]]',  '·ʃ< ]]'   ],
+        ['{$ $}',   '{\\$ \\$}'],
+        ['${ }',    '\\${ }'   ],
+        ['_( )_',   '_\\( \\)_']
+      ]
+      var rs, bb, i
+
+      riot.settings.brackets = undefined  // use default brackets
+      for (i = 0; i < 2; i++) {
+        expect(brfn(rs)).to.be(rs)
+        expect(brfn(0)).to.equal('{')
+        expect(brfn(1)).to.equal('}')
+        expect(brfn(2)).to.equal('{')
+        expect(brfn(3)).to.equal('}')
+        expect(brfn(4) + '').to.be('' + /\\({|})/g)
+        expect(brfn(5) + '').to.be('' + /(\\?)(?=([{\[\(])|{|})(?:({)|(})|.)?/g)
+        riot.settings.brackets = '{ }'    // same as defaults
+      }
+      for (i = 0; i < vals.length; i++) {
+
+        // set another brackets
+        rs = vals[i]
+        bb = (riot.settings.brackets = rs[0]).split(' ')
+        rs = rs[1]
+
+        expect(brfn(/{ }/g).source).to.equal(rs)
+        expect(brfn(0)).to.equal(bb[0])
+        expect(brfn(1)).to.equal(bb[1]); bb = rs.split(' ')
+        expect(brfn(2)).to.equal(bb[0])
+        expect(brfn(3)).to.equal(bb[1])
+        expect(brfn(4).source).to.equal('\\\\(' + rs.replace(' ', '|') + ')')
+        expect(brfn(5).source).to.equal('(\\\\?)(?=([{\\[\\(])|' +
+          rs.replace(' ', '|') + ')(?:(' + rs.replace(' ', ')|(') + ')|.)?')
+      }
+
+      riot.settings.brackets = null
+
+    })(riot.util.brackets)
 
   })
 

--- a/test/specs/tmpl.js
+++ b/test/specs/tmpl.js
@@ -202,7 +202,7 @@ describe('Tmpl', function() {
 
   })
 
-  it('compiles specs - 2015-07-10 tmpl update', function() {
+  it('compiles specs - 2015-07-16 tmpl update', function() {
 
     riot.settings.brackets = null
 
@@ -324,14 +324,14 @@ describe('Tmpl', function() {
     expect(render('{ "/* \\"comment\\" */" }')).to.be('/* "comment" */')
 
   //// Support for full ISO-8859-1 charset in js var and class names
-
+  /*
     expect(render('{ neón: 1 }')).to.be('neón')
     expect(render('{ -ä: 1 }')).to.be('-ä')                   // '-ä' is a valid class name
     expect(render('{ ä: 1 }')).to.be('ä')
     expect(render('{ (this["neón"] = 0, ++neón) }')).to.be(1)
     expect(render('{ (this["_ä"] = 1, _ä) }')).to.be(1)       // '-ä'' is not a var name
     expect(render('{ (this["ä"] = 1, ä) }')).to.be(1)
-
+  */
     // but you can include almost anything in quoted names
     expect(render('{ "_\u221A": 1 }')).to.be('_\u221A')
     expect(render('{ (this["\u221A"] = 1, this["\u221A"]) }')).to.be(1)
@@ -396,8 +396,6 @@ describe('Tmpl', function() {
         expect(brfn(1)).to.equal('}')
         expect(brfn(2)).to.equal('{')
         expect(brfn(3)).to.equal('}')
-        expect(brfn(4) + '').to.be('' + /\\({|})/g)
-        expect(brfn(5) + '').to.be('' + /(\\?)(?=([{\[\(])|{|})(?:({)|(})|.)?/g)
         riot.settings.brackets = '{ }'    // same as defaults
       }
       for (i = 0; i < vals.length; i++) {
@@ -412,9 +410,6 @@ describe('Tmpl', function() {
         expect(brfn(1)).to.equal(bb[1]); bb = rs.split(' ')
         expect(brfn(2)).to.equal(bb[0])
         expect(brfn(3)).to.equal(bb[1])
-        expect(brfn(4).source).to.equal('\\\\(' + rs.replace(' ', '|') + ')')
-        expect(brfn(5).source).to.equal('(\\\\?)(?=([{\\[\\(])|' +
-          rs.replace(' ', '|') + ')(?:(' + rs.replace(' ', ')|(') + ')|.)?')
       }
 
       riot.settings.brackets = null

--- a/test/specs/tmpl.js
+++ b/test/specs/tmpl.js
@@ -21,7 +21,7 @@ describe('Tmpl', function() {
 
   it('compiles specs', function() {
 
-    //this.timeout(5000)
+    this.timeout(5000)
     //// return values
 
     // expressions always return a raw value


### PR DESCRIPTION
This version is passing the riot tests in the dev branch, and all tests in the new-tmpl-1 branch, except the one listed here, for class shorthand with a property over an undefined value (`!this.nonExistingVar.length`).
This have kept all the new characteristics of the version in v1 branch.

### Changed:

Class shorthands are using the same wrapper as the rest of the expressions.
i.e. there's no protection at property level, but at expression level.
In this example, the new behavior causes different results from the current:

The test fail (as expressions do) on undefined with nested properties, so
```javascript
{ loading: !nonExistingVar.length }       // returns "", instead "ok"
```
is equivalent to:
```javascript
{ loading: !this.nonExistingVar.length }  // returns "", or
{ !this.nonExistingVar.length }           // returns undefined, or "" in templates
```
The big plus is that shorthands supports now **the full behavior** of "normal" expressions with a minor restriction...

#### Restrictions:
In the expression of shorthands, you can use commas for object literals and arrays but, outside these, usage of the comma operator requires parentheses.
EDIT:
Within any expression, you must escape forward slashes.

### Removed:
_"Instantiation with the constructor's name in parentheses use the default context"_

NOTE: `this`, `global`, and `window` are not prefixed with context detection, so you can force the context with code like: `{ new window.Date() }`

For those interested:
I updated my Google Drive files to include [examples of the output of this version](https://drive.google.com/open?id=0B-b6qZXAKYLNflFEWmpxQ01yMDNTT3RKT3lqVnpISEJUT1p1bDhoWDhnWlZtWlljVVJZVlE)
(See: tmpl_output_20150710.txt)
In these you can see the size reduction of the generated code for the getters.

#### Size info:

Branch | Full | Minified | saving | Minified with -c | saving
----------|-----|-----------|----------|----------|-----
new-tmpl-1  | 43,056 | 4,388    | 89.8%  | 4,261    | 90.1%
new-tmpl-2  |  8,227 | 3,187    | 61.3%  | 3,108 | 62.2%
dev         |  6,759 | 1,887    | 72.1%  | 1,869    | 72.3%

Please, checkout and test.

EDIT @ 2015-07-14

_Updates for lib/browser/tmpl.js_:
Comments removed with [rmcomms.js, simple tool available as Git](https://gist.github.com/aMarCruz/4c4937a2cb37ab2edf93), donated to the riot team.
Regexps revised, faster and more reliable.
(changes in code size, have also been updated in this comment).

_Updates for test/specs/tmpl.js_
Added tests for secure regexp detection.

EDIT @ 2015-07-16

Removed support for 8 bit, iso-8859-1 characteres, since caller doesn't supports these.
Revision of quoted string detection.
Code is more compact.
(update code size data in this comment).
