### PR TITLE
Fixes #1458 yield with nested tags

### DIFF
--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -347,9 +347,7 @@ function replaceYield(tmpl, innerHTML) {
       for (var t=0;t<yieldFrom.length;t++) {
         var node = yieldFrom[t]
         var toNodes = sourceElement.querySelectorAll('yield[to="'+node.getAttribute('from')+'"]')
-        if (toNodes.length==1) {
-          node.outerHTML = toNodes[0].innerHTML
-        }
+        node.outerHTML = toNodes.length ? toNodes[0].innerHTML : ''
       }
       return tmplElement.innerHTML
     }

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -318,42 +318,44 @@ function mkEl(name) {
 }
 
 /**
- * Create a generic DOM node, and fill it with innerHTML
- * @param   { String } name - name of the DOM node we want to create
- * @param   { String } innerHTML - innerHTML of the new DOM
- * @returns { Object } DOM node just created
- */
-function mkElWithInnerHTML(name, innerHTML) {
-  var el = mkEl(name)
-  el.innerHTML = innerHTML || ''
-  return el
-}
-
-/**
  * Replace the yield tag from any tag template with the innerHTML of the
  * original tag in the page
  * @param   { String } tmpl - tag implementation template
  * @param   { String } innerHTML - original content of the tag in the DOM
  * @returns { String } tag template updated without the yield tag
  */
+
 function replaceYield(tmpl, innerHTML) {
+  // do nothing if no yield
   if (!/<yield\b/i.test(tmpl)) return tmpl
 
-  var tmplElement = mkElWithInnerHTML('div', tmpl)
-  // if ($('yield[from]'.tmplElement)) { // this issues test errors
-  if (tmplElement.querySelector && tmplElement.querySelector('yield[from]')) { // code coverage path not taken (?)
-    // yield to(s) must be direct children from innerHTML(root), all other tags are ignored
-    each(mkElWithInnerHTML('div', innerHTML).childNodes, function(toYield) {
-      if (toYield.nodeType == 1 && toYield.tagName == 'YIELD' && toYield.getAttribute('to')) {
-        // replace all yield[from]
-        each($$('yield[from="'+toYield.getAttribute('to')+'"]', tmplElement), function(fromYield) {
-          fromYield.outerHTML = toYield.innerHTML
-        })
-      }
-    })
-    return tmplElement.innerHTML
+  function mkElWithInnerHTML(name, innerHTML) {
+    var el = mkEl(name)
+    el.innerHTML = innerHTML || ''
+    return el
   }
-  // just replace yield in tmpl with the innerHTML
+
+  // create a temporary element out of template
+  var tmplElement = mkElWithInnerHTML('div', tmpl)
+
+  if (tmplElement.querySelector) {
+    // get all yield[from]
+    var yieldFrom = tmplElement.querySelectorAll('yield[from]')
+
+    if (yieldFrom.length>0) {
+      var sourceElement = mkElWithInnerHTML('div', innerHTML)
+      for (var t=0;t<yieldFrom.length;t++) {
+        var node = yieldFrom[t]
+        var toNodes = sourceElement.querySelectorAll('yield[to="'+node.getAttribute('from')+'"]')
+        if (toNodes.length==1) {
+          node.outerHTML = toNodes[0].innerHTML
+        }
+      }
+      return tmplElement.innerHTML
+    }
+  }
+
+  // yield without any "from", replace yield in tmpl with the innerHTML
   return tmpl.replace(/<yield\s*(?:\/>|>\s*<\/yield\s*>)/gi, innerHTML || '')
 }
 

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -758,9 +758,9 @@ describe('Compiler Browser', function() {
   })
 
   it('<yield> from/to multi-transclusion', function() {
-    injectHTML('<yield-multi><yield to="content">content</yield></yield-multi>')
+    injectHTML('<yield-multi><yield to="content">content</yield><yield to="nested-content">content</yield></yield-multi>')
     var tag = riot.mount('yield-multi', {})[0]
-    expect(normalizeHTML(tag.root.innerHTML)).to.be('<p>yield the content here</p>')
+    expect(normalizeHTML(tag.root.innerHTML)).to.be('<p>yield the content here</p><div><p>yield the nested content here</p></div>')
     tags.push(tag)
   })
 

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -758,9 +758,9 @@ describe('Compiler Browser', function() {
   })
 
   it('<yield> from/to multi-transclusion', function() {
-    injectHTML('<yield-multi><yield to="content">content</yield><yield to="nested-content">content</yield></yield-multi>')
+    injectHTML('<yield-multi><yield to="content">content</yield><yield to="nested-content">content</yield><yield to="nowhere">content</yield></yield-multi>')
     var tag = riot.mount('yield-multi', {})[0]
-    expect(normalizeHTML(tag.root.innerHTML)).to.be('<p>yield the content here</p><div><p>yield the nested content here</p></div>')
+    expect(normalizeHTML(tag.root.innerHTML)).to.be('<p>yield the content here</p><div><p>yield the nested content here</p><p>do not yield the unreference content here</p></div>')
     tags.push(tag)
   })
 

--- a/test/tag/yield-multi.tag
+++ b/test/tag/yield-multi.tag
@@ -2,5 +2,6 @@
   <p>yield the <yield from="content" /> here</p>
   <div>
      <p>yield the nested <yield from="nested-content" /> here</p>
+     <p>do not yield the unreference content <yield from="unreferenced-content" />here</p>
   </div>
 </yield-multi>

--- a/test/tag/yield-multi.tag
+++ b/test/tag/yield-multi.tag
@@ -1,4 +1,6 @@
 <yield-multi>
   <p>yield the <yield from="content" /> here</p>
-
+  <div>
+     <p>yield the nested <yield from="nested-content" /> here</p>
+  </div>
 </yield-multi>


### PR DESCRIPTION
I've rewritten the yield from/to part:
- fixed the bug 
- `mkElWithInnerHTML()` made private 
- modified the test case to include nested/multiple yields

What is not clear to me is if we can use `querySelectorAll()`, because when running on server it's undefined. 

