### PR TITLE
Implements #905 and #1070

### DIFF
--- a/lib/browser/compiler/compile.js
+++ b/lib/browser/compiler/compile.js
@@ -43,7 +43,10 @@ riot.compile = (function () {
     }
 
     function compileTag(src, opts, url) {
-      globalEval(compile(src, opts, url))
+      var code = compile(src, opts)
+
+      if (url) code += '\n//# sourceURL=' + url + '.js'
+      globalEval(code)
       if (!--scriptsAmount) done()
     }
 

--- a/lib/browser/compiler/compile.js
+++ b/lib/browser/compiler/compile.js
@@ -43,7 +43,7 @@ riot.compile = (function () {
     }
 
     function compileTag(src, opts, url) {
-      var code = compile(src, opts)
+      var code = compile(src, opts, url)
 
       if (url) code += '\n//# sourceURL=' + url + '.js'
       globalEval(code)


### PR DESCRIPTION
This is a modified version of the PR #1070 from @beders.
For .tag files, the compiled code is visible in the element "(not domain)" of Chrome DevTools, with the same path as the .tag file and a .js extension added.