### PR TITLE
Prevent loop state from leaking out and getting modified.

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -22,8 +22,10 @@ function mkitem(expr, key, val) {
  * Unmount the redundant tags
  * @param   { Array } items - array containing the current items to loop
  * @param   { Array } tags - array containing all the children tags
+ * @param   { String } tagName - key used to identify the type of tag
+ * @param   { Object } parent - parent tag to remove the child from
  */
-function unmountRedundant(items, tags) {
+function unmountRedundant(items, tags, tagName, parent) {
 
   var i = tags.length,
     j = items.length,
@@ -33,6 +35,7 @@ function unmountRedundant(items, tags) {
     t = tags[--i]
     tags.splice(i, 1)
     t.unmount()
+    removeChildTag(t, tagName, parent)
   }
 }
 
@@ -188,6 +191,7 @@ function _each(dom, parent, expr) {
         }
 
         tags.splice(i, 0, tag)
+        if (child) addChildTag(tag, tagName, parent, true)
         pos = i // handled here so no move
       } else tag.update(item)
 
@@ -218,18 +222,11 @@ function _each(dom, parent, expr) {
     }, true) // allow null values
 
     // remove the redundant tags
-    unmountRedundant(items, tags)
+    unmountRedundant(items, tags, tagName, parent)
 
     // insert the new nodes
     if (isOption) root.appendChild(frag)
     else root.insertBefore(frag, ref)
-
-    // set the 'tags' property of the parent tag
-    // if child is 'undefined' it means that we don't need to set this property
-    // for example:
-    // we don't need store the `myTag.tags['div']` property if we are looping a div tag
-    // but we need to track the `myTag.tags['child']` property looping a custom child node named `child`
-    if (child) parent.tags[tagName] = tags
 
     // clone the items array
     oldItems = items.slice()

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -205,19 +205,8 @@ function Tag(impl, conf, innerHTML) {
 
       if (parent) {
         ptag = getImmediateCustomParentTag(parent)
-        // remove this tag from the parent tags object
-        // if there are multiple nested tags with same name..
-        // remove this element form the array
-        if (isArray(ptag.tags[tagName]))
-          each(ptag.tags[tagName], function(tag, i) {
-            if (tag._riot_id == self._riot_id)
-              ptag.tags[tagName].splice(i, 1)
-          })
-        else
-          // otherwise just delete the tag instance
-          ptag.tags[tagName] = undefined
+        removeChildTag(self, tagName, ptag)
       }
-
       else
         while (el.firstChild) el.removeChild(el.firstChild)
 

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -75,9 +75,14 @@ function getTag(dom) {
  * @param   { Object } tag - child tag instance
  * @param   { String } tagName - key where the new tag will be stored
  * @param   { Object } parent - tag instance where the new child tag will be included
+ * @param   { Boolean } ensureArray - force the value on tags to be an array
  */
-function addChildTag(tag, tagName, parent) {
+function addChildTag(tag, tagName, parent, ensureArray) {
   var cachedTag = parent.tags[tagName]
+
+  if (ensureArray && !isArray(cachedTag)) {
+    parent.tags[tagName] = cachedTag ? [cachedTag] : []
+  }
 
   // if there are multiple children tags having the same name
   if (cachedTag) {
@@ -112,6 +117,18 @@ function moveChildTag(tag, tagName, newPos) {
   if (isArray(tags))
     tags.splice(newPos, 0, tags.splice(tags.indexOf(tag), 1)[0])
   else addChildTag(tag, tagName, parent)
+}
+
+function removeChildTag(tag, tagName, parent) {
+  if (isArray(parent.tags[tagName])) {
+    each(parent.tags[tagName], function(t, i) {
+      if (t._riot_id == tag._riot_id)
+        parent.tags[tagName].splice(i, 1)
+    })
+  }
+  else
+    // otherwise just delete the tag instance
+    parent.tags[tagName] = undefined
 }
 
 /**

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -468,6 +468,20 @@ describe('Compiler Browser', function() {
 
   })
 
+  it('tags in different each loops dont collide', function() {
+
+    var tag = riot.mount('loop-combo')[0]
+    tags.push(tag)
+
+    expect(normalizeHTML(tag.root.innerHTML))
+      .to.be('<lci x="a"></lci><div><lci x="y"></lci></div>')
+
+    tag.update({b: ['z']})
+
+    expect(normalizeHTML(tag.root.innerHTML))
+      .to.be('<lci x="a"></lci><div><lci x="z"></lci></div>')
+  })
+
   it('iterate over an object, then modify the property and update itself', function() {
 
     var tag = riot.mount('loop-object')[0]

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -4,6 +4,7 @@ loadTagsAndScripts([
   'tag/~custom-parsers.tag',
   'tag/loop.tag',
   'tag/loop-child.tag',
+  'tag/loop-combo.tag',
   'tag/loop-reorder.tag',
   'tag/loop-manip.tag',
   'tag/loop-object.tag',

--- a/test/tag/loop-combo.tag
+++ b/test/tag/loop-combo.tag
@@ -1,0 +1,14 @@
+
+<loop-combo>
+  <lci x={x} each={x in a} />
+
+  <div each={x in b}>
+    <lci x={x} />
+  </div>
+
+  this.a = ['a']
+  this.b = ['y']
+</loop-combo>
+
+<lci>
+</lci>

--- a/test/tags.html
+++ b/test/tags.html
@@ -28,6 +28,7 @@
     <loop-replace></loop-replace>
     <touch-events></touch-events>
     <lazy-if></lazy-if>
+    <loop-combo></loop-combo>
     <loop-multi></loop-multi>
     <loop-context></loop-context>
     <loop-option></loop-option>


### PR DESCRIPTION
`each` has it's own array that tracks the tags for every item. This array was being assigned to the parent's `tags` collection, thus leaking outside of `each`.

If another instance of that tag is created outside the loop, it gets added to that array (by addChildTag). Now, when `each` wants to remove tags (because items have changed) it will inadvertently remove the instance that was created outside the loop.

Instead of just setting parent.tags, use the addChildTag and removeChildTag to modify the parent's collection. This has the downside that parent.tags order won't match DOM order, but it's much less code.

Fixes #1519