### PR TITLE
dynamic riot-tag and unmount issues

### DIFF
--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -49,7 +49,7 @@ function parseExpressions(root, tag, expressions) {
 
 
     if (expr = getAttr(dom, RIOT_TAG)) {
-      if ( expr.trim().slice(0, 1) == brackets(0)) {
+      if (tmpl.hasExpr(expr)) {
         attr = {isRtag: true, expr: expr, dom: dom, children: []}
         parent.children.push(attr)
         parent = attr

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -47,6 +47,14 @@ function parseExpressions(root, tag, expressions) {
       if (bool) { remAttr(dom, name); return false }
     })
 
+
+    if (expr = getAttr(dom, RIOT_TAG)) {
+      if ( expr.trim().slice(0, 1) == brackets(0)) {
+        attr = {isRtag: true, expr: expr, dom: dom, children: []}
+        parent.children.push(attr)
+        parent = attr
+      }
+    }
     // whatever the parent is, all child elements get the same parent.
     // If this element had an if-attr, that's the parent for all child elements
     return {parent: parent}

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -10,7 +10,7 @@ function Tag(impl, conf, innerHTML) {
     childTags = [],
     root = conf.root,
     fn = impl.fn,
-    tagName = root.tagName.toLowerCase(),
+    tagName = conf.tagName || root.tagName.toLowerCase(),
     attr = {},
     propsInSyncWithParent = [],
     dom
@@ -207,10 +207,12 @@ function Tag(impl, conf, innerHTML) {
           each(ptag.tags[tagName], function(tag, i) {
             if (tag._riot_id == self._riot_id)
               ptag.tags[tagName].splice(i, 1)
+            if (!ptag.tags[tagName].length) delete ptag.tags[tagName]
+            if (ptag.tags[tagName].length == 1) ptag.tags[tagName] = ptag.tags[tagName][0]
           })
         else
           // otherwise just delete the tag instance
-          ptag.tags[tagName] = undefined
+          delete ptag.tags[tagName]
       }
 
       else

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -89,6 +89,7 @@ function update(expressions, tag) {
 
     if (expr.isIf) return updateIf(expr, old, value, tag)
     if (expr.isTag) return updateTagRef(expr, tag)
+    if (expr.isRtag && value) return updateRtag(expr, tag)
     if (expr.isLoop) return expr.update()
     if (expr.isNamed) return updateNamed(expr, old, value, tag)
 
@@ -158,6 +159,24 @@ function updateTagRef(expr, parent) {
   expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent)
   expr.tag.mount()
   expr.tag.update()
+}
+
+function updateRtag(expr, parent) {
+  var tagName = tmpl(expr.value, parent),
+    conf
+
+  if (expr.tag && expr.tagName == tagName) {
+    expr.tag.update()
+    return
+  }
+
+  expr.impl = __tagImpl[tagName]
+  conf = {root: expr.dom, parent: parent, hasImpl: true, tagName: tagName}
+  expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent)
+  expr.tagName = tagName
+  expr.tag.mount()
+  expr.tag.update()
+
 }
 
 // If expressions add or remove DOM, as well as control the flow of updates.

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -161,6 +161,12 @@ function updateTagRef(expr, parent) {
   expr.tag.update()
 }
 
+/**
+ * Update dynamically created riot-tag with changing expressions
+ * @param   { Object } expr - expression tag and expression info
+ * @param   { Tag } parent - parent for tag creation
+ */
+
 function updateRtag(expr, parent) {
   var tagName = tmpl(expr.value, parent),
     conf
@@ -168,6 +174,15 @@ function updateRtag(expr, parent) {
   if (expr.tag && expr.tagName == tagName) {
     expr.tag.update()
     return
+  }
+
+  // sync _parent to accommodate changing tagnames
+  if (expr.tag) {
+    var delName = expr.tag.opts.riotTag,
+      tags = expr.tag._parent.tags[delName]
+
+    if (isArray(tags)) tags.splice(tags.indexOf(expr.tag), 1); else delete expr.tag._parent.tags[delName]
+
   }
 
   expr.impl = __tagImpl[tagName]

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -90,7 +90,7 @@ function addChildTag(tag, tagName, parent) {
       if (cachedTag !== tag)
         parent.tags[tagName] = [cachedTag]
     // add the new nested tag to the array
-    if (!contains(parent.tags[tagName], tag))
+    if (isArray(parent.tags[tagName]) && !contains(parent.tags[tagName], tag))
       parent.tags[tagName].push(tag)
   } else {
     parent.tags[tagName] = tag

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -126,7 +126,7 @@ function moveChildTag(tag, tagName, newPos) {
  */
 function initChildTag(child, opts, innerHTML, parent) {
   var tag = new Tag(child, opts, innerHTML),
-    tagName = getTagName(opts.root),
+    tagName = opts.tagName || getTagName(opts.root),
     ptag = getImmediateCustomParentTag(parent)
   // fix for the parent attribute in the looped elements
   tag.parent = ptag

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1818,7 +1818,23 @@ it('raw contents', function() {
     var tag = riot.mount('dynamic-riot-tag')[0]
     var divs = tag.root.querySelectorAll('div')
     expect(divs[0].querySelector('input').getAttribute('type')).to.be('color')
+    expect(divs[1].querySelector('input').getAttribute('type')).to.be('color')
+    expect(divs[2].querySelector('input').getAttribute('type')).to.be('date')
     expect(divs[3].querySelector('input').getAttribute('type')).to.be('date')
+
+    tag.single = 'color'
+    tag.update()
+    expect(divs[3].querySelector('input').getAttribute('type')).to.be('color')
+
+    tag.intags.reverse()
+    tag.update()
+    divs = tag.root.querySelectorAll('div')
+    expect(divs[0].querySelector('input').getAttribute('type')).to.be('date')
+    expect(divs[1].querySelector('input').getAttribute('type')).to.be('color')
+    expect(divs[2].querySelector('input').getAttribute('type')).to.be('color')
+
+
+    tags.push(tag)
   })
 
 })

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1813,4 +1813,12 @@ it('raw contents', function() {
     tag.update()
   })
 
+  it('riot-tag can be dynamically created by expression', function() {
+    injectHTML('<dynamic-riot-tag></dynamic-riot-tag>')
+    var tag = riot.mount('dynamic-riot-tag')[0]
+    var divs = tag.root.querySelectorAll('div')
+    expect(divs[0].querySelector('input').getAttribute('type')).to.be('color')
+    expect(divs[3].querySelector('input').getAttribute('type')).to.be('date')
+  })
+
 })

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -72,6 +72,8 @@ loadTagsAndScripts([
 
   'tag/reserved-names.tag',
 
+  'tag/dynamic-riot-tag.tag',
+
   // these tags will be not autoinjected in the DOM
   // that's what `name = false` means
   {

--- a/test/tag/dynamic-riot-tag.tag
+++ b/test/tag/dynamic-riot-tag.tag
@@ -1,0 +1,20 @@
+<color>
+  <input type="color" name="{ opts.name }" />
+</color>
+
+<calendar>
+  <input type="date" name="{ opts.name }" />
+</calendar>
+
+<dynamic-riot-tag>
+  <div each={inp in intags } riot-tag={ inp.tag } inpname={ inp.name }></div>
+  <div riot-tag={intags[2].tag}></div>
+
+  this.intags = [
+  {name: 'aaa', tag: 'color'},
+  {name: 'bbb', tag: 'color'},
+  {name: 'ccc', tag: 'calendar'}
+  ]
+
+
+</dynamic-riot-tag>

--- a/test/tag/dynamic-riot-tag.tag
+++ b/test/tag/dynamic-riot-tag.tag
@@ -8,13 +8,15 @@
 
 <dynamic-riot-tag>
   <div each={inp in intags } riot-tag={ inp.tag } inpname={ inp.name }></div>
-  <div riot-tag={intags[2].tag}></div>
+  <div riot-tag={single}></div>
 
   this.intags = [
-  {name: 'aaa', tag: 'color'},
-  {name: 'bbb', tag: 'color'},
-  {name: 'ccc', tag: 'calendar'}
+    {name: 'aaa', tag: 'color'},
+    {name: 'bbb', tag: 'color'},
+    {name: 'ccc', tag: 'calendar'}
   ]
+
+  this.single = 'calendar'
 
 
 </dynamic-riot-tag>


### PR DESCRIPTION
There are basically 2 changes here, the addition of `riot-tag={expression}` and a fix to unmounting.

I think everyone is aware of the intention of `riot-tag={expression}` but please review.  I added the parsing after the other expressions are parsed so that the evaluated expressions would be fully reflected in the dom, does that seem reasonable @rogueg

The other change is as follows

When a tag is added to `tags` it is accessible with `this.tags.tagname`, when more than one tag of the same name is added, it is an array `this.tags.tagname[n]`.  the current functionality is when a tag is removed, and there is only one left, ti should go back to `this.tags.tagname` but it remains an array, so this has been corrected

The second change is when a tag is completely removed, it is set to undefined, it should be deleted, I think this was an IE8 issue with using `delete` but I am not sure if this is still an issue with other IE versions or if there are other issues that I am not aware of.

I will add more extensive tests in the near future