### PR TITLE
Resolve innerHTML bug on the server

### DIFF
--- a/lib/server/sdom.js
+++ b/lib/server/sdom.js
@@ -19,8 +19,8 @@ Object.defineProperty(simpleDom.Element.prototype, 'innerHTML', {
     var html = '',
         next = this.firstChild
 
-    while (next && next.nextSibling) {
-      sdom.serialize(next)
+    while (next) {
+      html += sdom.serialize(next)
       next = next.nextSibling
     }
 

--- a/test/specs/node.js
+++ b/test/specs/node.js
@@ -55,4 +55,12 @@ describe('Node/io.js', function() {
     expect(els.last().text()).to.be('post 2')
   })
 
+  it('render tag: blog (using yield)', function() {
+    var blk = riot.render('block')
+    var $ = cheerio.load(blk)
+    expect($('block').length).to.be(1)
+    expect($('yoyo').length).to.be(1)
+    expect($('yoyo').innerHTML).to.be('Hello World!')
+  })
+
 })

--- a/test/specs/node.js
+++ b/test/specs/node.js
@@ -60,7 +60,7 @@ describe('Node/io.js', function() {
     var $ = cheerio.load(blk)
     expect($('block').length).to.be(1)
     expect($('yoyo').length).to.be(1)
-    expect($('yoyo').innerHTML).to.be('Hello World!')
+    expect($('yoyo').html()).to.be('Hello World!')
   })
 
 })

--- a/test/specs/node.js
+++ b/test/specs/node.js
@@ -55,7 +55,7 @@ describe('Node/io.js', function() {
     expect(els.last().text()).to.be('post 2')
   })
 
-  it('render tag: blog (using yield)', function() {
+  it('render tag: simple block (using yield)', function() {
     var blk = riot.render('block')
     var $ = cheerio.load(blk)
     expect($('block').length).to.be(1)

--- a/test/tag/block.tag
+++ b/test/tag/block.tag
@@ -1,0 +1,7 @@
+<block>
+	<yoyo>Hello World!</yoyo>
+</block>
+
+<yoyo>
+	<yield/>
+</yoyo>


### PR DESCRIPTION
Remove nextSibling from loop condition so that nodes with a single child
will be visited.
Concatenate the result of calling sdom.serialize() to the html variable.