### PR TITLE
Fix to #1043

### DIFF
--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -113,11 +113,11 @@ function riotjs(js) {
     var l = line.trim()
 
     // method start
-    if (l[0] != '}' && l.indexOf('(') > 0 && l.indexOf('function') == -1) {
-      var end = /[{}]/.exec(l.slice(-1)),
-          m = end && /(\s+)([\w]+)\s*\(([\w,\s]*)\)\s*\{/.exec(line)
+    if (l[0] != '}' && ~l.indexOf('(')) {
+      var end = l.match(/[{}]$/),
+          m = end && line.match(/^(\s+)([$\w]+)\s*\(([$\w,\s]*)\)\s*\{/)
 
-      if (m && !/^(if|while|switch|for|catch)$/.test(m[2])) {
+      if (m && !/^(if|while|switch|for|catch|function)$/.test(m[2])) {
         lines[i] = m[1] + 'this.' + m[2] + ' = function(' + m[3] + ') {'
 
         // foo() { }

--- a/test/specs/compiler/expect/riotjs.getter-setter.js
+++ b/test/specs/compiler/expect/riotjs.getter-setter.js
@@ -1,0 +1,5 @@
+  var foo = {
+    get bar() {
+      return 'baz'
+    }
+  }

--- a/test/specs/compiler/fixtures/riotjs.getter-setter.js
+++ b/test/specs/compiler/fixtures/riotjs.getter-setter.js
@@ -1,0 +1,5 @@
+  var foo = {
+    get bar() {
+      return 'baz'
+    }
+  }

--- a/test/specs/compiler/riotjs.js
+++ b/test/specs/compiler/riotjs.js
@@ -31,5 +31,9 @@ describe('riotjs', function() {
     var file = 'riotjs.try-catch.js'
     expect(render(cat('fixtures', file))).to.equal(cat('expect', file))
   })
+  it('preserves non es6 methods #1043', function() {
+    var file = 'riotjs.getter-setter.js'
+    expect(render(cat('fixtures', file))).to.equal(cat('expect', file))
+  })
 
 })


### PR DESCRIPTION
Fix to #1043 - Getters and setters are treated as regular function definition.
i.e. Any method in non-ES6 format is left unchanged.
**NOTE:** getter/setter is not IE8 compatible!