### PR TITLE
addRiotTags() should escape double quotes in search query `tag[name="…

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -84,7 +84,7 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      list += ', *[' + RIOT_TAG + '="' + e.trim() + '"]'
+      list += ', *[' + RIOT_TAG + '="' + e.trim().replace(/"/g, '\\"') + '"]'
     })
     return list
   }


### PR DESCRIPTION
…some-name"]`

All details in previous PR https://github.com/riot/riot/pull/1446