### PR TITLE
Fix broken parsing of expr cli parameter

### DIFF
--- a/lib/server/cli.js
+++ b/lib/server/cli.js
@@ -201,7 +201,7 @@ function cli() {
   // Get CLI arguments
 
   var args = require('minimist')(process.argv.slice(2), {
-    boolean: ['watch', 'compact', 'help', 'version', 'whitespace', 'modular', 'check'],
+    boolean: ['watch', 'compact', 'help', 'version', 'whitespace', 'modular', 'check', 'expr'],
     alias: { w: 'watch', c: 'compact', h: 'help', v: 'version', t: 'type', m: 'modular' }
   })
 


### PR DESCRIPTION
The source argument was ignored when `--expr` was present. Because it was taken as value for the `--expr` option.