### PR TITLE
Parse jade file as html5 by default #912

### DIFF
--- a/lib/server/parsers.js
+++ b/lib/server/parsers.js
@@ -1,7 +1,7 @@
 var parsers = {
   html: {
     jade: function(html) {
-      return require('jade').render(html, {pretty: true})
+      return require('jade').render(html, {pretty: true, doctype: 'html'})
     }
   },
   css: {},


### PR DESCRIPTION
Then we can get a boolean attribute according to html5 standard with jade template.
and also solved the `style(scoped).` problem in #912