### PR TITLE
add each limit regexp

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -167,6 +167,10 @@ function _each(dom, parent, expr) {
           item: item
         }, dom.innerHTML)
 
+        // cache the original item to use it in the events bound to this node
+        // and its children, add _item before mount
+        tag._item = item
+
         tag.mount()
         if (isVirtual) tag._root = tag.root.firstChild // save reference for further moves or inserts
         // this tag must be appended
@@ -205,9 +209,6 @@ function _each(dom, parent, expr) {
         if (!child) moveNestedTags(tag, i)
       }
 
-      // cache the original item to use it in the events bound to this node
-      // and its children
-      tag._item = item
       // cache the real parent tag internally
       defineProperty(tag, '_parent', parent)
 


### PR DESCRIPTION
if use `each` attribute without `{  }`, it will loop with the count of string