### PR TITLE
Added raw before test-mocha to prevent build failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ eslint:
 	# check code style
 	@ $(ESLINT) -c ./.eslintrc lib test
 
-test-mocha:
+test-mocha: raw
 	RIOT=../../dist/riot/riot.js $(ISTANBUL) cover $(MOCHA) -- test/runner.js -R spec
 
 test-karma:


### PR DESCRIPTION
When I forked the repo the `make test` command fails:

```bash
Error: Cannot find module '../../dist/riot/riot.js'
```

This is because the `test-mocha` task depends on the `dist` being built. 

I've added the `raw` step as part of the `test-mocha` task. 

I didn't add it on the `test` task since it was only the `test-mocha` task that was dependent on the `dist`-folder being built. 