### PR TITLE
setNamed() simplified, getAttr() added.

### DIFF
--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -4,7 +4,7 @@ function parseNamedElements(root, parent, childTags) {
 
   walk(root, function(dom) {
     if (dom.nodeType == 1) {
-      dom.isLoop = dom.isLoop || (dom.parentNode && dom.parentNode.isLoop || dom.getAttribute('each')) ? 1 : 0
+      dom.isLoop = dom.isLoop || (dom.parentNode && dom.parentNode.isLoop || getAttr(dom, 'each')) ? 1 : 0
 
       // custom child tag
       var child = getTag(dom)
@@ -65,7 +65,7 @@ function parseExpressions(root, tag, expressions) {
     /* element */
 
     // loop
-    var attr = dom.getAttribute('each')
+    var attr = getAttr(dom, 'each')
 
     if (attr) { _each(dom, tag, attr); return false }
 

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -15,8 +15,12 @@ function remAttr(dom, name) {
   dom.removeAttribute(name)
 }
 
+function getAttr(dom, name) {
+  return dom.getAttribute(name)
+}
+
 function getTag(dom) {
-  return tagImpl[dom.getAttribute(RIOT_TAG) || dom.tagName.toLowerCase()]
+  return tagImpl[getAttr(RIOT_TAG) || dom.tagName.toLowerCase()]
 }
 
 function getImmediateCustomParentTag(tag) {
@@ -30,7 +34,7 @@ function getImmediateCustomParentTag(tag) {
 
 function getTagName(dom) {
   var child = getTag(dom),
-    namedTag = dom.getAttribute('name'),
+    namedTag = getAttr('name'),
     tagName = namedTag && namedTag.indexOf(brackets(0)) < 0 ? namedTag : child ? child.name : dom.tagName.toLowerCase()
 
   return tagName
@@ -141,18 +145,18 @@ function inherit(parent) {
 }
 
 function setNamed(dom, parent, keys) {
-  each(dom.attributes, function(attr) {
-    if (dom._visited) return
-    if (attr.name === 'id' || attr.name === 'name') {
-      dom._visited = true
-      var p, v = attr.value
-      if (~keys.indexOf(v)) return
+  if (dom._visited) return
+  var p,
+      v = getAttr(dom, 'id') || getAttr(dom, 'name')
 
+  if (v) {
+    if (keys.indexOf(v) < 0) {
       p = parent[v]
       if (!p)
         parent[v] = dom
       else
-        isArray(p) ? p.push(dom) : (parent[v] = [p, dom])
+        isArray(p) ? p.push(dom) : (parent[v] = [p, dom]) // p is another dom
     }
-  })
+    dom._visited = true
+  }
 }

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -20,7 +20,7 @@ function getAttr(dom, name) {
 }
 
 function getTag(dom) {
-  return tagImpl[getAttr(RIOT_TAG) || dom.tagName.toLowerCase()]
+  return tagImpl[getAttr(dom, RIOT_TAG) || dom.tagName.toLowerCase()]
 }
 
 function getImmediateCustomParentTag(tag) {
@@ -34,7 +34,7 @@ function getImmediateCustomParentTag(tag) {
 
 function getTagName(dom) {
   var child = getTag(dom),
-    namedTag = getAttr('name'),
+    namedTag = getAttr(dom, 'name'),
     tagName = namedTag && namedTag.indexOf(brackets(0)) < 0 ? namedTag : child ? child.name : dom.tagName.toLowerCase()
 
   return tagName

--- a/lib/browser/tag/vdom.js
+++ b/lib/browser/tag/vdom.js
@@ -102,11 +102,11 @@ riot.mount = function(selector, tagName, opts) {
   function pushTags(root) {
     var last
     if (root.tagName) {
-      if (tagName && (!(last = root.getAttribute(RIOT_TAG)) || last != tagName))
+      if (tagName && (!(last = getAttr(root, RIOT_TAG)) || last != tagName))
         root.setAttribute(RIOT_TAG, tagName)
 
       var tag = mountTo(root,
-        tagName || root.getAttribute(RIOT_TAG) || root.tagName.toLowerCase(), opts)
+        tagName || getAttr(root, RIOT_TAG) || root.tagName.toLowerCase(), opts)
 
       if (tag) tags.push(tag)
     }


### PR DESCRIPTION
I think the current `setNamed` does too much work for a simple task.
This was difficult to trace, but if I understood, this function:
  * saves a dom element (a reference) in a property of their parent.
  * parent property is named with the id|name attribute value of the dom element.
  * if the dom element...
      - is already visited (`_visited` flag set), returns with no action.
      - has no id|name attribute (can be revisited later), returns w/ no action.
      - is registered in `keys[]` (property of the root parent?), does nothing to the parent, but set the `_visited` flag*
  * if parent[id|name] doesn't exists, create this property and set the reference as their value.
  * if parent[id|name] is an array, adds the reference to the array.
  * if parent[id|name] exists and is not an array, this is another dom reference, so converts the property to an array with both references as elements.
  * last, set the `_visited` flag.
  Note: this function is called for nodes of type 1 (Element) with isLoop property
        =falsy by `parseNamedElements()` and the 'updated' event seted by `_each()`.

So, this implementation does the same in simple form ...and is easy for tracing.
`getAttr()` saves some bytes in the minimified version of riot.js