### PR TITLE
Dynamic CSS - fixed test for IE9/10

### DIFF
--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -972,8 +972,9 @@ describe('Compiler Browser', function() {
     }
 
     // test style defined but string replacement not occurred yet
+    // in IE9/10 incorrect styles are erased, other browsers retain them
     var styles = getRiotStyles()
-    expect(styles).to.match(/\bparsed-style\s*\{\s*color:\s*@varcolor;\s*}/)
+    expect(styles).to.match(/\bparsed-style\s*\{((\s*color:\s*@varcolor;\s*)|(\s*))}/)
 
     // test style parsing during mount
     riot.styleNode.updateStyles()

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -959,44 +959,57 @@ describe('Compiler Browser', function() {
     tags.push(tag)
   })
 
-  it('parser function in global style node', function() {
+  it('runtime parsed styles', function() {
 
+    // test riot.styleNode
     expect(riot.styleNode).to.not.be(undefined)
     expect(riot.styleNode.tagName).to.be('STYLE')
     expect(riot.styleNode.updateStyles).to.be.an('function')
 
+    // set a style parsing function before mounting the tag
     var varcolor = 'red'
-
     riot.styleNode.parser = function(css)  {
       return css.replace(/@varcolor/, varcolor)
     }
 
-    // test style defined but string replacement not occurred yet
-    // in IE9/10 incorrect styles are erased, other browsers retain them
-    var styles = getRiotStyles()
-    expect(styles).to.match(/\bparsed-style\s*\{((\s*color:\s*@varcolor;\s*)|(\s*))}/)
+    // test style isn't injected yet
+    styles = getRiotStyles()
+    expect(styles).not.to.match(/\bparsed-style\s*\{/)
 
-    // test style parsing during mount
-    riot.styleNode.updateStyles()
-    var tag = riot.mount('style-parser')[0]
+    // define a dynamically parsed style tag
+    riot.tag('runtime-style-parsing', '<div></div>', '.parsed-style { color: @varcolor; }', '', function(opts) { })
+
+    // test style isn't injected by the simple tag definition
+    styles = getRiotStyles()
+    expect(styles).not.to.match(/\bparsed-style\s*\{/)
+
+    // mount the tag
+    injectHTML(['<runtime-style-parsing></runtime-style-parsing>' ])
+    var tag = riot.mount('runtime-style-parsing')[0]
+
+    // test style correctly parsed and injected
     styles = getRiotStyles()
     expect(styles).to.match(/\bparsed-style\s*\{\s*color:\s*red;\s*}/)
 
-    // test style parsing after manual update
+    // manual update of style
     varcolor = 'green'
     riot.styleNode.updateStyles()
+
+    // test style parsing after manual update
     styles = getRiotStyles()
+    expect(styles).not.to.match(/\bparsed-style\s*\{\s*color:\s*red;\s*}/)
     expect(styles).to.match(/\bparsed-style\s*\{\s*color:\s*green;\s*}/)
+
+    // remount (unmount+mount)
+    tag.unmount()
+    tag = riot.mount('runtime-style-parsing')[0]
 
     // test remount does not affect style
-    tag.unmount()
-    injectHTML('<style-parser></style-parser>')
-    var tag2 = riot.mount('style-parser')[0]
     styles = getRiotStyles()
     expect(styles).to.match(/\bparsed-style\s*\{\s*color:\s*green;\s*}/)
-    expect(styles.match(/\bparsed-style\s*\{/g)).to.have.length(1)
-    tags.push(tag2)
 
+    // test remount does not duplicate rule
+    expect(styles.match(/\bparsed-style\s*\{/g)).to.have.length(1)
   })
 
   it('preserve attributes from tag definition', function() {

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -67,9 +67,6 @@ loadTagsAndScripts([
   'tag/~style-tag3.tag',
   'tag/style-tag4.tag',
 
-  // check parser function on global style tag
-  'tag/style-parser.tag',
-
   'tag/preserve-attr.tag',
 
   // these tags will be not autoinjected in the DOM

--- a/test/tag/style-parser.tag
+++ b/test/tag/style-parser.tag
@@ -1,7 +1,0 @@
-<style-parser>
-  <style>
-     .parsed-style {
-	     color: @varcolor;
-	   }
-  </style>  
-</style-parser>


### PR DESCRIPTION
This makes test work also for IE9/10 for #1449. Failing test was due to the fact that in IE9/10 incorrect styles are erased, while all other browsers retain them.