### PR TITLE
supported jade in browser

### DIFF
--- a/lib/browser/compiler/core.js
+++ b/lib/browser/compiler/core.js
@@ -20,11 +20,11 @@ function unindent(src) {
   return src
 }
 
-function globalEval(js) {
+function globalEval(js, opts) {
   var node = doc.createElement('script'),
       root = doc.documentElement
 
-  node.text = compile(js)
+  node.text = compile(js, opts)
   root.appendChild(node)
   root.removeChild(node)
 }
@@ -46,7 +46,9 @@ function compileScripts(fn) {
       var url = script.getAttribute('src')
 
       function compileTag(source) {
-        globalEval(source)
+        globalEval(source, {
+          template: script.getAttribute('template')
+        })
         scriptsAmount--
         if (!scriptsAmount) {
           done()

--- a/lib/browser/compiler/parsers.js
+++ b/lib/browser/compiler/parsers.js
@@ -1,6 +1,10 @@
 /* istanbul ignore next */
 var parsers = {
-  html: {},
+  html: {
+    jade: function(html) {
+      return jade.render(html, {pretty: true, doctype: 'html'})
+    }
+  },
   css: {},
   js: {
     coffee: function(js) {


### PR DESCRIPTION
Supported jade in browser.
I choose a template engine to see an attribute.

```html
    <script type="riot/tag" template='jade'>
      app
        h1 {msg}

        script.
          this.msg = 'Hello, Riot.js'
    </script>
```

Please merge it if you like.

## example

http://goo.gl/BHp8jU