### PR TITLE
preprocess scoped styles

### DIFF
--- a/lib/shared/compiler.js
+++ b/lib/shared/compiler.js
@@ -20,7 +20,7 @@ var BOOL_ATTR = ('allowfullscreen,async,autofocus,autoplay,checked,compact,contr
   // (tagname) (html) (javascript) endtag
   CUSTOM_TAG = /^<([\w\-]+)\s?([^>]*)>([^\x00]*[\w\/}"']>$)?([^\x00]*?)^<\/\1>/gim,
   SCRIPT = /<script(?:\s+type=['"]?([^>'"]+)['"]?)?>([^\x00]*?)<\/script>/gi,
-  STYLE = /<style(?:\s+type=['"]?([^>'"]+)['"]?|\s+scope(d)[=\s]?[^>]*)?>([^\x00]*?)<\/style>/gi,
+  STYLE = /<style(?:\s+([^>]+))?>([^\x00]*?)<\/style>/gi,
   CSS_SELECTOR = /(^|\}|\{)\s*([^\{\}]+)\s*(?=\{)/g,
   HTML_COMMENT = /<!--.*?-->/g,
   CLOSED_TAG = /<([\w\-]+)([^>]*)\/\s*>/g,
@@ -174,9 +174,11 @@ function compileTemplate(lang, html) {
   return parser(html.replace(/\r\n?/g, '\n'))
 }
 
-function compileCSS(style, tag, type) {
-  if (type == 'scoped-css') style = scopedCSS(tag, style)
+function compileCSS(style, tag, type, scoped) {
+  if (type === 'scoped-css') scoped = 1
   else if (riot.parsers.css[type]) style = riot.parsers.css[type](tag, style)
+  else if (type !== 'css') throw new Error('CSS parser not found: "' + type + '"')
+  if (scoped) style = scopedCSS(tag, style)
   return style.replace(/\s+/g, ' ').replace(/\\/g, '\\\\').replace(/'/g, "\\'").trim()
 }
 
@@ -210,10 +212,11 @@ function compile(src, opts) {
       }
 
       // styles in <style> tag
-      html = html.replace(STYLE, function(_, type, scoped, _style) {
-        if (scoped) type = 'scoped-css'
-        else type = type && type.replace('text/', '') || 'css'
-        style += (style ? ' ' : '') + compileCSS(_style.trim(), tagName, type)
+      html = html.replace(STYLE, function(_, types, _style) {
+        var scoped = /(?:^|\s+)scoped(\s|=|$)/i.test(types),
+            type = types && types.match(/(?:^|\s+)type\s*=\s*['"]?([^'"\s]+)['"]?/i)
+        if (type) type = type[1].replace('text/', '')
+        style += (style ? ' ' : '') + compileCSS(_style.trim(), tagName, type || 'css', scoped)
         return ''
       })
     }

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -293,11 +293,12 @@ describe('Compiler Browser', function() {
 
           '<script type=\"riot\/tag\">',
           '  <style-tag3>',
-          '    <style scoped=\"scoped\">',
+          '    <style scoped=\"scoped\" type="text/myparser">',
           '      p {border: solid 3px black;}',
           '    <\/style>',
           '    <style>',
-          '      #style4 {border: solid 3px black;}',
+          '      p {border: solid 1px black}',
+          '      #style4 {border: solid 2px black;}',
           '    <\/style>',
           '    <p><\/p>',
           '  <\/style-tag3>',
@@ -306,7 +307,7 @@ describe('Compiler Browser', function() {
 
           '<script type=\"riot\/tag\">',
           '  <style-tag4>',
-          '    <p id=\"style4\"><\/p>',
+          '    <p id=\"style4\"><\/p><p>x</p>',
           '  <\/style-tag4>',
           '<\/script>',
           '<style-tag4><\/style-tag4>',
@@ -420,7 +421,7 @@ describe('Compiler Browser', function() {
   // adding some custom riot parsers
   // css
   riot.parsers.css.myparser = function(tag, css) {
-    return css.replace(/@tag/, tag)
+    return css.replace(/@tag/, tag).replace(' 3px ', ' 4px ')
   }
   // js
   riot.parsers.js.myparser = function(js) {
@@ -1081,13 +1082,20 @@ describe('Compiler Browser', function() {
 
   it('scoped css tag supports htm5 syntax, multiple style tags', function () {
 
-    checkCSS(riot.mount('style-tag3')[0])
-    checkCSS(riot.mount('style-tag4')[0])
+    checkCSS(riot.mount('style-tag3')[0], '4px')
+    checkCSS(riot.mount('style-tag4')[0], '2px', 1)
+    delete riot.parsers.css.cssup
 
-    function checkCSS(t) {
+    function checkCSS(t, x, p2) {
+      t.update()
       var e = t.root.firstElementChild
       expect(e.tagName).to.be('P')
-      expect(window.getComputedStyle(e, null).borderTopWidth).to.be('3px')
+      expect(window.getComputedStyle(e, null).borderTopWidth).to.be(x)
+      if (p2) {
+        e = t.root.getElementsByTagName('P')[1]
+        expect(e.innerHTML).to.be('x')
+        expect(window.getComputedStyle(e, null).borderTopWidth).to.be('1px')
+      }
       tags.push(t)
     }
   })


### PR DESCRIPTION
Enhancement to #1093
Complement of #912

The pre-processing is performed before riot parse the scoped rules.
For consistency, the CSS compiler throws an error if there's no preprocessor for given type.