### PR TITLE
Fix for #1549.

### DIFF
--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -15,6 +15,8 @@ var mkdom = (function (checkIE) {
       th: 'tr',
       td: 'tr',
       tbody: 'table',
+      thead: 'table',
+      tfoot: 'table',
       col: 'colgroup'
     },
     reToSrc = /<yield\s+to=(['"])?@\1\s*>([\S\s]+?)<\/yield\s*>/.source,

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1528,17 +1528,17 @@ it('raw contents', function() {
       heads = tag.root.getElementsByTagName('thead'),
       foots = tag.root.getElementsByTagName('tfoot')
 
-    expect(bodies.length).to.be(3)
-    expect(heads.length).to.be(2)
-    expect(foots.length).to.be(2)
+    expect(bodies.length).to.be(1)
+    expect(heads.length).to.be(1)
+    expect(foots.length).to.be(1)
 
     var ths = tag.root.getElementsByTagName('th'),
       trs = tag.root.getElementsByTagName('tr'),
       tds = tag.root.getElementsByTagName('td')
 
-    expect(ths.length).to.be(6)
-    expect(trs.length).to.be(13)
-    expect(tds.length).to.be(15)
+    expect(ths.length).to.be(3)
+    expect(trs.length).to.be(5)
+    expect(tds.length).to.be(6)
 
     tags.push(tag)
   })

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1521,6 +1521,28 @@ it('raw contents', function() {
     tags.push(tag)
   })
 
+  it('table with tbody and thead #1549', function() {
+
+    var tag = riot.mount('table-thead-tfoot-nested')[0],
+      bodies = tag.root.getElementsByTagName('tbody'),
+      heads = tag.root.getElementsByTagName('thead'),
+      foots = tag.root.getElementsByTagName('tfoot')
+
+    expect(bodies.length).to.be(3)
+    expect(heads.length).to.be(2)
+    expect(foots.length).to.be(2)
+
+    var ths = tag.root.getElementsByTagName('th'),
+      trs = tag.root.getElementsByTagName('tr'),
+      tds = tag.root.getElementsByTagName('td')
+
+    expect(ths.length).to.be(6)
+    expect(trs.length).to.be(13)
+    expect(tds.length).to.be(15)
+
+    tags.push(tag)
+  })
+
   it('table with caption and looped cols, ths, and trs #1067', function() {
     var data = {
       // copied from loop-cols.tag

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -29,6 +29,8 @@ loadTagsAndScripts([
   'tag/loop-null-items.tag',
   'tag/table-data.tag',
   'tag/table-loop-extra-row.tag',
+  'tag/table-thead-tfoot.tag',
+  'tag/table-thead-tfoot-nested.tag',
   'tag/loop-named.tag',
   'tag/loop-single-tags.tag',
   'tag/timetable.tag',

--- a/test/tag/table-thead-tfoot-nested.tag
+++ b/test/tag/table-thead-tfoot-nested.tag
@@ -1,0 +1,9 @@
+<table-thead-tfoot-nested>
+
+  <table-thead-tfoot header={ header } footer={ footer } rows={ rows }></table-thead-tfoot>
+
+  this.header = [{ cell: 'One'}, { cell: 'Two'}, { cell: 'Three'}]
+  this.footer = [{ cell: 'One'}, { cell: 'Two'}, { cell: 'Three'}]
+  this.rows = [['One'], ['Two'], ['Three']]
+
+</table-thead-tfoot-nested>

--- a/test/tag/table-thead-tfoot-nested.tag
+++ b/test/tag/table-thead-tfoot-nested.tag
@@ -1,6 +1,6 @@
 <table-thead-tfoot-nested>
 
-  <table-thead-tfoot header={ header } footer={ footer } rows={ rows }></table-thead-tfoot>
+  <table riot-tag="table-thead-tfoot" header="{ header }" footer="{ footer }" rows="{ rows }"></table>
 
   this.header = [{ cell: 'One'}, { cell: 'Two'}, { cell: 'Three'}]
   this.footer = [{ cell: 'One'}, { cell: 'Two'}, { cell: 'Three'}]

--- a/test/tag/table-thead-tfoot.tag
+++ b/test/tag/table-thead-tfoot.tag
@@ -1,43 +1,16 @@
 <table-thead-tfoot>
 
-  <h3>Header</h3>
-  <table>
-    <thead>
-      <tr><th each={ header }>{ cell }</th></tr>
-    </thead>
-    <tbody>
-      <tr each={ col in rows }>
-        <td each={ cell in col }>{ cell }</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <h3>Footer</h3>
-  <table>
-    <tfoot>
-      <tr><td each={ footer }>{ cell }</td></tr>
-    </tfoot>
-    <tbody>
-      <tr each={ col in rows }>
-        <td each={ cell in col }>{ cell }</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <h3>Both</h3>
-  <table>
-    <thead>
-      <tr><th each={ header }>{ cell }</th></tr>
-    </thead>
-    <tfoot>
-      <tr><td each={ footer }>{ cell }</td></tr>
-    </tfoot>
-    <tbody>
-      <tr each={ col in rows }>
-        <td each={ cell in col }>{ cell }</td>
-      </tr>
-    </tbody>
-  </table>
+  <thead>
+    <tr><th each={ header }>{ cell }</th></tr>
+  </thead>
+  <tfoot>
+    <tr><td each={ footer }>{ cell }</td></tr>
+  </tfoot>
+  <tbody>
+    <tr each={ col in rows }>
+      <td each={ cell in col }>{ cell }</td>
+    </tr>
+  </tbody>
 
   this.header = opts.header
   this.footer = opts.footer

--- a/test/tag/table-thead-tfoot.tag
+++ b/test/tag/table-thead-tfoot.tag
@@ -1,0 +1,46 @@
+<table-thead-tfoot>
+
+  <h3>Header</h3>
+  <table>
+    <thead>
+      <tr><th each={ header }>{ cell }</th></tr>
+    </thead>
+    <tbody>
+      <tr each={ col in rows }>
+        <td each={ cell in col }>{ cell }</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Footer</h3>
+  <table>
+    <tfoot>
+      <tr><td each={ footer }>{ cell }</td></tr>
+    </tfoot>
+    <tbody>
+      <tr each={ col in rows }>
+        <td each={ cell in col }>{ cell }</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Both</h3>
+  <table>
+    <thead>
+      <tr><th each={ header }>{ cell }</th></tr>
+    </thead>
+    <tfoot>
+      <tr><td each={ footer }>{ cell }</td></tr>
+    </tfoot>
+    <tbody>
+      <tr each={ col in rows }>
+        <td each={ cell in col }>{ cell }</td>
+      </tr>
+    </tbody>
+  </table>
+
+  this.header = opts.header
+  this.footer = opts.footer
+  this.rows = opts.rows
+
+</table-thead-tfoot>


### PR DESCRIPTION
When using table element as root, thead and tfoot didn't work correctly, table was rendered empty. This fixes it.