### PR TITLE
Unexpected second time mountings

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -78,20 +78,20 @@ riot.mount = function(selector, tagName, opts) {
   }
 
   function isInnerTag(el) {
-    var parent = el.parentElement;
+    var parent = el.parentElement
     while (parent) {
-      if (tagImpl[parent.tagName.toLowerCase()]) return true;
-      parent = parent.parentElement;
+      if (tagImpl[parent.tagName.toLowerCase()]) return true
+      parent = parent.parentElement
     }
-    return false;
+    return false
   }
 
   function pushTags(root) {
     var last
 
     if (root.tagName) {
-      if (root._tag) return;
-      if (typeof selector === T_STRING && isInnerTag(root)) return;
+      if (root._tag) return
+      if (typeof selector === T_STRING && isInnerTag(root)) return
       if (tagName && (!(last = getAttr(root, RIOT_TAG)) || last != tagName))
         setAttr(root, RIOT_TAG, tagName)
 

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -81,6 +81,7 @@ riot.mount = function(selector, tagName, opts) {
     var last
 
     if (root.tagName) {
+      if (root._tag) return;
       if (tagName && (!(last = getAttr(root, RIOT_TAG)) || last != tagName))
         setAttr(root, RIOT_TAG, tagName)
 

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -77,11 +77,21 @@ riot.mount = function(selector, tagName, opts) {
     return keys + addRiotTags(keys)
   }
 
+  function isInnerTag(el) {
+    var parent = el.parentElement;
+    while (parent) {
+      if (tagImpl[parent.tagName.toLowerCase()]) return true;
+      parent = parent.parentElement;
+    }
+    return false;
+  }
+
   function pushTags(root) {
     var last
 
     if (root.tagName) {
       if (root._tag) return;
+      if (isInnerTag(root)) return;
       if (tagName && (!(last = getAttr(root, RIOT_TAG)) || last != tagName))
         setAttr(root, RIOT_TAG, tagName)
 

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -91,7 +91,7 @@ riot.mount = function(selector, tagName, opts) {
 
     if (root.tagName) {
       if (root._tag) return;
-      if (isInnerTag(root)) return;
+      if (typeof selector === T_STRING && isInnerTag(root)) return;
       if (tagName && (!(last = getAttr(root, RIOT_TAG)) || last != tagName))
         setAttr(root, RIOT_TAG, tagName)
 


### PR DESCRIPTION
This PR solves unexpected second time mountings demonstrated below:

```html
<!-- my-button is used in many other places -->
<my-outer>
  <my-button></my-button>
</my-outer>

<script>
  riot.mount("my-button");
  riot.mount("my-outer");
</script>
```

Here `my-button` is mounted once when `riot.mount("my-button")` is executed, then it is mounted again when `riot.mount("my-outer")` is executed, leading to repeated generation.

This PR works by checking at mount time whether a tag been mounted is already mounted or it is an inner tag of some outer custom tag. In that case, the outer tag is responsible for its mounting.