### PR TITLE
Data driven tag generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ eslint:
 	@ $(ESLINT) -c ./.eslintrc lib test
 
 test-mocha:
-	RIOT=../../dist/riot/riot.js $(ISTANBUL) cover $(MOCHA) debug -- test/runner.js -R spec
+	RIOT=../../dist/riot/riot.js $(ISTANBUL) cover $(MOCHA) -- test/runner.js -R spec
 
 test-karma:
 	@ $(KARMA) start test/karma.conf.js

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ eslint:
 	@ $(ESLINT) -c ./.eslintrc lib test
 
 test-mocha:
-	RIOT=../../dist/riot/riot.js $(ISTANBUL) cover $(MOCHA) -- test/runner.js -R spec
+	RIOT=../../dist/riot/riot.js $(ISTANBUL) cover $(MOCHA) debug -- test/runner.js -R spec
 
 test-karma:
 	@ $(KARMA) start test/karma.conf.js

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -19,6 +19,36 @@ function Tag(impl, conf, innerHTML) {
     root._tag.unmount(true)
   }
 
+  riot.tag('dynamic', '', function(opts) {
+    var self = this
+    if (!opts.tag) {
+      return
+    }
+    self.dynamicTagName = opts.tag
+    self.dynamicDom = document.createElement(opts.tag)
+    self.root.appendChild(self.dynamicDom)
+    self.dynamicTag = initChildTag(tagImpl[opts.tag], self.dynamicDom, self)
+    childTags.push(self.dynamicTag)
+    self.dynamicTag.mount()
+
+    this.on('update', function() {
+      if (opts.tag == self.dynamicTagName) {
+        return
+      }
+      self.dynamicTag.unmount()
+      var index = childTags.indexOf(self.dynamicTag)
+      childTags.splice(index, 1)
+
+      self.dynamicTagName = opts.tag
+      self.dynamicDom = document.createElement(opts.tag)
+      self.root.appendChild(self.dynamicDom)
+      self.dynamicTag = initChildTag(tagImpl[opts.tag], self.dynamicDom, self)
+
+      childTags.push(self.dynamicTag)
+      self.dynamicTag.mount()
+    })
+  })
+
   // not yet mounted
   this.isMounted = false
   root.isLoop = isLoop
@@ -119,7 +149,6 @@ function Tag(impl, conf, innerHTML) {
 
     // parse layout after init. fn may calculate args for nested custom tags
     parseExpressions(dom, self, expressions)
-
     // mount the child tags
     toggle(true)
 
@@ -220,6 +249,4 @@ function Tag(impl, conf, innerHTML) {
 
   // named elements available for fn
   parseNamedElements(dom, this, childTags)
-
-
 }

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -75,7 +75,6 @@ function update(expressions, tag) {
       dom.nodeValue = '' + value    // #815 related
       return
     }
-
     // remove original attribute
     remAttr(dom, attrName)
     // event handler

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -414,6 +414,12 @@ describe('Compiler Browser', function() {
           '<script type=\"riot\/tag\" src=\"tag\/observable-attr.tag\"><\/script>',
           '<observable-attr><\/observable-attr>',
 
+          //dynamic tag selection
+          '<script type=\"riot\/tag\" src=\"tag\/dynamic-with-update.tag\"><\/script>',
+          '<script type=\"riot\/tag\" src=\"tag\/dynamic-one.tag\"><\/script>',
+          '<script type=\"riot\/tag\" src=\"tag\/dynamic-two.tag\"><\/script>',
+          '<dynamic-with-update></dynamic-with-update>',
+
           ''    // keep it last please, avoids break PRs
     ].join('\r'),
       tags = [],
@@ -1638,6 +1644,19 @@ describe('Compiler Browser', function() {
     expect(ps[0].innerHTML).to.be(ps[1].innerHTML)
     expect(ps[0].innerHTML).to.be('hello world')
 
+  })
+
+  it('tags with dynamic tags properly change their contents on update', function() {
+    var tag = riot.mount('dynamic-with-update')[0]
+
+    pre = tag.root.getElementsByTagName('pre')[0]
+    expect(pre.innerHTML).to.be('This tag was dynamically chosen')
+
+    tag.dynamicChoice = 'dynamic-two'
+    tag.update()
+
+    pre = tag.root.getElementsByTagName('pre')[0]
+    expect(pre.innerHTML).to.be('This tag was also dynamically chosen')
   })
 
 })

--- a/test/specs/node.js
+++ b/test/specs/node.js
@@ -55,4 +55,16 @@ describe('Node/io.js', function() {
     expect(els.last().text()).to.be('post 2')
   })
 
+  it('render tag: dynamic-generation', function() {
+    var dynamicOne = riot.render('dynamic-generation', {tag: 'dynamic-one'})
+    var dynamicTwo = riot.render('dynamic-generation', {tag: 'dynamic-two'})
+    var $one = cheerio.load(dynamicOne)
+    var $two = cheerio.load(dynamicTwo)
+    var elsOne = $one('pre')
+    var elsTwo = $two('pre')
+
+    expect(elsOne.text()).to.be('This tag was dynamically chosen')
+    expect(elsTwo.text()).to.be('This tag was also dynamically chosen')
+
+  })
 })

--- a/test/tag/dynamic-generation.tag
+++ b/test/tag/dynamic-generation.tag
@@ -1,0 +1,3 @@
+<dynamic-generation>
+  <dynamic tag={ opts.tag }/>
+</dynamic-generation>

--- a/test/tag/dynamic-one.tag
+++ b/test/tag/dynamic-one.tag
@@ -1,0 +1,3 @@
+<dynamic-one>
+  <pre>This tag was dynamically chosen</pre>
+</dynamic-one>

--- a/test/tag/dynamic-two.tag
+++ b/test/tag/dynamic-two.tag
@@ -1,0 +1,3 @@
+<dynamic-two>
+  <pre>This tag was also dynamically chosen</pre>
+</dynamic-two>

--- a/test/tag/dynamic-with-update.tag
+++ b/test/tag/dynamic-with-update.tag
@@ -1,0 +1,6 @@
+<dynamic-with-update>
+  <dynamic tag={dynamicChoice} />
+  <script>
+    this.dynamicChoice = 'dynamic-one'    
+  </script>
+</dynamic-with-update>

--- a/test/tags.html
+++ b/test/tags.html
@@ -85,7 +85,6 @@
 
     <loop-numbers-nested></loop-numbers-nested>
     <loop-conditional></loop-conditional>
-
   </div>
 
   <script src="../dist/riot/riot.js"></script>


### PR DESCRIPTION
This pull request is meant to be a starting point for a discussion about data driven tag generation. There have been a few forum posts and github issues asking how to do this. (see #528, https://muut.com/riot-js#!/using:is-it-possible-to-use-dynam). There doesn't appear to be a great approach at this point.

I am suggesting the following approach. The code changes here introduce a special tag built into the framework called "dynamic". This tag takes a single option "tag". Based on the value of that option, the dynamic tag will render a single child tag using that tag name.

If folks like this idea there's some additional work to make this pull request real. Namely making it work with options, cleaning up the code structure, and adding some additional tests.