### PR TITLE
WIP Fix for compiler returning tags asynchronously

### DIFF
--- a/lib/browser/compiler/core.js
+++ b/lib/browser/compiler/core.js
@@ -103,9 +103,9 @@ riot.compile = function(arg, fn) {
 // reassign mount methods
 var mount = riot.mount
 
-riot.mount = function(a, b, c) {
+riot.mount = function(a, b, c, d) {
   var ret
-  riot.compile(function() { ret = mount(a, b, c) })
+  riot.compile(function() { ret = mount(a, b, c); if (typeof d === 'function') { d(ret) } })
   return ret
 }
 

--- a/riot+compiler.js
+++ b/riot+compiler.js
@@ -1716,9 +1716,9 @@ riot.compile = function(arg, fn) {
 // reassign mount methods
 var mount = riot.mount
 
-riot.mount = function(a, b, c) {
+riot.mount = function(a, b, c, d) {
   var ret
-  riot.compile(function() { ret = mount(a, b, c) })
+  riot.compile(function() { ret = mount(a, b, c); if (typeof d === 'function') { d(ret) } })
   return ret
 }
 


### PR DESCRIPTION
#### Use Case:

Currently when async functionality is used through riot.mount there is no way to get a meaningful return value. This patch adds an optional fourth "done callback" to be called post mount:

```javascript
var appTag = riot.mount(
    '#my-app',
    'my-app',
    {
        someApiEndpoint: '/api/list/things',
    },
    function(ret) {
        appTag = ret;
        console.log(appTag);
    }
);
```

Currently the `function(ret)` callback would not be called. leaving appTag `undefined`.This patches things so that if provided it is called and would allow it to still be defined.

#### Background
I understand there are now going to be postmount style events, but I wrote this patch months ago and forgot about it until tonight. I rebased it and saw it was still potentially useful for somebody so I figured I would create a MR for it to both measure worthiness of working on it further and to prod me into actually writing tests for it if it is worthy of inclusion.

#### Todo:
- [ ] Identify if desirable
- [ ] Write tests
- [ ] Modify to support varying signatures