### PR TITLE
Fix #691 (not for IE9)

### DIFF
--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -23,7 +23,7 @@ var mkdom = (function (checkIE) {
   checkIE = checkIE && checkIE < 10
 
   // creates any dom element in a div, table, or colgroup container
-  function _mkdom(html) {
+  function _mkdom(html, innerHTML) {
 
     var match = html && html.match(/^\s*<([-\w]+)/),
         tagName = match && match[1].toLowerCase(),
@@ -31,6 +31,9 @@ var mkdom = (function (checkIE) {
         el = mkEl(rootTag)
 
     el.stub = true
+
+    if (innerHTML)                  // search <yield> in all valid forms
+      html = html.replace(/<(yield)\s*(?:\/\s*|>\s*<\/\1\s*)?>/gi, innerHTML)
 
     if (checkIE && tagName && (match = tagName.match(TESTTAG)))
       ie9elem(el, html, tagName, !!match[1])

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -2,7 +2,7 @@ function Tag(impl, conf, innerHTML) {
 
   var self = riot.observable(this),
       opts = inherit(conf.opts) || {},
-      dom = mkdom(impl.tmpl),
+      dom = mkdom(impl.tmpl, innerHTML),
       parent = conf.parent,
       isLoop = conf.isLoop,
       hasImpl = conf.hasImpl,
@@ -41,10 +41,6 @@ function Tag(impl, conf, innerHTML) {
     // remember attributes with expressions only
     if (brackets(/\{.*\}/).test(val)) attr[el.name] = val
   })
-
-  if (dom.innerHTML && !/select|optgroup|table|tbody|tr|col(?:group)?/.test(tagName))
-    // replace all the yield tags with the tag inner html
-    dom.innerHTML = replaceYield(dom.innerHTML, innerHTML)
 
   // options
   function updateOpts() {

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -96,10 +96,6 @@ function mkEl(name) {
   return document.createElement(name)
 }
 
-function replaceYield(tmpl, innerHTML) {
-  return tmpl.replace(/<(yield)\/?>(<\/\1>)?/gi, innerHTML || '')
-}
-
 function $$(selector, ctx) {
   return (ctx || document).querySelectorAll(selector)
 }

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -1514,8 +1514,10 @@ describe('Compiler Browser', function() {
     var iev = (window.document || {}).documentMode | 0
     if (iev < 1 || iev > 9) {
       var tag = riot.mount('yield-option')[0],
-          ops = tag.root.firstElementChild.options
+          ops
 
+      tag.update()
+      ops = tag.root.firstElementChild.options
       expect(ops.length).to.be(1)
       expect(ops(0).text.trim()).to.be('bar')
       tags.push(tag)

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -1517,9 +1517,13 @@ describe('Compiler Browser', function() {
           ops
 
       tag.update()
-      ops = tag.root.firstElementChild.options
-      expect(ops.length).to.be(1)
-      expect(ops(0).text.trim()).to.be('bar')
+      ops = tag.root.getElementsByTagName('select')[0]
+      if (!ops)
+        console.log(' - - - select element not found!')
+      else {
+        expect(ops.length).to.be(1)
+        expect(ops[0].text.trim()).to.be('bar')
+      }
       tags.push(tag)
     }
   })

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -1510,20 +1510,14 @@ describe('Compiler Browser', function() {
   })
 
   it('yield options with select, except in IE8-IE9', function() {
-
     var iev = (window.document || {}).documentMode | 0
     if (iev < 1 || iev > 9) {
       var tag = riot.mount('yield-option')[0],
           ops
-
       tag.update()
       ops = tag.root.getElementsByTagName('select')[0]
-      if (!ops)
-        console.log(' - - - select element not found!')
-      else {
-        expect(ops.length).to.be(1)
-        expect(ops[0].text.trim()).to.be('bar')
-      }
+      expect(ops.length).to.be(1)
+      expect(ops[0].text.trim()).to.be('bar')
       tags.push(tag)
     }
   })

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -1510,12 +1510,16 @@ describe('Compiler Browser', function() {
   })
 
   it('yield options with select, except in IE8-IE9', function() {
-    var tag = riot.mount('yield-option')[0],
-        ops = tag.root.firstElementChild.options
 
-    expect(ops.length).to.be(1)
-    expect(ops(0).text.trim()).to.be('bar')
-    tags.push(tag)
+    var iev = (window.document || {}).documentMode | 0
+    if (iev < 1 || iev > 9) {
+      var tag = riot.mount('yield-option')[0],
+          ops = tag.root.firstElementChild.options
+
+      expect(ops.length).to.be(1)
+      expect(ops(0).text.trim()).to.be('bar')
+      tags.push(tag)
+    }
   })
 
 })

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -373,8 +373,18 @@ describe('Compiler Browser', function() {
 
           // table with caption and looped cols, ths and trs
           '<script type=\"riot\/tag\" src=\"tag\/loop-cols.tag\"><\/script>',
-          '<loop-cols><\/loop-cols>'
+          '<loop-cols><\/loop-cols>',
 
+          '<script type="riot/tag">',
+          '  <yield-option>',
+          '    <select><yield/></select>',
+          '  </yield-option>',
+          '</script>',
+          '<yield-option>',
+          '  <option>bar</option>',
+          '</yield-option>',
+
+          ''        // avoid edit previous line
     ].join('\r'),
       tags = [],
       div = document.createElement('div')
@@ -1497,6 +1507,15 @@ describe('Compiler Browser', function() {
       if (!e) e = tag.root
       return e.getElementsByTagName(t)
     }
+  })
+
+  it('yield options with select, except in IE8-IE9', function() {
+    var tag = riot.mount('yield-option')[0],
+        ops = tag.root.firstElementChild.options
+
+    expect(ops.length).to.be(1)
+    expect(ops(0).text.trim()).to.be('bar')
+    tags.push(tag)
   })
 
 })


### PR DESCRIPTION
Fix #691 - not for IE8 nor IE9
Now you can yield and select with options.
This can work with tables, too, but need testing.
There's no solution in my mind for IE9, sorry

**NOTE:** I'm not limiting what elements combine with `<yield>`, use this at your own risk :) If works with optgroups, tables, colgroups or tr's, please let me know.

#### **NOTE:** _This solution was based on idea and code of @Scritik in his PR #731_