### PR TITLE
lower-case livescript

### DIFF
--- a/lib/server/parsers.js
+++ b/lib/server/parsers.js
@@ -10,7 +10,7 @@ var parsers = {
       return js
     },
     livescript: function(js) {
-      return require('LiveScript').compile(js, { bare: true, header: false })
+      return require('livescript').compile(js, { bare: true, header: false })
     },
     typescript: function(js) {
       return require('typescript-simple')(js)


### PR DESCRIPTION
'LiveScript' recently renamed to lower-case 'livescript'. http://livescript.net/blog/livescript-1.4.0-source-maps-more.html