### PR TITLE
Fix issue #947

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -2,7 +2,7 @@
 // { key, i in items} -> { key, i, items }
 function loopKeys(expr) {
   var b0 = brackets(0),
-      els = expr.slice(b0.length).match(/^\s*(\S+?)\s*(?:,\s*(\S+))?\s+in\s+(.+)$/)
+      els = expr.slice(b0.length).trim().match(/^(\S+?)\s*(?:,\s*(\S+))?\s+in\s+(.+)$/)
   return els ? { key: els[1], pos: els[2], val: b0 + els[3] } : { val: expr }
 }
 

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -2,7 +2,7 @@
 // { key, i in items} -> { key, i, items }
 function loopKeys(expr) {
   var b0 = brackets(0),
-      els = expr.slice(b0.length).trim().match(/^(\S+?)\s*(?:,\s*(\S+))?\s+in\s+(.+)$/)
+      els = expr.trim().slice(b0.length).match(/^\s*(\S+?)\s*(?:,\s*(\S+))?\s+in\s+(.+)$/)
   return els ? { key: els[1], pos: els[2], val: b0 + els[3] } : { val: expr }
 }
 

--- a/test/tag/isloop-test.tag
+++ b/test/tag/isloop-test.tag
@@ -1,6 +1,6 @@
 <plans>
   <h2>Plans</h2>
-  <plan each="{ name in names }" name="{ name }"></plan>
+  <plan each=" { name in names } " name="{ name }"></plan>
 
   this.names = ['plan1', 'plan2'];
 


### PR DESCRIPTION
Trims whitespace in expressions of type `{key in items}` or `{key,i in items}`, forcing these to return raw values.