### PR TITLE
Handle rare edge case where tag.tags is not set

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -206,7 +206,7 @@ function _each(dom, parent, expr) {
         oldItems.splice(i, 0, oldItems.splice(pos, 1)[0])
         // if the loop tags are not custom
         // we need to move all their custom tags into the right position
-        if (!child) moveNestedTags(tag, i)
+        if (!child && tag.tags) moveNestedTags(tag, i)
       }
 
       // cache the original item to use it in the events bound to this node

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1791,4 +1791,12 @@ it('raw contents', function() {
 
   })
 
+  it('still loops with reserved property names #1526', function() {
+    var tag = riot.mount('reserved-names')[0]
+    tag.reorder()
+    tag.update()
+    tag.reorder()
+    tag.update()
+  })
+
 })

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -70,6 +70,8 @@ loadTagsAndScripts([
 
   'tag/preserve-attr.tag',
 
+  'tag/reserved-names.tag',
+
   // these tags will be not autoinjected in the DOM
   // that's what `name = false` means
   {

--- a/test/tag/reserved-names.tag
+++ b/test/tag/reserved-names.tag
@@ -1,0 +1,18 @@
+<reserved-names>
+    <p>Looping over an array containing objects w/ reserved property names</p>
+    <ul each={items}>
+        <li>{name}: {String(tags)}</li>
+    </ul>
+    <button onclick={reorder}>Reorder</button>
+    <script>
+        this.items = [
+            {name: "item 1", tags: null},
+            {name: "item 2", tags: ["a", "b", "c"]},
+            {name: "item3"}
+        ]
+
+        reorder() {
+            this.items.reverse()
+        }
+    </script>
+</reserved-names>

--- a/test/tags.html
+++ b/test/tags.html
@@ -70,6 +70,7 @@
 
     <loop-numbers-nested></loop-numbers-nested>
     <loop-conditional></loop-conditional>
+    <reserved-names></reserved-names>
 
   </div>
 


### PR DESCRIPTION
In some cases, a tag object's `tags` property won't get set, which causes an exception in `moveNestedTags()`.

This is a strange bug that only occured after downloading and displaying a large amount of data from a server, therefore I couldn't yet reproduce it in a small and controlled setting. This fix, however, will most likely not break anything.