### PR TITLE
micro-op for yield and tmpl

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -48,7 +48,8 @@ function Tag(impl, conf, innerHTML) {
 
     // update opts from current DOM attributes
     each(root.attributes, function(el) {
-      opts[toCamel(el.name)] = tmpl(el.value, ctx)
+      var val = el.value
+      opts[toCamel(el.name)] = tmpl.hasExpr(val) ? tmpl(val, ctx) : val
     })
     // recover those with expressions
     each(Object.keys(attr), function(name) {

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -337,6 +337,8 @@ function mkElWithInnerHTML(name, innerHTML) {
  * @returns { String } tag template updated without the yield tag
  */
 function replaceYield(tmpl, innerHTML) {
+  if (!/<yield\b/i.test(tmpl)) return tmpl
+
   var tmplElement = mkElWithInnerHTML('div', tmpl)
   // if ($('yield[from]'.tmplElement)) { // this issues test errors
   if (tmplElement.querySelector && tmplElement.querySelector('yield[from]')) { // code coverage path not taken (?)
@@ -350,9 +352,9 @@ function replaceYield(tmpl, innerHTML) {
       }
     })
     return tmplElement.innerHTML
-  } else
-    // just replace yield in tmpl with the innerHTML
-    return tmpl.replace(/<yield\s*(?:\/>|>\s*<\/yield\s*>)/gi, innerHTML || '')
+  }
+  // just replace yield in tmpl with the innerHTML
+  return tmpl.replace(/<yield\s*(?:\/>|>\s*<\/yield\s*>)/gi, innerHTML || '')
 }
 
 /**


### PR DESCRIPTION
This pr avoids the creation of dom elements when there's no yield in a template, this is expensive in mobile environments.
Also, prevents tmpl instantiate functions unnecessarily.