### PR TITLE
replace tag internal _id property with a Symbol

### DIFF
--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -4,6 +4,8 @@ var riot = { version: 'WIP', settings: {} },
   // counter to give a unique id to all the Tag instances
   __uid = 0,
 
+  Symbol = Symbol && typeof Symbol.iterator === 'symbol' ? Symbol: function(s) { return '_riot_'+s },
+
   // riot specific prefixes
   RIOT_PREFIX = 'riot-',
   RIOT_TAG = RIOT_PREFIX + 'tag',
@@ -15,7 +17,7 @@ var riot = { version: 'WIP', settings: {} },
   T_FUNCTION = 'function',
   // special native tags that cannot be treated like the others
   SPECIAL_TAGS_REGEX = /^(?:opt(ion|group)|tbody|col|t[rhd])$/,
-  RESERVED_WORDS_BLACKLIST = ['_item', '_id', '_parent', 'update', 'root', 'mount', 'unmount', 'mixin', 'isMounted', 'isLoop', 'tags', 'parent', 'opts', 'trigger', 'on', 'off', 'one'],
+  RESERVED_WORDS_BLACKLIST = ['_item', '_parent', 'update', 'root', 'mount', 'unmount', 'mixin', 'isMounted', 'isLoop', 'tags', 'parent', 'opts', 'trigger', 'on', 'off', 'one'],
 
   // version# for IE 8-11, 0 for others
   IE_VERSION = (window && window.document || {}).documentMode | 0,

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -13,7 +13,8 @@ function Tag(impl, conf, innerHTML) {
     fn = impl.fn,
     tagName = root.tagName.toLowerCase(),
     attr = {},
-    propsInSyncWithParent = []
+    propsInSyncWithParent = [],
+    _id = Symbol('id')
 
   if (fn && root._tag) {
     root._tag.unmount(true)
@@ -29,7 +30,7 @@ function Tag(impl, conf, innerHTML) {
 
   // create a unique id to this tag
   // it could be handy to use it also to improve the virtual dom rendering speed
-  this._id = __uid++
+  this[_id] = __uid++
 
   extend(this, { parent: parent, root: root, opts: opts, tags: {} }, item)
 
@@ -183,7 +184,7 @@ function Tag(impl, conf, innerHTML) {
         // remove this element form the array
         if (isArray(ptag.tags[tagName]))
           each(ptag.tags[tagName], function(tag, i) {
-            if (tag._id == self._id)
+            if (tag[_id] == self[_id])
               ptag.tags[tagName].splice(i, 1)
           })
         else

--- a/test/fixtures/symbol.js
+++ b/test/fixtures/symbol.js
@@ -1,0 +1,3 @@
+/*eslint no-native-reassign: 0*/
+
+Symbol = function(s) { return '_riot_'+s }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function(config) {
     },
     files: [
       'polyfills/bind.js',
+      'fixtures/symbol.js',
       '../node_modules/mocha/mocha.js',
       '../node_modules/expect.js/index.js',
       '../dist/riot/riot.js',

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -849,14 +849,14 @@ describe('Compiler Browser', function() {
 /*  it('the loop children instances get correctly removed in the right order', function() {
 
     var tag = riot.mount('loop-ids')[0],
-      thirdItemId = tag.tags['loop-ids-item'][2]._id
+      thirdItemId = tag.tags['loop-ids-item'][2]._riot_id
 
     tag.items.splice(0, 1)
     tag.update(tag.tags['loop-ids-item'])
     expect(tag.items.length).to.be(2)
     // the second tag instance got removed
     // so now the third tag got moved to the second position
-    expect(tag.tags['loop-ids-item'][1]._id).to.be(thirdItemId)
+    expect(tag.tags['loop-ids-item'][1]._riot_id).to.be(thirdItemId)
     tags.push(tag)
 
   })*/

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -2,7 +2,7 @@ describe('Mixin', function() {
 
   var IdMixin = {
     getId: function() {
-      return this._id
+      return this._riot_id
     }
   }
 
@@ -39,7 +39,7 @@ describe('Mixin', function() {
 
     var tag = riot.mount('my-mixin')[0]
 
-    expect(tag._id).to.be(tag.getId())
+    expect(tag._riot_id).to.be(tag.getId())
     tag.unmount()
   })
 
@@ -81,9 +81,9 @@ describe('Mixin', function() {
     var first = riot.mount('#one')[0],
       second = riot.mount('#two')[0]
 
-    expect(first._id).to.be(first.getId())
-    expect(second._id).to.be(second.getId())
-    expect(first._id).not.to.be(second._id)
+    expect(first._riot_id).to.be(first.getId())
+    expect(second._riot_id).to.be(second.getId())
+    expect(first._riot_id).not.to.be(second._riot_id)
     expect(first.getId()).not.to.be(second.getId())
     first.unmount()
     second.unmount()
@@ -100,7 +100,7 @@ describe('Mixin', function() {
     var tag = riot.mount('my-mixin')[0],
       newOpts = {'some': 'option', 'value': Math.random()}
 
-    expect(tag._id).to.be(tag.getId())
+    expect(tag._riot_id).to.be(tag.getId())
     expect(tag.opts).to.be(tag.getOpts())
     tag.setOpts(newOpts)
     expect(tag.opts).to.be(tag.getOpts())
@@ -122,9 +122,9 @@ describe('Mixin', function() {
 
     var tag = riot.mount('my-mixin')[0]
 
-    expect(tag._id).to.be(tag.getId())
+    expect(tag._riot_id).to.be(tag.getId())
     expect(tag.tags['sub-mixin']).not.to.be('undefined')
-    expect(tag.tags['sub-mixin']._id).to.be(tag.tags['sub-mixin'].getId())
+    expect(tag.tags['sub-mixin']._riot_id).to.be(tag.tags['sub-mixin'].getId())
     expect(tag.getId()).not.to.be(tag.tags['sub-mixin'].getId())
     tag.unmount()
   })
@@ -139,7 +139,7 @@ describe('Mixin', function() {
 
     var tag = riot.mount('my-mixin')[0]
 
-    expect(tag.root.innerHTML).to.be('<span>some tag ' + tag._id + '</span>')
+    expect(tag.root.innerHTML).to.be('<span>some tag ' + tag._riot_id + '</span>')
     tag.unmount()
   })
 
@@ -168,7 +168,7 @@ describe('Mixin', function() {
 
     var tag = riot.mount('my-mixin')[0]
 
-    expect(tag._id).to.be(tag.getId())
+    expect(tag._riot_id).to.be(tag.getId())
     tag.unmount()
   })
 


### PR DESCRIPTION
This PR replace tag internal _id property with an ES6 Symbol to prevent name conflicts. 
It fixes issue https://github.com/riot/riot/issues/1181

Symbols as keys of properties are the best way to prevent any clash with user data. Symbols are already supported in Chrome, Firefox and Microsoft Edge. Also, it is really easy to provide a simple fallback to older browsers. The fallback I chose returns a String prefixed by ' \_riot_', so that '_id' becomes '_riot_id' for the old grumpy Internet Explorer.

Some unit tests for mixins were using this internal property _id, but when using Symbols this property is no longer exposed outside of Riot source. So I had to add a fixture in mocha tests that forces to use the fallback, which exposes _riot_id.

This does __not__ solve issue https://github.com/riot/riot/issues/1190 because these other blacklisted properties and methods are useful to the user, so we have to figure out something else for these.