### PR TITLE
replaceYield with regex

### DIFF
--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -17,25 +17,29 @@ var mkdom = (function (checkIE) {
       tbody: 'table',
       col: 'colgroup'
     },
+    reToSrc = /<yield\s+to=(['"])?@\1\s*>([\S\s]+?)<\/yield\s*>/.source,
     GENERIC = 'div'
 
   checkIE = checkIE && checkIE < 10
 
   // creates any dom element in a div, table, or colgroup container
-  function _mkdom(html) {
+  function _mkdom(templ, html) {
 
-    var match = html && html.match(/^\s*<([-\w]+)/),
+    var match = templ && templ.match(/^\s*<([-\w]+)/),
       tagName = match && match[1].toLowerCase(),
       rootTag = rootEls[tagName] || GENERIC,
       el = mkEl(rootTag)
 
     el.stub = true
 
+    // replace all the yield tags with the tag inner html
+    if (html) templ = replaceYield(templ, html)
+
     /* istanbul ignore next */
     if (checkIE && tagName && (match = tagName.match(SPECIAL_TAGS_REGEX)))
-      ie9elem(el, html, tagName, !!match[1])
+      ie9elem(el, templ, tagName, !!match[1])
     else
-      el.innerHTML = html
+      el.innerHTML = templ
 
     return el
   }
@@ -56,6 +60,30 @@ var mkdom = (function (checkIE) {
 
   }
   // end ie9elem()
+
+  /**
+   * Replace the yield tag from any tag template with the innerHTML of the
+   * original tag in the page
+   * @param   { String } templ - tag implementation template
+   * @param   { String } html  - original content of the tag in the DOM
+   * @returns { String } tag template updated without the yield tag
+   */
+  function replaceYield(templ, html) {
+    // do nothing if no yield
+    if (!/<yield\b/i.test(templ)) return templ
+
+    // be careful with #1343 - string on the source having `$1`
+    var n = 0
+    templ = templ.replace(/<yield\s+from=['"]([-\w]+)['"]\s*(?:\/>|>\s*<\/yield\s*>)/ig,
+      function (str, ref) {
+        var m = html.match(RegExp(reToSrc.replace('@', ref), 'i'))
+        ++n
+        return m && m[2] || ''
+      })
+
+    // yield without any "from", replace yield in templ with the innerHTML
+    return n ? templ : templ.replace(/<yield\s*(?:\/>|>\s*<\/yield\s*>)/gi, html || '')
+  }
 
   return _mkdom
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -2,7 +2,6 @@ function Tag(impl, conf, innerHTML) {
 
   var self = riot.observable(this),
     opts = inherit(conf.opts) || {},
-    dom = mkdom(impl.tmpl),
     parent = conf.parent,
     isLoop = conf.isLoop,
     hasImpl = conf.hasImpl,
@@ -13,7 +12,8 @@ function Tag(impl, conf, innerHTML) {
     fn = impl.fn,
     tagName = root.tagName.toLowerCase(),
     attr = {},
-    propsInSyncWithParent = []
+    propsInSyncWithParent = [],
+    dom
 
   if (fn && root._tag) root._tag.unmount(true)
 
@@ -38,9 +38,7 @@ function Tag(impl, conf, innerHTML) {
     if (tmpl.hasExpr(val)) attr[el.name] = val
   })
 
-  if (dom.innerHTML && !/^(select|optgroup|table|tbody|tr|col(?:group)?)$/.test(tagName))
-    // replace all the yield tags with the tag inner html
-    dom.innerHTML = replaceYield(dom.innerHTML, innerHTML)
+  dom = mkdom(impl.tmpl, innerHTML)
 
   // options
   function updateOpts() {

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -319,48 +319,6 @@ function mkEl(name) {
 }
 
 /**
- * Replace the yield tag from any tag template with the innerHTML of the
- * original tag in the page
- * @param   { String } tmpl - tag implementation template
- * @param   { String } innerHTML - original content of the tag in the DOM
- * @returns { String } tag template updated without the yield tag
- */
-
-function replaceYield(tmpl, innerHTML) {
-  // do nothing if no yield
-  if (!/<yield\b/i.test(tmpl)) return tmpl
-
-  function mkElWithInnerHTML(name, innerHTML) {
-    var el = mkEl(name)
-    el.innerHTML = innerHTML || ''
-    return el
-  }
-
-  // create a temporary element out of template
-  var tmplElement = mkElWithInnerHTML('div', tmpl),
-    t = 0,
-    yieldFrom, sourceElement, node, toNodes
-
-  if (tmplElement.querySelector) {
-    // get all yield[from]
-    yieldFrom = $$('yield[from]', tmplElement)
-
-    if (yieldFrom.length>0) {
-      sourceElement = mkElWithInnerHTML('div', innerHTML)
-      for (;t < yieldFrom.length; t++) {
-        node = yieldFrom[t]
-        toNodes = $$('yield[to="'+ getAttr(node, 'from') +'"]', sourceElement)
-        node.outerHTML = toNodes.length ? toNodes[0].innerHTML : ''
-      }
-      return tmplElement.innerHTML
-    }
-  }
-
-  // yield without any "from", replace yield in tmpl with the innerHTML
-  return tmpl.replace(/<yield\s*(?:\/>|>\s*<\/yield\s*>)/gi, innerHTML || '')
-}
-
-/**
  * Shorter and fast way to select multiple nodes in the DOM
  * @param   { String } selector - DOM selector
  * @param   { Object } ctx - DOM node where the targets of our search will is located

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -764,6 +764,30 @@ describe('Compiler Browser', function() {
     tags.push(tag)
   })
 
+  it('<yield> from/to multi-transclusion nested #1458', function() {
+    var html = [
+      '<yield-multi2>',
+      '  <yield to="options">',
+      '    <ul>',
+      '      <li>Option 1</li>',
+      '      <li>Option 2</li>',
+      '    </ul>',
+      '  </yield>',
+      '  <div>',
+      '    <yield to="toggle"><span class="icon"></span></yield>',
+      '    <yield to="hello">Hello</yield><yield to="world">World</yield>',
+      '    <yield to="hello">dummy</yield>',
+      '  </div>',
+      '</yield-multi2>'
+    ]
+    injectHTML(html.join('\n'))
+    expect($('yield-multi2')).not.to.be(null)
+    var tag = riot.mount('yield-multi2', {})[0]
+    html = '<ul><li>Option 1</li><li>Option 2</li></ul><span class="icon"></span><p>Hello World</p>'
+    expect(normalizeHTML(tag.root.innerHTML)).to.be(html)
+    tags.push(tag)
+  })
+
   it('multiple mount <yield> tag', function() {
 
     riot.mount('inner-html')

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -103,6 +103,10 @@ loadTagsAndScripts([
     path: 'tag/yield-multi.tag',
     name: false
   },
+  {
+    path: 'tag/yield-multi2.tag',
+    name: false
+  },
 
   // the following tags will be injected having custom attributes
   {

--- a/test/tag/yield-multi2.tag
+++ b/test/tag/yield-multi2.tag
@@ -1,0 +1,5 @@
+<yield-multi2>
+  <yield from="options"></yield>
+  <yield from="toggle"></yield>
+  <p><yield from="hello"/> <yield from="world"/></p>
+</yield-multi2>


### PR DESCRIPTION
First try, apparently it is working properly.
The replacement is carried out before ~~monting on~~ injecting the html content into the DOM, so it is slightly faster and less restrictive.