### PR TITLE
riot.mount with querySelector like `tag[name="some-name"]` had failed…

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -84,7 +84,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g,'\\"') + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g, '\\"') + '"]'
     })
     return list
   }

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -84,7 +84,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim() + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g,'\\"') + '"]'
     })
     return list
   }

--- a/riot+compiler.js
+++ b/riot+compiler.js
@@ -2274,7 +2274,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g,'\\"') + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g, '\\"') + '"]'
     })
     return list
   }

--- a/riot+compiler.js
+++ b/riot+compiler.js
@@ -2274,7 +2274,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim() + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g,'\\"') + '"]'
     })
     return list
   }

--- a/riot.js
+++ b/riot.js
@@ -2274,7 +2274,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g,'\\"') + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g, '\\"') + '"]'
     })
     return list
   }

--- a/riot.js
+++ b/riot.js
@@ -2274,7 +2274,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim() + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g,'\\"') + '"]'
     })
     return list
   }


### PR DESCRIPTION
… because of double quotes...

```javascript
riot.mount('rt-pony-login[pid="2"]', opts);
```
When I ran this code exception was raised...