### PR TITLE
remove unnecessary use of global and eval in compiler on server side

### DIFF
--- a/lib/browser/compiler/core.js
+++ b/lib/browser/compiler/core.js
@@ -1,6 +1,9 @@
 var doc = window.document,
     promise,
-    ready
+    ready,
+    compiler = riotCompiler(riot),
+    compile = compiler.compile,
+    T_STRING = compiler.T_STRING
 
 
 function GET(url, fn) {

--- a/lib/server/compiler.js
+++ b/lib/server/compiler.js
@@ -1,16 +1,8 @@
 var compilerPath = require('path').join(__dirname, '../shared/compiler.js')
 
-global.riot = require(process.env.RIOT || '../../riot')
-global.riot.parsers = require('./parsers')
+var riot = require(process.env.RIOT || '../../riot')
+riot.parsers = require('./parsers')
 
-// Evaluate the compiler shared functions in this context
-/*eslint-disable*/
-eval(require('fs').readFileSync(compilerPath, 'utf8'))
-/*eslint-enable*/
+var compiler = require(compilerPath)(riot)
 
-module.exports = {
-  compile: compile,
-  html: compileHTML,
-  style: compileCSS,
-  js: compileJS
-}
+module.exports = compiler

--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -1,222 +1,258 @@
-var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,'+
-  'defaultchecked,defaultmuted,defaultselected,defer,disabled,draggable,enabled,formnovalidate,hidden,'+
-  'indeterminate,inert,ismap,itemscope,loop,multiple,muted,nohref,noresize,noshade,novalidate,nowrap,open,'+
-  'pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,spellcheck,translate,truespeed,'+
-  'typemustmatch,visible').split(','),
-  // these cannot be auto-closed
-  VOID_TAGS = 'area,base,br,col,command,embed,hr,img,input,keygen,link,meta,param,source,track,wbr'.split(','),
-  /*
-    Following attributes give error when parsed on browser with { exrp_values }
+!function (module, exports) {
 
-    'd' describes the SVG <path>, Chrome gives error if the value is not valid format
-    https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d
-  */
-  PREFIX_ATTR = ['style', 'src', 'd'],
+  module[exports] = function (riot) {
 
-  LINE_TAG = /^<([\w\-]+)>(.*)<\/\1>/gim,
-  QUOTE = /=({[^}]+})([\s\/\>])/g,
-  SET_ATTR = /([\w\-]+)=(["'])([^\2]+?)\2/g,
-  EXPR = /{\s*([^}]+)\s*}/g,
-  // (tagname) (html) (javascript) endtag
-  CUSTOM_TAG = /^<([\w\-]+)\s?([^>]*)>([^\x00]*[\w\/}"']>$)?([^\x00]*?)^<\/\1>/gim,
-  SCRIPT = /<script(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gm,
-  STYLE = /<style(\s+type=['"]?([^>'"]+)['"]?|\s+scoped)?>([^\x00]*?)<\/style>/gm,
-  CSS_SELECTOR = /(^|\}|\{)\s*([^\{\}]+)\s*(?=\{)/g,
-  CSS_COMMENT = /\/\*[^\x00]*?\*\//gm,
-  HTML_COMMENT = /<!--.*?-->/g,
-  CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
-  LINE_COMMENT = /^\s*\/\/.*$/gm,
-  JS_COMMENT = /\/\*[^\x00]*?\*\//gm,
-  INPUT_NUMBER = /(<input\s[^>]*?)type=['"]number['"]/gm
+    var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,default,'+
+      'defaultchecked,defaultmuted,defaultselected,defer,disabled,draggable,enabled,formnovalidate,hidden,'+
+      'indeterminate,inert,ismap,itemscope,loop,multiple,muted,nohref,noresize,noshade,novalidate,nowrap,open,'+
+      'pauseonexit,readonly,required,reversed,scoped,seamless,selected,sortable,spellcheck,translate,truespeed,'+
+      'typemustmatch,visible').split(','),
+      // these cannot be auto-closed
+      VOID_TAGS = 'area,base,br,col,command,embed,hr,img,input,keygen,link,meta,param,source,track,wbr'.split(','),
+      /*
+        Following attributes give error when parsed on browser with { exrp_values }
 
-function mktag(name, html, css, attrs, js) {
-  return 'riot.tag(\''
-    + name + '\', \''
-    + html + '\''
-    + (css ? ', \'' + css + '\'' : '')
-    + (attrs ? ', \'' + attrs.replace(/'/g, "\\'") + '\'' : '')
-    + ', function(opts) {' + js + '\n});'
-}
+        'd' describes the SVG <path>, Chrome gives error if the value is not valid format
+        https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d
+      */
+      PREFIX_ATTR = ['style', 'src', 'd'],
 
-function compileHTML(html, opts, type) {
+      LINE_TAG = /^<([\w\-]+)>(.*)<\/\1>/gim,
+      QUOTE = /=({[^}]+})([\s\/\>])/g,
+      SET_ATTR = /([\w\-]+)=(["'])([^\2]+?)\2/g,
+      EXPR = /{\s*([^}]+)\s*}/g,
+      // (tagname) (html) (javascript) endtag
+      CUSTOM_TAG = /^<([\w\-]+)\s?([^>]*)>([^\x00]*[\w\/}"']>$)?([^\x00]*?)^<\/\1>/gim,
+      SCRIPT = /<script(\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gm,
+      STYLE = /<style(\s+type=['"]?([^>'"]+)['"]?|\s+scoped)?>([^\x00]*?)<\/style>/gm,
+      CSS_SELECTOR = /(^|\}|\{)\s*([^\{\}]+)\s*(?=\{)/g,
+      CSS_COMMENT = /\/\*[^\x00]*?\*\//gm,
+      HTML_COMMENT = /<!--.*?-->/g,
+      CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
+      LINE_COMMENT = /^\s*\/\/.*$/gm,
+      JS_COMMENT = /\/\*[^\x00]*?\*\//gm,
+      INPUT_NUMBER = /(<input\s[^>]*?)type=['"]number['"]/gm
 
-  var brackets = riot.util.brackets
-
-  // foo={ bar } --> foo="{ bar }"
-  html = html.replace(brackets(QUOTE), '="$1"$2')
-
-  // whitespace
-  html = opts.whitespace ? html.replace(/\n/g, '\\n') : html.replace(/\s+/g, ' ')
-
-  // strip comments
-  html = html.trim().replace(HTML_COMMENT, '')
-
-  // input type=numbr
-  html = html.replace(INPUT_NUMBER, '$1riot-type='+brackets(0)+'"number"'+brackets(1)) // fake expression
-
-  // alter special attribute names
-  html = html.replace(SET_ATTR, function(full, name, _, expr) {
-    if (expr.indexOf(brackets(0)) >= 0) {
-      name = name.toLowerCase()
-
-      if (PREFIX_ATTR.indexOf(name) >= 0) name = 'riot-' + name
-
-      // IE8 looses boolean attr values: `checked={ expr }` --> `__checked={ expr }`
-      else if (BOOL_ATTR.indexOf(name) >= 0) name = '__' + name
+    function mktag(name, html, css, attrs, js) {
+      return 'riot.tag(\''
+        + name + '\', \''
+        + html + '\''
+        + (css ? ', \'' + css + '\'' : '')
+        + (attrs ? ', \'' + attrs.replace(/'/g, "\\'") + '\'' : '')
+        + ', function(opts) {' + js + '\n});'
     }
 
-    return name + '="' + expr + '"'
-  })
+    function compileHTML(html, opts, type) {
 
-  // run expressions trough parser
-  if (opts.expr) {
-    html = html.replace(brackets(EXPR), function(_, expr) {
-      var ret = compileJS(expr, opts, type).trim().replace(/\r?\n|\r/g, '').trim()
-      if (ret.slice(-1) == ';') ret = ret.slice(0, -1)
-      return brackets(0) + ret + brackets(1)
-    })
-  }
+      var brackets = riot.util.brackets
 
-  // <foo/> -> <foo></foo>
-  html = html.replace(CLOSED_TAG, function(_, name, attr) {
-    var tag = '<' + name + (attr ? ' ' + attr.trim() : '') + '>'
+      // foo={ bar } --> foo="{ bar }"
+      html = html.replace(brackets(QUOTE), '="$1"$2')
 
-    // Do not self-close HTML5 void tags
-    if (VOID_TAGS.indexOf(name.toLowerCase()) == -1) tag += '</' + name + '>'
-    return tag
-  })
+      // whitespace
+      html = opts.whitespace ? html.replace(/\n/g, '\\n') : html.replace(/\s+/g, ' ')
 
-  // escape single quotes
-  html = html.replace(/'/g, "\\'")
+      // strip comments
+      html = html.trim().replace(HTML_COMMENT, '')
 
-  // \{ jotain \} --> \\{ jotain \\}
-  html = html.replace(brackets(/\\{|\\}/g), '\\$&')
+      // input type=numbr
+      html = html.replace(INPUT_NUMBER, '$1riot-type='+brackets(0)+'"number"'+brackets(1)) // fake expression
 
-  // compact: no whitespace between tags
-  if (opts.compact) html = html.replace(/> </g, '><')
+      // alter special attribute names
+      html = html.replace(SET_ATTR, function(full, name, _, expr) {
+        if (expr.indexOf(brackets(0)) >= 0) {
+          name = name.toLowerCase()
 
-  return html
+          if (PREFIX_ATTR.indexOf(name) >= 0) name = 'riot-' + name
 
-}
-
-
-function riotjs(js) {
-
-  // strip comments
-  js = js.replace(LINE_COMMENT, '').replace(JS_COMMENT, '')
-
-  // ES6 method signatures
-  var lines = js.split('\n'),
-      es6Ident = ''
-
-  lines.forEach(function(line, i) {
-    var l = line.trim()
-
-    // method start
-    if (l[0] != '}' && l.indexOf('(') > 0 && l.indexOf('function') == -1) {
-      var end = /[{}]/.exec(l.slice(-1)),
-          m = end && /(\s+)([\w]+)\s*\(([\w,\s]*)\)\s*\{/.exec(line)
-
-      if (m && !/^(if|while|switch|for|catch)$/.test(m[2])) {
-        lines[i] = m[1] + 'this.' + m[2] + ' = function(' + m[3] + ') {'
-
-        // foo() { }
-        if (end[0] == '}') {
-          lines[i] += ' ' + l.slice(m[0].length - 1, -1) + '}.bind(this)'
-
-        } else {
-          es6Ident = m[1]
+          // IE8 looses boolean attr values: `checked={ expr }` --> `__checked={ expr }`
+          else if (BOOL_ATTR.indexOf(name) >= 0) name = '__' + name
         }
+
+        return name + '="' + expr + '"'
+      })
+
+      // run expressions trough parser
+      if (opts.expr) {
+        html = html.replace(brackets(EXPR), function(_, expr) {
+          var ret = compileJS(expr, opts, type).trim().replace(/\r?\n|\r/g, '').trim()
+          if (ret.slice(-1) == ';') ret = ret.slice(0, -1)
+          return brackets(0) + ret + brackets(1)
+        })
       }
 
-    }
+      // <foo/> -> <foo></foo>
+      html = html.replace(CLOSED_TAG, function(_, name, attr) {
+        var tag = '<' + name + (attr ? ' ' + attr.trim() : '') + '>'
 
-    // method end
-    if (line.slice(0, es6Ident.length + 1) == es6Ident + '}') {
-      lines[i] = es6Ident + '}.bind(this);'
-      es6Ident = ''
-    }
-
-  })
-
-  return lines.join('\n')
-
-}
-
-function scopedCSS (tag, style, type) {
-  return style.replace(CSS_COMMENT, '').replace(CSS_SELECTOR, function (m, p1, p2) {
-    return p1 + ' ' + p2.split(/\s*,\s*/g).map(function(sel) {
-      var s = sel.trim().replace(/:scope\s*/, '')
-      return s[0] == '@' || s == 'from' || s == 'to' || /%$/.test(s) ? s :
-        tag + ' ' + s + ', [riot-tag="' + tag + '"] ' + s
-    }).join(',')
-  }).trim()
-}
-
-function compileJS(js, opts, type) {
-  var parser = opts.parser || (type ? riot.parsers.js[type] : riotjs)
-  if (!parser) throw new Error('Parser not found "' + type + '"')
-  return parser(js, opts)
-}
-
-function compileTemplate(lang, html) {
-  var parser = riot.parsers.html[lang]
-  if (!parser) throw new Error('Template parser not found "' + lang + '"')
-  return parser(html)
-}
-
-function compileCSS(style, tag, type) {
-  if (type == 'scoped-css') style = scopedCSS(tag, style)
-  else if (riot.parsers.css[type]) style = riot.parsers.css[type](tag, style)
-  return style.replace(/\s+/g, ' ').replace(/\\/g, '\\\\').replace(/'/g, "\\'").trim()
-}
-
-function compile(src, opts) {
-
-  opts = opts || {}
-
-  if (opts.brackets) riot.settings.brackets = opts.brackets
-
-  if (opts.template) src = compileTemplate(opts.template, src)
-
-  src = src.replace(LINE_TAG, function(_, tagName, html) {
-    return mktag(tagName, compileHTML(html, opts), '', '', '')
-  })
-
-  return src.replace(CUSTOM_TAG, function(_, tagName, attrs, html, js) {
-    html = html || ''
-    attrs = compileHTML(attrs, '', '')
-
-    // js wrapped inside <script> tag
-    var type = opts.type
-
-    if (!js.trim()) {
-      html = html.replace(SCRIPT, function(_, fullType, _type, script) {
-        if (_type) type = _type.replace('text/', '')
-        js = script
-        return ''
+        // Do not self-close HTML5 void tags
+        if (VOID_TAGS.indexOf(name.toLowerCase()) == -1) tag += '</' + name + '>'
+        return tag
       })
+
+      // escape single quotes
+      html = html.replace(/'/g, "\\'")
+
+      // \{ jotain \} --> \\{ jotain \\}
+      html = html.replace(brackets(/\\{|\\}/g), '\\$&')
+
+      // compact: no whitespace between tags
+      if (opts.compact) html = html.replace(/> </g, '><')
+
+      return html
+
     }
 
-    // styles in <style> tag
-    var styleType = 'css',
-        style = ''
 
-    html = html.replace(STYLE, function(_, fullType, _type, _style) {
-      if (fullType && fullType.trim() == 'scoped') styleType = 'scoped-css'
-        else if (_type) styleType = _type.replace('text/', '')
-      style = _style
-      return ''
-    })
+    function riotjs(js) {
 
-    return mktag(
-      tagName,
-      compileHTML(html, opts, type),
-      compileCSS(style, tagName, styleType),
-      attrs,
-      compileJS(js, opts, type)
-    )
+      // strip comments
+      js = js.replace(LINE_COMMENT, '').replace(JS_COMMENT, '')
 
-  })
+      // ES6 method signatures
+      var lines = js.split('\n'),
+          es6Ident = ''
 
-}
+      lines.forEach(function(line, i) {
+        var l = line.trim()
+
+        // method start
+        if (l[0] != '}' && l.indexOf('(') > 0 && l.indexOf('function') == -1) {
+          var end = /[{}]/.exec(l.slice(-1)),
+              m = end && /(\s+)([\w]+)\s*\(([\w,\s]*)\)\s*\{/.exec(line)
+
+          if (m && !/^(if|while|switch|for|catch)$/.test(m[2])) {
+            lines[i] = m[1] + 'this.' + m[2] + ' = function(' + m[3] + ') {'
+
+            // foo() { }
+            if (end[0] == '}') {
+              lines[i] += ' ' + l.slice(m[0].length - 1, -1) + '}.bind(this)'
+
+            } else {
+              es6Ident = m[1]
+            }
+          }
+
+        }
+
+        // method end
+        if (line.slice(0, es6Ident.length + 1) == es6Ident + '}') {
+          lines[i] = es6Ident + '}.bind(this);'
+          es6Ident = ''
+        }
+
+      })
+
+      return lines.join('\n')
+
+    }
+
+    function scopedCSS (tag, style, type) {
+      return style.replace(CSS_COMMENT, '').replace(CSS_SELECTOR, function (m, p1, p2) {
+        return p1 + ' ' + p2.split(/\s*,\s*/g).map(function(sel) {
+          var s = sel.trim().replace(/:scope\s*/, '')
+          return s[0] == '@' || s == 'from' || s == 'to' || /%$/.test(s) ? s :
+            tag + ' ' + s + ', [riot-tag="' + tag + '"] ' + s
+        }).join(',')
+      }).trim()
+    }
+
+    function compileJS(js, opts, type) {
+      var parser = opts.parser || (type ? riot.parsers.js[type] : riotjs)
+      if (!parser) throw new Error('Parser not found "' + type + '"')
+      return parser(js, opts)
+    }
+
+    function compileTemplate(lang, html) {
+      var parser = riot.parsers.html[lang]
+      if (!parser) throw new Error('Template parser not found "' + lang + '"')
+      return parser(html)
+    }
+
+    function compileCSS(style, tag, type) {
+      if (type == 'scoped-css') style = scopedCSS(tag, style)
+      else if (riot.parsers.css[type]) style = riot.parsers.css[type](tag, style)
+      return style.replace(/\s+/g, ' ').replace(/\\/g, '\\\\').replace(/'/g, "\\'").trim()
+    }
+
+    function compile(src, opts) {
+
+      opts = opts || {}
+
+      if (opts.brackets) riot.settings.brackets = opts.brackets
+
+      if (opts.template) src = compileTemplate(opts.template, src)
+
+      src = src.replace(LINE_TAG, function(_, tagName, html) {
+        return mktag(tagName, compileHTML(html, opts), '', '', '')
+      })
+
+      return src.replace(CUSTOM_TAG, function(_, tagName, attrs, html, js) {
+        html = html || ''
+        attrs = compileHTML(attrs, '', '')
+
+        // js wrapped inside <script> tag
+        var type = opts.type
+
+        if (!js.trim()) {
+          html = html.replace(SCRIPT, function(_, fullType, _type, script) {
+            if (_type) type = _type.replace('text/', '')
+            js = script
+            return ''
+          })
+        }
+
+        // styles in <style> tag
+        var styleType = 'css',
+            style = ''
+
+        html = html.replace(STYLE, function(_, fullType, _type, _style) {
+          if (fullType && fullType.trim() == 'scoped') styleType = 'scoped-css'
+            else if (_type) styleType = _type.replace('text/', '')
+          style = _style
+          return ''
+        })
+
+        return mktag(
+          tagName,
+          compileHTML(html, opts, type),
+          compileCSS(style, tagName, styleType),
+          attrs,
+          compileJS(js, opts, type)
+        )
+
+      })
+
+    }
+
+    return {
+      compile: compile,
+      html: compileHTML,
+      style: compileCSS,
+      js: compileJS,
+      mktag: mktag,
+      riotjs: riotjs,
+      scopedCSS: scopedCSS,
+      BOOL_ATTR: BOOL_ATTR,
+      VOID_TAGS: VOID_TAGS,
+      PREFIX_ATTR: PREFIX_ATTR,
+      LINE_TAG: LINE_TAG,
+      QUOTE: QUOTE,
+      SET_ATTR: SET_ATTR,
+      EXPR: EXPR,
+      CUSTOM_TAG: CUSTOM_TAG,
+      SCRIPT: SCRIPT,
+      STYLE: STYLE,
+      CSS_SELECTOR: CSS_SELECTOR,
+      CSS_COMMENT: CSS_COMMENT,
+      HTML_COMMENT: HTML_COMMENT,
+      CLOSED_TAG: CLOSED_TAG,
+      LINE_COMMENT: LINE_COMMENT,
+      JS_COMMENT: JS_COMMENT,
+      INPUT_NUMBER: INPUT_NUMBER
+    }
+
+
+  }
+
+}.apply(null, typeof module !== 'undefined' ? [module, 'exports'] : [this || window, 'riotCompiler'])


### PR DESCRIPTION
Really this is about starting a discussion, to demonstrate that eval is not required on the server side.

The issue actually stems from introducing implicit shared context in https://github.com/riot/riot/blob/master/lib/browser/compiler/index.js. IMO this is an antipattern, but that can be for another time. 

The real issue here is that the use of implicit context on the client side drove development on the server side towards using an unnecessarily risky approach. 

Regardless of whether there's any actual implications, simply the presence of `eval` and server side globals is going affect project credibility.

Using `eval` anywhere should have a strong discussion behind reasons for doing so, 
but to use it server side is to take extreme action. 

In this case I realise we're evalling static code that's under our control. Nevertheless when the code
being eval'd contains lots of regular expressions, we're increasing the potential attack vector. 
The same goes for evalling parser code. 

Even if it is safe given the intended use case, we can't predict every way this code may be used, we could easily be providing a big foot-gun to users here. Once an attacker has access via an eval, they can literally do anything to the server machine. 




