### PR TITLE
Remove UglifyJs warnings from webpack production shortcut (-p)

### DIFF
--- a/lib/browser/wrap/suffix.js
+++ b/lib/browser/wrap/suffix.js
@@ -2,7 +2,7 @@
   /* istanbul ignore next */
   if (typeof exports === T_OBJECT)
     module.exports = riot
-  else if (typeof define === 'function' && define.amd)
+  else if (typeof define === T_FUNCTION && typeof define.amd !== T_UNDEF)
     define(function() { return (window.riot = riot) })
   else
     window.riot = riot


### PR DESCRIPTION
Not Really a riot problem just an annoyance.

Webpack/UglifyJs throws this warnings:

Condition always true [./~/riot/riot.js:1365,0]
Dropping unreachable code [./~/riot/riot.js:1368,0]