### PR TITLE
update isArray to detect Array extensions

### DIFF
--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -21,4 +21,4 @@ var riot = { version: 'WIP', settings: {} },
   IE_VERSION = (window && window.document || {}).documentMode | 0,
 
   // Array.isArray for IE8 is in the polyfills
-  isArray = Array.isArray
+  isArray = function(a) { return Array.isArray(a) || a instanceof Array }

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -422,6 +422,10 @@ describe('Compiler Browser', function() {
       '<script type=\"riot\/tag\" src=\"tag\/observable-attr.tag\"><\/script>',
       '<observable-attr><\/observable-attr>',
 
+      // check arguments order of each attribute through array subclass loop
+      '<script type=\"riot\/tag\" src=\"tag\/loop-arraylike.tag\"><\/script>',
+      '<loop-arraylike><\/loop-arraylike>',
+
       ''    // keep it last please, avoids break PRs
     ].join('\r'),
     tags = [],
@@ -1691,6 +1695,14 @@ describe('Compiler Browser', function() {
 
     tags.push(tag)
 
+  })
+
+  it('loops correctly on array subclasses', function() {
+    var tag = riot.mount('loop-arraylike')[0],
+      root = tag.root
+    expect(normalizeHTML(root.getElementsByTagName('div')[0].innerHTML))
+      .to.be('<p>0 = zero</p><p>1 = one</p><p>2 = two</p><p>3 = three</p>')
+    tags.push(tag)
   })
 
 })

--- a/test/tag/loop-arraylike.tag
+++ b/test/tag/loop-arraylike.tag
@@ -1,0 +1,9 @@
+<loop-arraylike>
+  <div>
+    <p each="{ value, key in arraylike }">{ key } = { value }</p>
+  </div>
+
+  var array = [ 'zero', 'one', 'two', 'three' ]
+  this.arraylike = Object.create(Array.prototype)
+  this.arraylike.push.apply(this.arraylike, array)
+</loop-arraylike>


### PR DESCRIPTION
As discussed in https://github.com/riot/riot/issues/1223 , this modification prevents Riot templates to break when switching from an
Array to an Array subclass