### PR TITLE
Added missing whitespace option in cli.

### DIFF
--- a/lib/server/cli.js
+++ b/lib/server/cli.js
@@ -214,7 +214,8 @@ function cli() {
       type: args.type,
       brackets: args.brackets,
       expr: args.expr,
-      modular: args.modular
+      modular: args.modular,
+      whitespace: args.whitespace,
     },
     ext: args.ext,
     from: args._.shift(),


### PR DESCRIPTION
`riot -w tags/ app/tags.js --whitespace`, wasn't working for me.

I had some tags with pre elements that required newlines. Resolved the issue by adding the missing whitespace argument.