### PR TITLE
Don't update expressions or tags within a false if-attribute.

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -117,6 +117,7 @@ function _each(dom, parent, expr) {
 
   // parse the each expression
   expr = tmpl.loopKeys(expr)
+  expr.isLoop = true
 
   // insert a marked where the loop tags will be injected
   root.insertBefore(ref, dom)
@@ -127,8 +128,9 @@ function _each(dom, parent, expr) {
     // remove the original DOM node
     dom.parentNode.removeChild(dom)
     if (root.stub) root = parent.root
+  })
 
-  }).on('update', function () {
+  expr.update = function () {
     // get the new items collection
     var items = tmpl(expr.val, parent),
       // create a fragment to hold the new DOM nodes to inject in the parent tag
@@ -152,7 +154,7 @@ function _each(dom, parent, expr) {
         oldPos = oldItems.indexOf(item),
         pos = ~oldPos && _mustReorder ? oldPos : i,
         // does a tag exist in this position?
-        tag = tags[pos]
+        tag = tags[pos], domToInsert
 
       item = !hasKeys && expr.key ? mkitem(expr, item, i) : item
 
@@ -172,18 +174,19 @@ function _each(dom, parent, expr) {
         }, dom.innerHTML)
 
         tag.mount()
+        domToInsert = tag.stub || tag.root
         if (isVirtual) tag._root = tag.root.firstChild // save reference for further moves or inserts
         // this tag must be appended
         if (i == tags.length) {
           if (isVirtual)
             addVirtual(tag, frag)
-          else frag.appendChild(tag.root)
+          else frag.appendChild(domToInsert)
         }
         // this tag must be insert
         else {
           if (isVirtual)
             addVirtual(tag, root, tags[i])
-          else root.insertBefore(tag.root, tags[i].root)
+          else root.insertBefore(domToInsert, tags[i].root)
           oldItems.splice(i, 0, item)
         }
 
@@ -233,7 +236,7 @@ function _each(dom, parent, expr) {
 
     // clone the items array
     oldItems = items.slice()
+  }
 
-  })
-
+  return expr
 }

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -1,65 +1,54 @@
-
-
-function parseNamedElements(root, tag, childTags, forceParsingNamed) {
-
-  walk(root, function(dom) {
-    if (dom.nodeType == 1) {
-      dom.isLoop = dom.isLoop ||
-                  (dom.parentNode && dom.parentNode.isLoop || getAttr(dom, 'each'))
-                    ? 1 : 0
-
-      // custom child tag
-      if (childTags) {
-        var child = getTag(dom)
-
-        if (child && !dom.isLoop)
-          childTags.push(initChildTag(child, {root: dom, parent: tag}, dom.innerHTML, tag))
-      }
-
-      if (!dom.isLoop || forceParsingNamed)
-        setNamed(dom, tag, [])
-    }
-
-  })
-
-}
-
 function parseExpressions(root, tag, expressions) {
+  var base = {parent: {children: expressions}}
 
-  function addExpr(dom, val, extra) {
-    if (tmpl.hasExpr(val)) {
-      expressions.push(extend({ dom: dom, expr: val }, extra))
-    }
-  }
-
-  walk(root, function(dom) {
-    var type = dom.nodeType,
-      attr
+  walk(root, function(dom, ctx) {
+    var type = dom.nodeType, parent = ctx.parent, attr, expr
 
     // text node
-    if (type == 3 && dom.parentNode.tagName != 'STYLE') addExpr(dom, dom.nodeValue)
-    if (type != 1) return
+    if (type == 3 && dom.parentNode.tagName != 'STYLE' && tmpl.hasExpr(dom.nodeValue))
+      parent.children.push({dom: dom, expr: dom.nodeValue})
 
-    /* element */
+    if (type != 1) return ctx // not an element
 
-    // loop
-    attr = getAttr(dom, 'each')
+    // loop. each does it's own thing (for now)
+    if (attr = getAttr(dom, 'each')) {
+      parent.children.push(_each(dom, tag, attr))
+      return false
+    }
 
-    if (attr) { _each(dom, tag, attr); return false }
+    // if-attrs become the new parent. Any following expressions (either on the current
+    // element, or below it) become children of this expression.
+    if (expr = getAttr(dom, 'if')) {
+      remAttr(dom, 'if')
+      attr = {isIf: true, expr: expr, dom: dom, children: []}
+      parent.children.push(attr)
+      parent = attr
+    }
+
+    if (expr = getNamedKey(dom)) {
+      parent.children.push({isNamed: true, dom: dom, expr: expr})
+    }
+
+    // if this is a tag, stop traversing here.
+    // we ignore the root, since parseExpressions is called while we're mounting that root
+    var tagImpl = getTag(dom)
+    if (tagImpl && dom !== root) {
+      parent.children.push({isTag: true, dom: dom, impl: tagImpl})
+      return false
+    }
 
     // attribute expressions
     each(dom.attributes, function(attr) {
-      var name = attr.name,
-        bool = name.split('__')[1]
+      var name = attr.name, bool = name.split('__')[1]
+      if (!tmpl.hasExpr(attr.value)) return // no expressions here
 
-      addExpr(dom, attr.value, { attr: bool || name, bool: bool })
+      expr = {dom: dom, expr: attr.value, attr: bool || attr.name, bool: bool}
+      parent.children.push(expr)
       if (bool) { remAttr(dom, name); return false }
-
     })
 
-    // skip custom tags
-    if (getTag(dom)) return false
-
-  })
-
+    // whatever the parent is, all child elements get the same parent.
+    // If this element had an if-attr, that's the parent for all child elements
+    return {parent: parent}
+  }, base)
 }

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -136,18 +136,18 @@ function Tag(impl, conf, innerHTML) {
     // initialiation
     if (fn) fn.call(self, opts)
 
-    // parse layout after init. fn may calculate args for nested custom tags
-    parseExpressions(dom, self, expressions)
-
-    // mount the child tags
-    toggle(true)
-
     // update the root adding custom attributes coming from the compiler
     // it fixes also #1087
     if (impl.attrs || hasImpl) {
       walkAttributes(impl.attrs, function (k, v) { setAttr(root, k, v) })
       parseExpressions(self.root, self, expressions)
     }
+
+    // parse layout after init. fn may calculate args for nested custom tags
+    parseExpressions(dom, self, expressions)
+
+    // unmount automatically when our parent does
+    if (parent) parent.on('unmount', self.unmount)
 
     if (!self.parent || isLoop) self.update(item)
 
@@ -162,11 +162,6 @@ function Tag(impl, conf, innerHTML) {
       while (dom.firstChild) root.appendChild(dom.firstChild)
       if (root.stub) self.root = root = parent.root
     }
-
-    // parse the named dom nodes in the looped child
-    // adding them to the parent as well
-    if (isLoop)
-      parseNamedElements(self.root, self.parent, null, true)
 
     // if it's not a child tag we can trigger its mount event
     if (!self.parent || self.parent.isMounted) {
@@ -230,30 +225,10 @@ function Tag(impl, conf, innerHTML) {
 
 
     self.trigger('unmount')
-    toggle()
+    if (parent) parent.off('unmount', self.unmount)
     self.off('*')
     self.isMounted = false
     delete root._tag
 
   })
-
-  function toggle(isMount) {
-
-    // mount/unmount children
-    each(childTags, function(child) { child[isMount ? 'mount' : 'unmount']() })
-
-    // listen/unlisten parent (events flow one way from parent to children)
-    if (!parent) return
-    var evt = isMount ? 'on' : 'off'
-
-    // the loop tags will be always in sync with the parent automatically
-    if (isLoop)
-      parent[evt]('unmount', self.unmount)
-    else
-      parent[evt]('update', self.update)[evt]('unmount', self.unmount)
-  }
-
-  // named elements available for fn
-  parseNamedElements(dom, this, childTags)
-
 }

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -69,7 +69,7 @@ function update(expressions, tag) {
     var dom = expr.dom,
       attrName = expr.attr,
       value = tmpl(expr.expr, tag),
-      parent = expr.dom.parentNode
+      parent = dom && dom.parentNode
 
     if (expr.bool)
       value = value ? attrName : false
@@ -84,9 +84,16 @@ function update(expressions, tag) {
       parent.value = value
     }
 
-    // no change
-    if (expr.value === value) return
+    var old = expr.value
     expr.value = value
+
+    if (expr.isIf) return updateIf(expr, old, value, tag)
+    if (expr.isTag) return updateTagRef(expr, tag)
+    if (expr.isLoop) return expr.update()
+    if (expr.isNamed) return updateNamed(expr, old, value, tag)
+
+    // no change, so nothing more to do
+    if (old === value) return
 
     // text node
     if (!attrName) {
@@ -100,37 +107,6 @@ function update(expressions, tag) {
     if (isFunction(value)) {
       setEventHandler(attrName, value, dom, tag)
 
-    // if- conditional
-    } else if (attrName == 'if') {
-      var stub = expr.stub,
-        add = function() { insertTo(stub.parentNode, stub, dom) },
-        remove = function() { insertTo(dom.parentNode, dom, stub) }
-
-      // add to DOM
-      if (value) {
-        if (stub) {
-          add()
-          dom.inStub = false
-          // avoid to trigger the mount event if the tags is not visible yet
-          // maybe we can optimize this avoiding to mount the tag at all
-          if (!isInStub(dom)) {
-            walk(dom, function(el) {
-              if (el._tag && !el._tag.isMounted)
-                el._tag.isMounted = !!el._tag.trigger('mount')
-            })
-          }
-        }
-      // remove from DOM
-      } else {
-        stub = expr.stub = stub || document.createTextNode('')
-        // if the parentNode is defined we can easily replace the tag
-        if (dom.parentNode)
-          remove()
-        // otherwise we need to wait the updated event
-        else (tag.parent || tag).one('updated', remove)
-
-        dom.inStub = true
-      }
     // show / hide
     } else if (/^(show|hide)$/.test(attrName)) {
       if (attrName == 'hide') value = !value
@@ -158,4 +134,54 @@ function update(expressions, tag) {
 
   })
 
+}
+
+// Named expressions set a property on the parent, so that
+// <input name='foo' /> is available as this.foo
+function updateNamed(expr, old, value, tag) {
+  if (expr.done) return // only set named once
+  // names only get set on custom tags (not loop items, for example)
+  var parent = getImmediateCustomParentTag(tag)
+  setNamed(expr.dom, parent, value)
+  expr.done = true
+}
+
+// TagRef points to a child tag that may or may not exist yet.
+// This way, we don't mount a tag until it's actually going to be inserted into DOM
+function updateTagRef(expr, parent) {
+  if (expr.tag) {
+    expr.tag.update()
+    return
+  }
+
+  var conf = {root: expr.dom, parent: parent, hasImpl: true}
+  expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent)
+  expr.tag.mount()
+  expr.tag.update()
+}
+
+// If expressions add or remove DOM, as well as control the flow of updates.
+// An if-expression that remains false won't update any dependants.
+// When the truthyness changes, we insert the DOM, or a stub to hold position.
+function updateIf(expr, old, value, tag) {
+  // if the truthyness remains unchange
+  if (expr.started && !value == !old) {
+    if (value)
+      update(expr.children, tag)
+    return
+  }
+
+  var stub, dom = expr.dom
+  stub = expr.stub = expr.stub || document.createTextNode('')
+
+  // add to DOM
+  if (value) {
+    update(expr.children, tag)
+    insertTo(stub.parentNode, stub, dom)
+  } else {
+    if (dom.parentNode) insertTo(dom.parentNode, dom, stub)
+    // pretty sure this only happens with <foo each={items} if={show} />
+    else tag.stub = stub
+  }
+  expr.started = true
 }

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -268,16 +268,18 @@ function cleanUpData(data) {
  * Walk down recursively all the children tags starting dom node
  * @param   { Object }   dom - starting node where we will start the recursion
  * @param   { Function } fn - callback to transform the child node just found
+ * @param   { Object }   context - fn can optionally return an object, which is passed to children
  */
-function walk(dom, fn) {
+function walk(dom, fn, context) {
   if (dom) {
+    var res = fn(dom, context)
     // stop the recursion
-    if (fn(dom) === false) return
+    if (res === false) return
     else {
       dom = dom.firstChild
 
       while (dom) {
-        walk(dom, fn)
+        walk(dom, fn, res)
         dom = dom.nextSibling
       }
     }
@@ -364,45 +366,26 @@ function getNamedKey(dom) {
  * Set the named properties of a tag element
  * @param { Object } dom - DOM node we need to parse
  * @param { Object } parent - tag instance where the named dom element will be eventually added
- * @param { Array } keys - list of all the tag instance properties
+ * @param { Array } key - the key on which to set on parent
  */
-function setNamed(dom, parent, keys) {
+function setNamed(dom, parent, key) {
   // get the key value we want to add to the tag instance
-  var key = getNamedKey(dom),
-    isArr,
-    // add the node detected to a tag instance using the named property
-    add = function(value) {
-      // avoid to override the tag properties already set
-      if (contains(keys, key)) return
-      // check whether this value is an array
-      isArr = isArray(value)
-      // if the key was never set
-      if (!value)
-        // set it once on the tag instance
-        parent[key] = dom
-      // if it was an array and not yet set
-      else if (!isArr || isArr && !contains(value, dom)) {
-        // add the dom node into the array
-        if (isArr)
-          value.push(dom)
-        else
-          parent[key] = [value, dom]
-      }
-    }
-
-  // skip the elements with no named properties
+  key = key || getNamedKey(dom)
   if (!key) return
 
-  // check whether this key has been already evaluated
-  if (tmpl.hasExpr(key))
-    // wait the first updated event only once
-    parent.one('mount', function() {
-      key = getNamedKey(dom)
-      add(parent[key])
-    })
-  else
-    add(parent[key])
+  var dest = parent[key]
+  var isArr = isArray(dest)
 
+  // if the key was never set, set it once on the tag instance
+  if (!dest) parent[key] = dom
+  // if it was an array and not yet set
+  else if (!isArr || isArr && !contains(dest, dom)) {
+    // add the dom node into the array
+    if (isArr)
+      dest.push(dom)
+    else
+      parent[key] = [dest, dom]
+  }
 }
 
 /**

--- a/test/tag/loop-inherit.tag
+++ b/test/tag/loop-inherit.tag
@@ -1,6 +1,6 @@
 <loop-inherit>
   <div each={ item, index in items} class={ active: item == 'active' }>
-    <loop-inherit-item id={ index } name={ item } nice={ isFun } onmouseenter={ onMouseEnter }></loop-inherit-item>
+    <loop-inherit-item id={ index } name={ item } nice={ isFun } onmouseenter={ parent.onMouseEnter }></loop-inherit-item>
   </div>
 
   <loop-inherit-list each={ item in items } if={ item != 'me' }></loop-inherit-list>

--- a/test/tag/loop-single-tags.tag
+++ b/test/tag/loop-single-tags.tag
@@ -1,12 +1,11 @@
 <loop-single-tags>
-  <ul>
-    <li each={ tags }>{ name }</li>
-  </ul>
   <single-tag1></single-tag1>
   <single-tag2></single-tag2>
   <single-tag3></single-tag3>
   <single-tag4></single-tag4>
-
+  <ul>
+    <li each={ tags }>{ name }</li>
+  </ul>
 </loop-single-tags>
 
 <single-tag1>

--- a/test/tag/loop-tag-instances.tag
+++ b/test/tag/loop-tag-instances.tag
@@ -28,7 +28,10 @@
     </loop-tag-instance>
   </loop-tag-instances-test>
 
-  this.inst = this.tags['loop-tag-instances-test']
+  start() {
+    this.inst = this.tags['loop-tag-instances-test']
+    this.update()
+  }
 
 </loop-tag-instances>
 


### PR DESCRIPTION
Before, expressions and child tags were run even if they never made it into the DOM. This was unnecessary work, and sometimes caused spurious errors.

The change combines parsing into a single function that finds all expressions and child tags. The parser returns a tree, so we know what expressions are under what if-attribute.

Instead of using observable, updates propagate through this tree, which lets us stop at a false if-attribute. Child tags are only created and mounted if they're actually going to be inserted into the DOM.

The most notable side-effect of this change is that child tags are available later than they used to be. Before, it was one of the first things that happened, so you could reference them in the init function, mount, or update callbacks. Now, they aren't available until after the first update has finished.