### PR TITLE
Adding riot.renderAsync

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -34,6 +34,15 @@ riot.render = function(tagName, opts) {
   return html
 }
 
+riot.renderAsync = function(tagName, opts, cb) {
+  opts.asyncDone = function(){
+    var html = sdom.serialize(tag.root);
+    tag.unmount();
+    cb(html);
+  }
+  var tag = createTag(tagName, opts);
+}
+
 riot.render.dom = function(tagName, opts) {
   return createTag(tagName, opts).root
 }


### PR DESCRIPTION
A first whack at adding `riot.renderAsync` so that riot tags can complete async functions as part of server-side rendering.