### PR TITLE
New syntax for this.mixin to reflect riot.mixin

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -101,7 +101,7 @@ function Tag(impl, conf, innerHTML, mixins) {
   })
 
   defineProperty(this, 'mixin', function(mixins) {
-    each([].concat(mixins), function(mix) {
+    each(arguments.length > 1 ? arguments : [].concat(mixins), function(mix) {
       var instance
 
       mix = typeof mix === T_STRING ? riot.mixin(mix) : mix

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -100,8 +100,8 @@ function Tag(impl, conf, innerHTML, mixins) {
     return this
   })
 
-  defineProperty(this, 'mixin', function() {
-    each(arguments, function(mix) {
+  defineProperty(this, 'mixin', function(mixins) {
+    each([].concat(mixins), function(mix) {
       var instance
 
       mix = typeof mix === T_STRING ? riot.mixin(mix) : mix
@@ -117,10 +117,10 @@ function Tag(impl, conf, innerHTML, mixins) {
       // loop the keys in the function prototype or the all object keys
       each(Object.getOwnPropertyNames(mix), function(key) {
         // bind methods to self
-        if (key != 'init')
-          self[key] = isFunction(instance[key]) ?
-                        instance[key].bind(self) :
-                        instance[key]
+        if (key == 'init') return
+        self[key] = isFunction(instance[key])
+                      ? instance[key].bind(self)
+                      : instance[key]
       })
 
       // init method will be called automatically


### PR DESCRIPTION
Discused on #1510, this commit brings syntax from `riot.mixin` to `this.mixin`, so instead of multiple arguments

    this.mixin(mixin1, mixin2, 'shared_mixin1', ...)
now we have single array of mixins, with backwards compatibility with "old" syntax

    this.mixin([mixin1, mixin2, 'shared_mixin1', ...])

or single mixin: 

    this.mixin(mixin)