### PR TITLE
avoids iOS bug in rAF

### DIFF
--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -481,13 +481,23 @@ var injectStyle = (function() {
 })()
 
 /**
- * requestAnimationFrame polyfill
+ * requestAnimationFrame function
+ * Adapted from https://gist.github.com/paulirish/1579671, license MIT
  */
-var rAF = (function(w) {
-  return  w.requestAnimationFrame       ||
-          w.webkitRequestAnimationFrame ||
-          w.mozRequestAnimationFrame    ||
-          function(cb) { setTimeout(cb, 1000 / 60) }
+var rAF = (function (w) {
+  var raf = w.requestAnimationFrame    ||
+            w.mozRequestAnimationFrame || w.webkitRequestAnimationFrame
+
+  if (!raf || /iP(ad|hone|od).*OS 6/.test(w.navigator.userAgent)) {  // buggy iOS6
+    var lastTime = 0
+
+    raf = function (cb) {
+      var nowtime = Date.now(), timeout = Math.max(16 - (nowtime - lastTime), 0)
+      setTimeout(function () { cb(lastTime = nowtime + timeout) }, timeout)
+    }
+  }
+  return raf
+
 })(window || {})
 
 /**


### PR DESCRIPTION
This PR prevents a bug in iOS 6 and has a micro-op in sync times.

See:
https://bugs.webkit.org/show_bug.cgi?id=132794
https://gist.github.com/KrofDrakula/5318048
http://paulirish.com/2011/requestanimationframe-for-smart-animating/
http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
