### PR TITLE
Support for //# sourceURL for easier debugging of compiled tags.

### DIFF
--- a/lib/browser/compiler/core.js
+++ b/lib/browser/compiler/core.js
@@ -2,6 +2,17 @@ var doc = window.document,
     promise,
     ready
 
+// props to http://davidwalsh.name/get-absolute-url
+var getAbsoluteURL = (function() {
+  var a
+
+  return function(url) {
+    if (!a) a = document.createElement('a')
+    a.href = url
+
+    return a.href
+  }
+})()
 
 function GET(url, fn) {
   var req = new XMLHttpRequest()
@@ -20,11 +31,11 @@ function unindent(src) {
   return src
 }
 
-function globalEval(js) {
+function globalEval(js, source) {
   var node = doc.createElement('script'),
       root = doc.documentElement
 
-  node.text = compile(js)
+  node.text = compile(js) + (source && '\n//# sourceURL=' + getAbsoluteURL(source) + '.compiled.js')
   root.appendChild(node)
   root.removeChild(node)
 }
@@ -45,19 +56,18 @@ function compileScripts(fn) {
     [].map.call(scripts, function(script) {
       var url = script.getAttribute('src')
 
-      function compileTag(source) {
-        globalEval(source)
+      function compileTag(source, url) {
+        globalEval(source, url)
         scriptsAmount--
         if (!scriptsAmount) {
           done()
         }
       }
 
-      return url ? GET(url, compileTag) : compileTag(unindent(script.innerHTML))
+      return url ? GET(url, function(data) { compileTag(data, url) }) : compileTag(unindent(script.innerHTML))
     })
   }
 }
-
 
 riot.compile = function(arg, fn) {
 


### PR DESCRIPTION
This adds a sourceURL to tags compiled by the in-browser compiler and makes it much easier to debug tags (no more adding 'debugger' statements!)

Chrome:
Generated code shows up next to the original file loaded with a 'compiled.js' suffix. You can add breakpoints here.

Safari:
Code shows up in 'Resources->Extra Scripts'. Also supports breakpoints.


