### PR TITLE
Refactor how tags get opts from their parents.

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -96,6 +96,7 @@ function moveVirtual(tag, src, target, len) {
  * @param   { Object } dom - DOM node we need to loop
  * @param   { Tag } parent - parent tag instance where the dom node is contained
  * @param   { String } expr - string contained in the 'each' attribute
+ * @returns { Object } expression object for this each loop
  */
 function _each(dom, parent, expr) {
 

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -29,23 +29,32 @@ function parseExpressions(root, tag, expressions) {
       parent.children.push({isNamed: true, dom: dom, expr: expr})
     }
 
+    // attribute expressions
+    var allAttrs = [], nameHasExpression = false
+    each(dom.attributes, function(attr) {
+      var name = attr.name, bool = name.split('__')[1]
+      var hasExp = tmpl.hasExpr(attr.value)
+      if (name === 'if') return // already handled
+
+      // dirty dirty hack until we can clean up named tags
+      if (name === 'name' && hasExp) nameHasExpression = true
+
+      expr = {dom: dom, expr: attr.value, attr: bool || attr.name, bool: bool}
+      allAttrs.push(expr) // stores all attributes, even without expressions
+
+      if (!hasExp) return // no expressions here
+      parent.children.push(expr)
+      if (bool) { remAttr(dom, name); return false }
+    })
+
     // if this is a tag, stop traversing here.
     // we ignore the root, since parseExpressions is called while we're mounting that root
     var tagImpl = getTag(dom)
     if (tagImpl && dom !== root) {
-      parent.children.push({isTag: true, dom: dom, impl: tagImpl})
+      parent.children.push({isTag: true, dom: dom, impl: tagImpl,
+        ownAttrs: allAttrs, nameHasExpression: nameHasExpression})
       return false
     }
-
-    // attribute expressions
-    each(dom.attributes, function(attr) {
-      var name = attr.name, bool = name.split('__')[1]
-      if (!tmpl.hasExpr(attr.value)) return // no expressions here
-
-      expr = {dom: dom, expr: attr.value, attr: bool || attr.name, bool: bool}
-      parent.children.push(expr)
-      if (bool) { remAttr(dom, name); return false }
-    })
 
     // whatever the parent is, all child elements get the same parent.
     // If this element had an if-attr, that's the parent for all child elements

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -5,13 +5,13 @@ function Tag(impl, conf, innerHTML) {
     parent = conf.parent,
     isLoop = conf.isLoop,
     hasImpl = conf.hasImpl,
+    ownAttrs = conf.ownAttrs, // attributes on this tag (evaluated in parent context)
     item = cleanUpData(conf.item),
     expressions = [],
     childTags = [],
     root = conf.root,
     fn = impl.fn,
     tagName = root.tagName.toLowerCase(),
-    attr = {},
     propsInSyncWithParent = [],
     dom
 
@@ -31,28 +31,29 @@ function Tag(impl, conf, innerHTML) {
 
   extend(this, { parent: parent, root: root, opts: opts, tags: {} }, item)
 
-  // grab attributes
-  each(root.attributes, function(el) {
-    var val = el.value
-    // remember attributes with expressions only
-    if (tmpl.hasExpr(val)) attr[el.name] = val
-  })
-
   dom = mkdom(impl.tmpl, innerHTML)
 
   // options
   function updateOpts() {
     var ctx = hasImpl && isLoop ? self : parent || self
 
-    // update opts from current DOM attributes
-    each(root.attributes, function(el) {
-      var val = el.value
-      opts[toCamel(el.name)] = tmpl.hasExpr(val) ? tmpl(val, ctx) : val
-    })
-    // recover those with expressions
-    each(Object.keys(attr), function(name) {
-      opts[toCamel(name)] = tmpl(attr[name], ctx)
-    })
+    // If we're nested beneath another tag, then our attributes are evaluated
+    // in that parent context. Here, we copy them onto opts.
+    if (ownAttrs) {
+      each(ownAttrs || [], function(expr) {
+        // if the attribute doesn't actually have an expression, there
+        // won't be a value. Just use the string itself in this case.
+        var v = expr.hasOwnProperty('value') ? expr.value : expr.expr
+        opts[toCamel(expr.attr)] = v
+      })
+
+    } else {
+      each(root.attributes, function(el) {
+        var val = el.value, hasTmpl = tmpl.hasExpr(val)
+        if (hasTmpl && ownAttrs) return // already handled above
+        opts[toCamel(el.name)] = hasTmpl ? tmpl(val, ctx) : val
+      })
+    }
   }
 
   function normalizeData(data) {

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -154,8 +154,8 @@ function updateTagRef(expr, parent) {
     return
   }
 
-  var conf = {root: expr.dom, parent: parent, hasImpl: true}
-  expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent)
+  var conf = {root: expr.dom, parent: parent, hasImpl: true, ownAttrs: expr.ownAttrs}
+  expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent, expr.nameHasExpression)
   expr.tag.mount()
   expr.tag.update()
 }

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -122,11 +122,12 @@ function moveChildTag(tag, tagName, newPos) {
  * @param   { Object } opts - tag options containing the DOM node where the tag will be mounted
  * @param   { String } innerHTML - inner html of the child node
  * @param   { Object } parent - instance of the parent tag including the child custom tag
+ * @param   { Boolean } skipName - hack to ignore the name attribute when attaching to parent
  * @returns { Object } instance of the new child tag just created
  */
-function initChildTag(child, opts, innerHTML, parent) {
+function initChildTag(child, opts, innerHTML, parent, skipName) {
   var tag = new Tag(child, opts, innerHTML),
-    tagName = getTagName(opts.root),
+    tagName = getTagName(opts.root, skipName),
     ptag = getImmediateCustomParentTag(parent)
   // fix for the parent attribute in the looped elements
   tag.parent = ptag
@@ -182,11 +183,12 @@ function defineProperty(el, key, value, options) {
 /**
  * Get the tag name of any DOM node
  * @param   { Object } dom - DOM node we want to parse
+ * @param   { Boolean } skipName - hack to ignore the name attribute when attaching to parent
  * @returns { String } name to identify this dom node in riot
  */
-function getTagName(dom) {
+function getTagName(dom, skipName) {
   var child = getTag(dom),
-    namedTag = getAttr(dom, 'name'),
+    namedTag = !skipName && getAttr(dom, 'name'),
     tagName = namedTag && !tmpl.hasExpr(namedTag) ?
                 namedTag :
               child ? child.name : dom.tagName.toLowerCase()

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1164,6 +1164,14 @@ describe('Compiler Browser', function() {
     tags.push(tag)
   })
 
+  it.only('only evalutes expressions once per update', function() {
+    var tag = riot.mount('expression-eval-count')[0]
+    expect(tag.count).to.be(1)
+    tag.update()
+    expect(tag.count).to.be(2)
+    tags.push(tag)
+  })
+
   it('multi named elements to an array', function() {
     var mount = function() {
         var tag = this

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -36,6 +36,7 @@ loadTagsAndScripts([
   'tag/virtual-nested-unmount.tag',
   // mount order
   'tag/deferred-mount.tag',
+  'tag/expression-eval-count.tag',
 
   // multi named elements to an array
   'tag/multi-named.tag',

--- a/test/tag/expression-eval-count.tag
+++ b/test/tag/expression-eval-count.tag
@@ -1,0 +1,6 @@
+<expression-eval-count>
+  <span foo={increment()}></span>
+
+  this.count = 0
+  increment() { this.count++ }
+</expression-eval-count>

--- a/test/tag/loop-inherit.tag
+++ b/test/tag/loop-inherit.tag
@@ -1,6 +1,6 @@
 <loop-inherit>
   <div each={ item, index in items} class={ active: item == 'active' }>
-    <loop-inherit-item id={ index } name={ item } nice={ isFun } onmouseenter={ parent.onMouseEnter }></loop-inherit-item>
+    <loop-inherit-item id={ index } name={ item } nice={ isFun } onmouseenter={ onMouseEnter }></loop-inherit-item>
   </div>
 
   <loop-inherit-list each={ item in items } if={ item != 'me' }></loop-inherit-list>

--- a/test/tags.html
+++ b/test/tags.html
@@ -41,6 +41,7 @@
     <loop-equalitems></loop-equalitems>
     <loop-reorder></loop-reorder>
     <expr-parent></expr-parent>
+    <expression-eval-count></expression-eval-count>
 
     <tag-nesting></tag-nesting>
 


### PR DESCRIPTION
Before this change, attribute expressions on a tag were evaluated twice: once by parent as part of the standard update, and then again by the tag itself inside of updateOpts. The first one actually modified the DOM, and the second one only affected the opts.

This was wasteful, and we should really only evaluate each expression once per update cycle. Here's how it works:

When parsing, we keep track of every attribute, whether it has an expression or not. These are stored as ownAttrs on the tag. The attributes with expressions are also stored on the parent's expression tree. When an update happens, the parent evaluates all its expressions (include the attributes on the child tag), then calls update on the child. Our updateOpts method now just copies the values of those already-eval'd expressions onto opts.

This also lets me revert the one dubious change I made to the tests. In the last version attributes got eval'd by the child tag first, and in the case of callbacks, that actually modifies the DOM and prevents the parent for eval'ing onmouseenter.