### PR TITLE
Add instanbul as devDependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Command line paths
 KARMA = ./node_modules/karma/bin/karma
-ISTANBUL = ./node_modules/karma-coverage/node_modules/.bin/istanbul
+ISTANBUL = ./node_modules/istanbul/lib/cli.js
 ESLINT = ./node_modules/eslint/bin/eslint.js
 MOCHA = ./node_modules/mocha/bin/_mocha
 SMASH = ./node_modules/.bin/smash

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint": "^1.7.3",
     "expect.js": "^0.3.1",
     "glob": "^5.0.15",
+    "istanbul": "^0.4.0",
     "jsdom": "^7.0.2",
     "karma": "^0.13.14",
     "karma-coverage": "^0.5.3",


### PR DESCRIPTION
I was unable to build + test riot because the `istanbul` package could not be located.  It's currently assumed to be a dependency of `karma-coverage`.

This is most likely a problem because of npm 3, which now installs dependencies as a flat hierarchy.
