### PR TITLE
Allow to `require` from tags

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -10,11 +10,14 @@ riot.parsers = compiler.parsers
 
 
 // allow to require('some.tag')
-require.extensions['.tag'] = function(module, filename) {
-  var src = riot.compile(require('fs').readFileSync(filename, 'utf8'))
-  module._compile(
-    'var riot = require(process.env.RIOT || "riot/riot.js");module.exports =' + src
-  , filename)
+if (!require.extensions['.tag']) {
+  require.extensions['.tag'] = function(module, filename) {
+    var src = riot.compile(require('fs').readFileSync(filename, 'utf8'))
+      .replace(/(\s?riot\.tag2?\()/, 'module.exports = $1')
+    module._compile(
+      'var riot = require(process.env.RIOT || "riot/riot.js");' + src
+    , filename)
+  }
 }
 
 // simple-dom helper


### PR DESCRIPTION
When using Webpack with riotjs-loader on the client, it is possible to `require` modules/tags (and probably use any JS code) at the top of any `.tag` file.
But when running `riot.render` on the server, it gives wrong output, because here is how such `.tag` file

```html
// foo.tag
require('./bar.tag');
<foo>
   <h1>Foo</h1>
  <bar></bar>
</foo>
```

precompiles to `.js` (when using `require('./foo.tag');` from server-side js files)
```javascript
var riot = require(process.env.RIOT || "riot/riot.js");module.exports = require('./bar.tag');

riot.tag2('foo', ...)
```
It `exports` what's in `require('./bar.tag')` but not the tag itself.

With this fix it will always put `module.exports = ` where it belongs, before `riot.tag2(...`, like so
```javascript
var riot = require(process.env.RIOT || "riot/riot.js");require('./bar.tag');

module.exports = riot.tag2('foo', ...)
```

I also wrapped `require.extensions['.tag'] = ...` with `if` so it will allow everyone to overwrite the behavior of this function from their code.