### PR TITLE
Fix server-side rendering in node.js < v4.0

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -12,10 +12,7 @@ riot.parsers = compiler.parsers
 // allow to require('some.tag')
 require.extensions['.tag'] = function(module, filename) {
   var src = riot.compile(require('fs').readFileSync(filename, 'utf8'))
-  module._compile(`
-  var riot = require(process.env.RIOT || '../../riot')
-  module.exports =  ${src}
-`, filename)
+  module._compile('var riot = require(process.env.RIOT || "../../riot");module.exports = ' + src, filename)
 }
 
 // simple-dom helper


### PR DESCRIPTION
This code is using es6 template strings, which is only supported in node.js >= 4.0:
https://github.com/riot/riot/blob/master/lib/server/index.js#L15-L18

Our riot apps are deployed on AWS Lambda, which currently only supports node.js v0.10.36
