### PR TITLE
Extend tag scope.

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -73,7 +73,7 @@ function _each(dom, parent, expr) {
 
         if (!tags[i]) {
           // mount new
-          (tags[i] = new Tag(impl, {
+          (tags[i] = createTag(impl, {
               parent: parent,
               isLoop: true,
               hasImpl: hasImpl,

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -61,6 +61,18 @@ function getTag(dom) {
 }
 
 /**
+ * Detect the tag implementation by a DOM node
+ * @param   { Object } impl - tag implementation
+ * @param   { Object } conf - tag configuration
+ * @param   { Object } innerHTML - HTML from DOM node where the tag will be mounted
+ * @returns { Object } instance of the new child tag just created
+ */
+function createTag(impl, conf, innerHTML) {
+  Tag.prototype = conf.parent || Object.prototype
+  return new Tag(impl, conf, innerHTML)
+}
+
+/**
  * Create a new child tag including it correctly into its parent
  * @param   { Object } child - child tag implementation
  * @param   { Object } dom - DOM node where the tag will be mounted
@@ -68,7 +80,7 @@ function getTag(dom) {
  * @returns { Object } instance of the new child tag just created
  */
 function initChildTag(child, dom, parent) {
-  var tag = new Tag(child, { root: dom, parent: parent }, dom.innerHTML),
+  var tag = createTag(child, { root: dom, parent: parent }, dom.innerHTML),
       tagName = getTagName(dom),
       ptag = getImmediateCustomParentTag(parent),
       cachedTag

--- a/lib/browser/tag/vdom.js
+++ b/lib/browser/tag/vdom.js
@@ -48,7 +48,7 @@ function mountTo(root, tagName, opts) {
   // clear the inner html
   root.innerHTML = ''
 
-  if (tag && root) tag = new Tag(tag, { root: root, opts: opts }, innerHTML)
+  if (tag && root) tag = createTag(tag, { root: root, opts: opts }, innerHTML)
 
   if (tag && tag.mount) {
     tag.mount()


### PR DESCRIPTION
That sample code is not work.

```js
	<script type="riot/tag">
		<demo>
			<h1>Hoge</h1>
			<my-button-group>
				<my-button onpush={ hoge }>Say hoge</my-button>
			</my-button-group>
			hoge() {
				alert("hoge!")
			}
		</demo>

		<my-button-group>
			<yield/>
		</my-button-group>

		<my-button>
			<button onclick={ opts.onpush }><yield/></button>
		</my-button>

		var self = this
	</script>
```

Because `hoge` not found at `onpush={ hoge }`.

`self.hoge` is defined but `self.tags['my-button-group'].hoge` is not defined.

This patch apply, after work fine!
