### PR TITLE
update isArray to detect Array extensions

### DIFF
--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -21,4 +21,4 @@ var riot = { version: 'WIP', settings: {} },
   IE_VERSION = (window && window.document || {}).documentMode | 0,
 
   // Array.isArray for IE8 is in the polyfills
-  isArray = Array.isArray
+  isArray = function(a){ return Array.isArray(a) || a instanceof Array }

--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -21,4 +21,4 @@ var riot = { version: 'WIP', settings: {} },
   IE_VERSION = (window && window.document || {}).documentMode | 0,
 
   // Array.isArray for IE8 is in the polyfills
-  isArray = function(a){ return Array.isArray(a) || a instanceof Array }
+  isArray = function(a) { return Array.isArray(a) || a instanceof Array }


### PR DESCRIPTION
As discussed in https://github.com/riot/riot/issues/1223 , this modification prevents Riot templates to break when switching from an Array to an Array subclass.