### PR TITLE
multi-tranclusion yield from, to with tests

### DIFF
--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -318,6 +318,18 @@ function mkEl(name) {
 }
 
 /**
+ * Create a generic DOM node, and fill it with innerHTML
+ * @param   { String } name - name of the DOM node we want to create
+ * @param   { String } innerHTML - innerHTML of the new DOM
+ * @returns { Object } DOM node just created
+ */
+function mkElWithInnerHTML(name, innerHTML) {
+  var el = mkEl(name)
+  el.innerHTML = innerHTML || ''
+  return el
+}
+
+/**
  * Replace the yield tag from any tag template with the innerHTML of the
  * original tag in the page
  * @param   { String } tmpl - tag implementation template
@@ -325,7 +337,23 @@ function mkEl(name) {
  * @returns { String } tag template updated without the yield tag
  */
 function replaceYield(tmpl, innerHTML) {
-  return tmpl.replace(/<(yield)\/?>(<\/\1>)?/gi, innerHTML || '')
+  var tmplElement = mkElWithInnerHTML('div', tmpl)
+  // if ($('yield[from]'.tmplElement)) { // this issues test errors
+  if (tmplElement.querySelector && tmplElement.querySelector('yield[from]')) { // code coverage path not taken (?)
+    // yield to(s) must be direct children from innerHTML(root), all other tags are ignored
+    each(mkElWithInnerHTML('div', innerHTML).childNodes, function(toYield) {
+      if (toYield.nodeType == 1 && toYield.tagName == 'YIELD' && toYield.getAttribute('to')) {
+        // replace all yield[from]
+        each($$('yield[from="'+toYield.getAttribute('to')+'"]', tmplElement), function(fromYield) {
+          fromYield.outerHTML = toYield.innerHTML
+        })
+      }
+    })
+    return tmplElement.innerHTML
+  } else {
+    // just replace yield in tmpl with the innerHTML
+    return tmpl.replace(/<(yield)\s*\/?>(<\/\1>)?/gi, innerHTML || '')
+  }
 }
 
 /**

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -370,6 +370,9 @@ describe('Compiler Browser', function() {
       '<loop-virtual><\/loop-virtual>',
       '<loop-virtual-reorder><\/loop-virtual-reorder>',
 
+      '<script type="riot/tag" src="tag\/yield-multi.tag"></script>',
+      '<yield-multi><yield to="content">content</yield></yield-multi>',
+
       ''    // keep it last please, avoids break PRs
     ].join('\n'),
     tags = [],
@@ -1060,6 +1063,14 @@ describe('Compiler Browser', function() {
     child3.root.getElementsByTagName('i')[0].onclick({})
 
     tags.push(tag)
+
+  })
+
+  it('<yield> from/to multi-transclusion', function() {
+
+    var tag = riot.mount('yield-multi', {})[0]
+
+    expect(normalizeHTML(tag.root.innerHTML)).to.be('<p>yield the content here</p>')
 
   })
 

--- a/test/specs/compiler-browser.js
+++ b/test/specs/compiler-browser.js
@@ -370,8 +370,8 @@ describe('Compiler Browser', function() {
       '<loop-virtual><\/loop-virtual>',
       '<loop-virtual-reorder><\/loop-virtual-reorder>',
 
-      '<script type="riot/tag" src="tag\/yield-multi.tag"></script>',
-      '<yield-multi><yield to="content">content</yield></yield-multi>',
+      '<script type="riot\/tag" src="tag\/yield-multi.tag"><\/script>',
+      '<yield-multi><yield to="content">content<\/yield><\/yield-multi>',
 
       ''    // keep it last please, avoids break PRs
     ].join('\n'),

--- a/test/tag/yield-multi.tag
+++ b/test/tag/yield-multi.tag
@@ -1,0 +1,4 @@
+<yield-multi>
+  <p>yield the <yield from="content" /> here</p>
+
+</yield-multi>


### PR DESCRIPTION
The same pull request referenced in #1332, with a few changes:

1) Tests !

2) A working example:
lmicra/riot-multi-tranclusion-poc@132151938667be428abd6db1e8808c7c46fa3548

3) performance tweak:
checks first if there are yield[from] tags in the template to avoid the need to cycle all the innerHTML direct children (the performance hit would be here for tags with many children)

(Still trying to figure out the pull-request thingy, so sorry for not making this in the same repository.)