### PR TITLE
fastAbs removed, getTag compacted

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -42,7 +42,7 @@ function Tag(impl, conf, innerHTML) {
 
   // create a unique id to this tag
   // it could be handy to use it also to improve the virtual dom rendering speed
-  this._id = fastAbs(~~(Date.now() * Math.random()))
+  this._id = ~~(Date.now() * Math.random())
 
   extend(this, { parent: parent, root: root, opts: opts, tags: {} }, item)
 

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -16,19 +16,15 @@ function remAttr(dom, name) {
   dom.removeAttribute(name)
 }
 
-function fastAbs(nr) {
-  return (nr ^ (nr >> 31)) - (nr >> 31)
-}
-
 function getTag(dom) {
-  var tagName = dom.tagName.toLowerCase()
-  return tagImpl[dom.getAttribute(RIOT_TAG) || tagName]
+  return tagImpl[dom.getAttribute(RIOT_TAG) || dom.tagName.toLowerCase()]
 }
 
 function getTagName(dom) {
   var child = getTag(dom),
     namedTag = dom.getAttribute('name'),
-    tagName = namedTag && namedTag.indexOf(brackets(0)) < 0 ? namedTag : child ? child.name : dom.tagName.toLowerCase()
+    tagName = namedTag && namedTag.indexOf(brackets(0)) < 0 ?
+              namedTag : child ? child.name : dom.tagName.toLowerCase()
 
   return tagName
 }


### PR DESCRIPTION
_id is used only in one place in browser/tag/tag.js/unmount() for comparación, so negative ids works fine.
Anyway, Date.now and Math.random both return positive numbers. The toInt32 convertion is ok.
Last, Math.abs is faster in Chrome, the most used browser today. In IE fastAbs is ~15% faster... 1 ns?
