### PR TITLE
classes as mixins

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -100,6 +100,7 @@ function Tag(impl, conf, innerHTML) {
   defineProperty(this, 'mixin', function() {
     each(arguments, function(mix) {
       mix = typeof mix === T_STRING ? riot.mixin(mix) : mix
+      if (typeof mix === T_FUNCTION) mix = new mix()
       each(Object.keys(mix), function(key) {
         // bind methods to self
         if (key != 'init')

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -1,254 +1,1 @@
-function Tag(impl, conf, innerHTML) {
-
-  var self = riot.observable(this),
-    opts = inherit(conf.opts) || {},
-    dom = mkdom(impl.tmpl),
-    parent = conf.parent,
-    isLoop = conf.isLoop,
-    hasImpl = conf.hasImpl,
-    item = cleanUpData(conf.item),
-    expressions = [],
-    childTags = [],
-    root = conf.root,
-    fn = impl.fn,
-    tagName = root.tagName.toLowerCase(),
-    attr = {},
-    propsInSyncWithParent = []
-
-  if (fn && root._tag) root._tag.unmount(true)
-
-  // not yet mounted
-  this.isMounted = false
-  root.isLoop = isLoop
-
-  // keep a reference to the tag just created
-  // so we will be able to mount this tag multiple times
-  root._tag = this
-
-  // create a unique id to this tag
-  // it could be handy to use it also to improve the virtual dom rendering speed
-  defineProperty(this, '_riot_id', ++__uid) // base 1 allows test !t._riot_id
-
-  extend(this, { parent: parent, root: root, opts: opts, tags: {} }, item)
-
-  // grab attributes
-  each(root.attributes, function(el) {
-    var val = el.value
-    // remember attributes with expressions only
-    if (tmpl.hasExpr(val)) attr[el.name] = val
-  })
-
-  if (dom.innerHTML && !/^(select|optgroup|table|tbody|tr|col(?:group)?)$/.test(tagName))
-    // replace all the yield tags with the tag inner html
-    dom.innerHTML = replaceYield(dom.innerHTML, innerHTML)
-
-  // options
-  function updateOpts() {
-    var ctx = hasImpl && isLoop ? self : parent || self
-
-    // update opts from current DOM attributes
-    each(root.attributes, function(el) {
-      opts[toCamel(el.name)] = tmpl(el.value, ctx)
-    })
-    // recover those with expressions
-    each(Object.keys(attr), function(name) {
-      opts[toCamel(name)] = tmpl(attr[name], ctx)
-    })
-  }
-
-  function normalizeData(data) {
-    for (var key in item) {
-      if (typeof self[key] !== T_UNDEF && isWritable(self, key))
-        self[key] = data[key]
-    }
-  }
-
-  function inheritFromParent () {
-    if (!self.parent || !isLoop) return
-    each(Object.keys(self.parent), function(k) {
-      // some properties must be always in sync with the parent tag
-      var mustSync = !contains(RESERVED_WORDS_BLACKLIST, k) && contains(propsInSyncWithParent, k)
-      if (typeof self[k] === T_UNDEF || mustSync) {
-        // track the property to keep in sync
-        // so we can keep it updated
-        if (!mustSync) propsInSyncWithParent.push(k)
-        self[k] = self.parent[k]
-      }
-    })
-  }
-
-  defineProperty(this, 'update', function(data) {
-
-    // make sure the data passed will not override
-    // the component core methods
-    data = cleanUpData(data)
-    // inherit properties from the parent
-    inheritFromParent()
-    // normalize the tag properties in case an item object was initially passed
-    if (data && typeof item === T_OBJECT) {
-      normalizeData(data)
-      item = data
-    }
-    extend(self, data)
-    updateOpts()
-    self.trigger('update', data)
-    update(expressions, self)
-    self.trigger('updated')
-    return this
-  })
-
-  defineProperty(this, 'mixin', function() {
-    each(arguments, function(mix) {
-      var instance
-      mix = typeof mix === T_STRING ? riot.mixin(mix) : mix
-
-      if (typeof mix === T_FUNCTION) {
-        instance = new mix()
-        mix = mix.prototype
-      }
-      else {
-        instance = mix
-      }
-
-      each(Object.getOwnPropertyNames(mix), function(key) {
-        // bind methods to self
-        if (key != 'init')
-          self[key] = isFunction(instance[key]) ? instance[key].bind(self) : instance[key]
-      })
-
-      // init method will be called automatically
-      if (instance.init) instance.init.bind(self)()
-    })
-    return this
-  })
-
-  defineProperty(this, 'mount', function() {
-
-    updateOpts()
-
-    // initialiation
-    if (fn) fn.call(self, opts)
-
-    // parse layout after init. fn may calculate args for nested custom tags
-    parseExpressions(dom, self, expressions)
-
-    // mount the child tags
-    toggle(true)
-
-    // update the root adding custom attributes coming from the compiler
-    // it fixes also #1087
-    if (impl.attrs || hasImpl) {
-      walkAttributes(impl.attrs, function (k, v) { setAttr(root, k, v) })
-      parseExpressions(self.root, self, expressions)
-    }
-
-    if (!self.parent || isLoop) self.update(item)
-
-    // internal use only, fixes #403
-    self.trigger('before-mount')
-
-    if (isLoop && !hasImpl) {
-      // update the root attribute for the looped elements
-      self.root = root = dom.firstChild
-
-    } else {
-      while (dom.firstChild) root.appendChild(dom.firstChild)
-      if (root.stub) self.root = root = parent.root
-    }
-
-    // parse the named dom nodes in the looped child
-    // adding them to the parent as well
-    if (isLoop)
-      parseNamedElements(self.root, self.parent, null, true)
-
-    // if it's not a child tag we can trigger its mount event
-    if (!self.parent || self.parent.isMounted) {
-      self.isMounted = true
-      self.trigger('mount')
-    }
-    // otherwise we need to wait that the parent event gets triggered
-    else self.parent.one('mount', function() {
-      // avoid to trigger the `mount` event for the tags
-      // not visible included in an if statement
-      if (!isInStub(self.root)) {
-        self.parent.isMounted = self.isMounted = true
-        self.trigger('mount')
-      }
-    })
-  })
-
-
-  defineProperty(this, 'unmount', function(keepRootTag) {
-    var el = root,
-      p = el.parentNode,
-      ptag
-
-    self.trigger('before-unmount')
-
-    // remove this tag instance from the global virtualDom variable
-    __virtualDom.splice(__virtualDom.indexOf(self), 1)
-
-    if (this._virts) {
-      each(this._virts, function(v) {
-        v.parentNode.removeChild(v)
-      })
-    }
-
-    if (p) {
-
-      if (parent) {
-        ptag = getImmediateCustomParentTag(parent)
-        // remove this tag from the parent tags object
-        // if there are multiple nested tags with same name..
-        // remove this element form the array
-        if (isArray(ptag.tags[tagName]))
-          each(ptag.tags[tagName], function(tag, i) {
-            if (tag._riot_id == self._riot_id)
-              ptag.tags[tagName].splice(i, 1)
-          })
-        else
-          // otherwise just delete the tag instance
-          ptag.tags[tagName] = undefined
-      }
-
-      else
-        while (el.firstChild) el.removeChild(el.firstChild)
-
-      if (!keepRootTag)
-        p.removeChild(el)
-      else
-        // the riot-tag attribute isn't needed anymore, remove it
-        remAttr(p, 'riot-tag')
-    }
-
-
-    self.trigger('unmount')
-    toggle()
-    self.off('*')
-    self.isMounted = false
-    // somehow ie8 does not like `delete root._tag`
-    root._tag = null
-
-  })
-
-  function toggle(isMount) {
-
-    // mount/unmount children
-    each(childTags, function(child) { child[isMount ? 'mount' : 'unmount']() })
-
-    // listen/unlisten parent (events flow one way from parent to children)
-    if (parent) {
-      var evt = isMount ? 'on' : 'off'
-
-      // the loop tags will be always in sync with the parent automatically
-      if (isLoop)
-        parent[evt]('unmount', self.unmount)
-      else
-        parent[evt]('update', self.update)[evt]('unmount', self.unmount)
-    }
-  }
-
-  // named elements available for fn
-  parseNamedElements(dom, this, childTags)
-
-}
+function Tag(impl, conf, innerHTML) {  var self = riot.observable(this),    opts = inherit(conf.opts) || {},    dom = mkdom(impl.tmpl),    parent = conf.parent,    isLoop = conf.isLoop,    hasImpl = conf.hasImpl,    item = cleanUpData(conf.item),    expressions = [],    childTags = [],    root = conf.root,    fn = impl.fn,    tagName = root.tagName.toLowerCase(),    attr = {},    propsInSyncWithParent = []  if (fn && root._tag) root._tag.unmount(true)  // not yet mounted  this.isMounted = false  root.isLoop = isLoop  // keep a reference to the tag just created  // so we will be able to mount this tag multiple times  root._tag = this  // create a unique id to this tag  // it could be handy to use it also to improve the virtual dom rendering speed  defineProperty(this, '_riot_id', ++__uid) // base 1 allows test !t._riot_id  extend(this, { parent: parent, root: root, opts: opts, tags: {} }, item)  // grab attributes  each(root.attributes, function(el) {    var val = el.value    // remember attributes with expressions only    if (tmpl.hasExpr(val)) attr[el.name] = val  })  if (dom.innerHTML && !/^(select|optgroup|table|tbody|tr|col(?:group)?)$/.test(tagName))    // replace all the yield tags with the tag inner html    dom.innerHTML = replaceYield(dom.innerHTML, innerHTML)  // options  function updateOpts() {    var ctx = hasImpl && isLoop ? self : parent || self    // update opts from current DOM attributes    each(root.attributes, function(el) {      opts[toCamel(el.name)] = tmpl(el.value, ctx)    })    // recover those with expressions    each(Object.keys(attr), function(name) {      opts[toCamel(name)] = tmpl(attr[name], ctx)    })  }  function normalizeData(data) {    for (var key in item) {      if (typeof self[key] !== T_UNDEF && isWritable(self, key))        self[key] = data[key]    }  }  function inheritFromParent () {    if (!self.parent || !isLoop) return    each(Object.keys(self.parent), function(k) {      // some properties must be always in sync with the parent tag      var mustSync = !contains(RESERVED_WORDS_BLACKLIST, k) && contains(propsInSyncWithParent, k)      if (typeof self[k] === T_UNDEF || mustSync) {        // track the property to keep in sync        // so we can keep it updated        if (!mustSync) propsInSyncWithParent.push(k)        self[k] = self.parent[k]      }    })  }  defineProperty(this, 'update', function(data) {    // make sure the data passed will not override    // the component core methods    data = cleanUpData(data)    // inherit properties from the parent    inheritFromParent()    // normalize the tag properties in case an item object was initially passed    if (data && typeof item === T_OBJECT) {      normalizeData(data)      item = data    }    extend(self, data)    updateOpts()    self.trigger('update', data)    update(expressions, self)    self.trigger('updated')    return this  })  defineProperty(this, 'mixin', function() {    each(arguments, function(mix) {      var instance      mix = typeof mix === T_STRING ? riot.mixin(mix) : mix      if (typeof mix === T_FUNCTION) {        instance = new mix()        mix = mix.prototype      }      else {        instance = mix      }      each(Object.getOwnPropertyNames(mix), function(key) {        // bind methods to self        if (key != 'init')          self[key] = isFunction(instance[key]) ? instance[key].bind(self) : instance[key]      })      // init method will be called automatically      if (instance.init) instance.init.bind(self)()    })    return this  })  defineProperty(this, 'mount', function() {    updateOpts()    // initialiation    if (fn) fn.call(self, opts)    // parse layout after init. fn may calculate args for nested custom tags    parseExpressions(dom, self, expressions)    // mount the child tags    toggle(true)    // update the root adding custom attributes coming from the compiler    // it fixes also #1087    if (impl.attrs || hasImpl) {      walkAttributes(impl.attrs, function (k, v) { setAttr(root, k, v) })      parseExpressions(self.root, self, expressions)    }    if (!self.parent || isLoop) self.update(item)    // internal use only, fixes #403    self.trigger('before-mount')    if (isLoop && !hasImpl) {      // update the root attribute for the looped elements      self.root = root = dom.firstChild    } else {      while (dom.firstChild) root.appendChild(dom.firstChild)      if (root.stub) self.root = root = parent.root    }    // parse the named dom nodes in the looped child    // adding them to the parent as well    if (isLoop)      parseNamedElements(self.root, self.parent, null, true)    // if it's not a child tag we can trigger its mount event    if (!self.parent || self.parent.isMounted) {      self.isMounted = true      self.trigger('mount')    }    // otherwise we need to wait that the parent event gets triggered    else self.parent.one('mount', function() {      // avoid to trigger the `mount` event for the tags      // not visible included in an if statement      if (!isInStub(self.root)) {        self.parent.isMounted = self.isMounted = true        self.trigger('mount')      }    })  })  defineProperty(this, 'unmount', function(keepRootTag) {    var el = root,      p = el.parentNode,      ptag    self.trigger('before-unmount')    // remove this tag instance from the global virtualDom variable    __virtualDom.splice(__virtualDom.indexOf(self), 1)    if (this._virts) {      each(this._virts, function(v) {        v.parentNode.removeChild(v)      })    }    if (p) {      if (parent) {        ptag = getImmediateCustomParentTag(parent)        // remove this tag from the parent tags object        // if there are multiple nested tags with same name..        // remove this element form the array        if (isArray(ptag.tags[tagName]))          each(ptag.tags[tagName], function(tag, i) {            if (tag._riot_id == self._riot_id)              ptag.tags[tagName].splice(i, 1)          })        else          // otherwise just delete the tag instance          ptag.tags[tagName] = undefined      }      else        while (el.firstChild) el.removeChild(el.firstChild)      if (!keepRootTag)        p.removeChild(el)      else        // the riot-tag attribute isn't needed anymore, remove it        remAttr(p, 'riot-tag')    }    self.trigger('unmount')    toggle()    self.off('*')    self.isMounted = false    // somehow ie8 does not like `delete root._tag`    root._tag = null  })  function toggle(isMount) {    // mount/unmount children    each(childTags, function(child) { child[isMount ? 'mount' : 'unmount']() })    // listen/unlisten parent (events flow one way from parent to children)    if (parent) {      var evt = isMount ? 'on' : 'off'      // the loop tags will be always in sync with the parent automatically      if (isLoop)        parent[evt]('unmount', self.unmount)      else        parent[evt]('update', self.update)[evt]('unmount', self.unmount)    }  }  // named elements available for fn  parseNamedElements(dom, this, childTags)}

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -99,16 +99,25 @@ function Tag(impl, conf, innerHTML) {
 
   defineProperty(this, 'mixin', function() {
     each(arguments, function(mix) {
+      var instance
       mix = typeof mix === T_STRING ? riot.mixin(mix) : mix
-      if (typeof mix === T_FUNCTION) mix = new mix()
-      
-      each(Object.keys(mix), function(key) {
+
+      if (typeof mix === T_FUNCTION) {
+        instance = new mix()
+        mix = mix.prototype
+      }
+      else {
+        instance = mix
+      }
+
+      each(Object.getOwnPropertyNames(mix), function(key) {
         // bind methods to self
         if (key != 'init')
-          self[key] = isFunction(mix[key]) ? mix[key].bind(self) : mix[key]
+          self[key] = isFunction(instance[key]) ? instance[key].bind(self) : instance[key]
       })
+
       // init method will be called automatically
-      if (mix.init) mix.init.bind(self)()
+      if (instance.init) instance.init.bind(self)()
     })
     return this
   })

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -101,6 +101,7 @@ function Tag(impl, conf, innerHTML) {
     each(arguments, function(mix) {
       mix = typeof mix === T_STRING ? riot.mixin(mix) : mix
       if (typeof mix === T_FUNCTION) mix = new mix()
+      
       each(Object.keys(mix), function(key) {
         // bind methods to self
         if (key != 'init')


### PR DESCRIPTION
In many cases, it is extremely useful to have a base mixin class / function prototype that other mixins can inherit from. Example (`es6`):

```js
class Notification {
  init() {
    this.notifyInitialized(this.message);
  }

  get type() {
    throw new Error('not implemented'); 
  }

  get message() {
    return 'Instance of ' + this.type + ' notification mixin created';
  }

  notifyInitialized(msg) {
    throw new Error('not implemented');
  }
}

class AlertNotificationMixin extends Notification {
  get type() {
    return 'alert';
  }

  notifyInitialized(msg) {
    alert(msg);
  }
}

class ConsoleNotificationMixin extends Notification {
  get type() {
    return 'console';
  }

  notifyInitialized(msg) {
    console.log(msg);
  }
}

this.mixin(AlertNotificationMixin, ConsoleNotificationMixin);
```

