### PR TITLE
setNamed() rewrite

### DIFF
--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -141,18 +141,18 @@ function inherit(parent) {
 }
 
 function setNamed(dom, parent, keys) {
-  each(dom.attributes, function(attr) {
-    if (dom._visited) return
-    if (attr.name === 'id' || attr.name === 'name') {
-      dom._visited = true
-      var p, v = attr.value
-      if (~keys.indexOf(v)) return
+  if (dom._visited) return
+  var p,
+      v = dom.getAttribute('id') || dom.getAttribute('name')
 
+  if (v) {
+    if (keys.indexOf(v) < 0) {
       p = parent[v]
       if (!p)
         parent[v] = dom
       else
         isArray(p) ? p.push(dom) : (parent[v] = [p, dom])
     }
-  })
+    dom._visited = true
+  }
 }


### PR DESCRIPTION
I think the current `setNamed` does too much work for a simple task.
This was difficult to trace, but if I understood, this function:
  Save a dom element reference in a property of the parent.
  * parent property is named with the id|name attribute value of the dom element.
  * if the dom element...
      - is already visited (`_visited` flag set), returns
      - has no id|name attribute (can be revisited later), returns
      - is registered in `keys[]` (property of the root parent?), does nothing in the parent, but set `_visited` flag*
  * if parent[id|name] doesn't exists, create and set it to the reference.
  * if parent[id|name] is an array, add the reference to this array.
  * if parent[id|name] exists and is not an array, this is another dom reference, so convert the property to an array with both references as elements.
  * last, set the `_visited` flag.
  Note: this function is called for nodes of type 1 (Element) with isLoop property
        =falsy by parseNamedElements() and the 'updated' event set by _each().

This implementation does the same, but is clearer ...and easier to trace.