### PR TITLE
Adds a link to my plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
 - [Yeoman generator - Generator riot element](https://www.npmjs.com/package/generator-riot-element)
 - [Riot for TypeScript](https://github.com/nippur72/RiotTS)
 - [Sublime Syntax Highlighting for Riot Tag Files](https://github.com/crisward/sublime-tag)
+- [Riot loader plugin for RequireJS](https://github.com/amenadiel/requirejs-riot)
 
 ### Performance
 - **Riot vs React performance:** [(Riot version)](https://github.com/kazzkiq/samples/tree/gh-pages/perf/dom-riot-vs-vanilla) vs [(React version)](https://github.com/kazzkiq/samples/tree/gh-pages/perf/dom-react-vs-vanilla)


### PR DESCRIPTION
I made a very simple plugin in order to load Riot tags with RequireJS, 
without resorting to fetch the tag contents and pass them to the compiler. 

At build step, the plugin precompiles and inlines tags.