### PR TITLE
Inject tag styles in batch

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -110,7 +110,7 @@ riot.mount = function(selector, tagName, opts) {
   }
 
   // ----- mount code -----
-  
+
   // inject styles into DOM
   tagStyles.inject()
 

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -112,7 +112,7 @@ riot.mount = function(selector, tagName, opts) {
   // ----- mount code -----
 
   // inject styles into DOM
-  tagStyles.inject()
+  if (tagStyles) tagStyles.inject()
 
   if (typeof tagName === T_OBJECT) {
     opts = tagName

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -43,7 +43,7 @@ riot.tag = function(name, html, css, attrs, fn) {
   }
   if (css) {
     if (isFunction(css)) fn = css
-    else if (injectStyle) injectStyle(css)
+    else if (tagStyles) tagStyles.add(css)
   }
   __tagImpl[name] = { name: name, tmpl: html, attrs: attrs, fn: fn }
   return name
@@ -60,7 +60,7 @@ riot.tag = function(name, html, css, attrs, fn) {
  * @returns { String } name/id of the tag just created
  */
 riot.tag2 = function(name, html, css, attrs, fn, bpair) {
-  if (css && injectStyle) injectStyle(css)
+  if (css && tagStyles) tagStyles.add(css)
   //if (bpair) riot.settings.brackets = bpair
   __tagImpl[name] = { name: name, tmpl: html, attrs: attrs, fn: fn }
   return name
@@ -110,6 +110,9 @@ riot.mount = function(selector, tagName, opts) {
   }
 
   // ----- mount code -----
+  
+  // inject styles into DOM
+  tagStyles.inject()
 
   if (typeof tagName === T_OBJECT) {
     opts = tagName

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -452,7 +452,7 @@ function startsWith(src, str) {
 /**
  * Function needed to inject in runtime the custom tags css
  */
-var injectStyle = (function() {
+var tagStyles = (function() {
 
   if (!window) return // skip injection on the server
 
@@ -468,16 +468,29 @@ var injectStyle = (function() {
     placeholder = null
   }
   else document.getElementsByTagName('head')[0].appendChild(styleNode)
-
-  /**
-   * This is the function exported that will be used to update the style tag just created
-   * innerHTML seems slow: http://jsperf.com/riot-insert-style
-   * @param   { String } css [description]
-   */
-  return styleNode.styleSheet ?
-    function (css) { styleNode.styleSheet.cssText += css } :
-    function (css) { styleNode.innerHTML += css }
-
+  
+  var stylesToInject = ""    
+  
+  return {
+    /**
+      * Save a tag style to be later injected into DOM
+      * @param   { String } css [description]
+      */
+    add: function(css) {
+      stylesToInject += css                          
+    },
+    
+    /**
+      * Inject all previously saved tag styles into DOM
+      * innerHTML seems slow: http://jsperf.com/riot-insert-style     
+      */
+    inject: function() {
+      if(styleNode.styleSheet) styleNode.styleSheet.cssText += stylesToInject  
+      else styleNode.innerHTML += stylesToInject
+      stylesToInject = ""           
+    }
+  }
+  
 })()
 
 /**

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -468,31 +468,31 @@ var tagStyles = (function() {
     placeholder = null
   }
   else document.getElementsByTagName('head')[0].appendChild(styleNode)
-  
-  var stylesToInject = ""    
-  
+
+  var stylesToInject = ''
+
   return {
     /**
       * Save a tag style to be later injected into DOM
       * @param   { String } css [description]
       */
     add: function(css) {
-      stylesToInject += css                          
+      stylesToInject += css
     },
-    
+
     /**
       * Inject all previously saved tag styles into DOM
-      * innerHTML seems slow: http://jsperf.com/riot-insert-style     
+      * innerHTML seems slow: http://jsperf.com/riot-insert-style
       */
     inject: function() {
-      if(stylesToInject) {
-        if(styleNode.styleSheet) styleNode.styleSheet.cssText += stylesToInject  
+      if (stylesToInject) {
+        if (styleNode.styleSheet) styleNode.styleSheet.cssText += stylesToInject
         else styleNode.innerHTML += stylesToInject
-        stylesToInject = "" 
-      }          
+        stylesToInject = ''
+      }
     }
   }
-  
+
 })()
 
 /**

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -485,9 +485,11 @@ var tagStyles = (function() {
       * innerHTML seems slow: http://jsperf.com/riot-insert-style     
       */
     inject: function() {
-      if(styleNode.styleSheet) styleNode.styleSheet.cssText += stylesToInject  
-      else styleNode.innerHTML += stylesToInject
-      stylesToInject = ""           
+      if(stylesToInject) {
+        if(styleNode.styleSheet) styleNode.styleSheet.cssText += stylesToInject  
+        else styleNode.innerHTML += stylesToInject
+        stylesToInject = "" 
+      }          
     }
   }
   


### PR DESCRIPTION
This PR allows tag styles to be mounted in batches, rather than one by one (see #1439).

`injectStyles` is now replaced with `tagStyles`. 

* When defining a tag with `riot.tag()`, `tagStyles.add(css)` is used to accumulated styles into the batch.
* When mounting tags with `riot.mount()`, `tagStyles.inject()` is used to inject the accumulated styles into the DOM and the batch is cleared.

I have assumed that `riot.mount()` is the right place/time when to inject styles. 

The only thing that isn't clear to me is why the old code checked for `injectStyles` to be defined:
```
else if (injectStyles) injectStyles(css)
```
```
if (css && injectStyles) injectStyles(css)
```
I have maintained the check, but I guess it's superfluous?





