### PR TITLE
Fix server pre-rendering

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -1,6 +1,6 @@
 
 // allow to require('riot')
-var riot = module.exports = require(process.env.RIOT || '../../riot')
+var riot = module.exports = require(process.env.RIOT || require('path').resolve(__dirname, '../../riot'))
 
 var compiler = require('riot-compiler')
 
@@ -13,7 +13,7 @@ riot.parsers = compiler.parsers
 require.extensions['.tag'] = function(module, filename) {
   var src = riot.compile(require('fs').readFileSync(filename, 'utf8'))
   module._compile(`
-  var riot = require(process.env.RIOT || '../../riot')
+  var riot = require(process.env.RIOT || 'riot/riot.js')
   module.exports =  ${src}
 `, filename)
 }


### PR DESCRIPTION
Turns out that #1307 didn't actually fix anything, but these changes do get `require`-ing of `.tag` files working.