### PR TITLE
Remove riot-tag attribute on unmount(true)

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -188,7 +188,9 @@ function Tag(impl, conf, innerHTML) {
 
       if (!keepRootTag)
         p.removeChild(el)
-
+      else 
+        // the riot-tag attribute isn't needed anymore, remove it
+        p.removeAttribute('riot-tag')
     }
 
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -188,7 +188,7 @@ function Tag(impl, conf, innerHTML) {
 
       if (!keepRootTag)
         p.removeChild(el)
-      else 
+      else
         // the riot-tag attribute isn't needed anymore, remove it
         p.removeAttribute('riot-tag')
     }


### PR DESCRIPTION
Currently the riot-tag attribute is kept on the parent node when a child tag is unmounted.
Clearing it when the "keepRootTag" argument is truthy fixes this wrong behavior.