### PR TITLE
non-serialized rendering (testability improvement)

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -15,7 +15,11 @@ require.extensions['.tag'] = function(module, filename) {
 var sdom = require('./sdom')
 
 riot.render = function(tagName, opts) {
+  return sdom.serialize(riot.render.dom(tagName, opts))
+}
+
+riot.render.dom = function(tagName, opts) {
   var root = document.createElement(tagName)
   var tag = riot.mount(root, opts)
-  return sdom.serialize(root)
+  return root
 }


### PR DESCRIPTION
This very simple tweak allows for greater testability, using `riot.render.dom` 
I can run tests against the simple-dom object (instead of having to regenerate my own DOM object)

