### PR TITLE
table/select as root

### DIFF
--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -22,7 +22,7 @@ var riot = { version: 'WIP', settings: {} },
   T_UNDEF  = 'undefined',
   T_FUNCTION = 'function',
   // special native tags that cannot be treated like the others
-  SPECIAL_TAGS_REGEX = /^(?:opt(ion|group)|tbody|col|t[rhd])$/,
+  SPECIAL_TAGS_REGEX = /^(?:t(?:body|head|foot|[rhd])|caption|col(?:group)?|opt(?:ion|group))$/,
   RESERVED_WORDS_BLACKLIST = ['_item', '_id', '_parent', 'update', 'root', 'mount', 'unmount', 'mixin', 'isMounted', 'isLoop', 'tags', 'parent', 'opts', 'trigger', 'on', 'off', 'one'],
 
   // version# for IE 8-11, 0 for others

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -109,7 +109,7 @@ function _each(dom, parent, expr) {
     root = dom.parentNode,
     ref = document.createTextNode(''),
     child = getTag(dom),
-    isOption = /option/gi.test(tagName), // the option tags must be treated differently
+    isOption = /^option$/i.test(tagName), // the option tags must be treated differently
     tags = [],
     oldItems = [],
     hasKeys,
@@ -215,7 +215,7 @@ function _each(dom, parent, expr) {
       // cache the real parent tag internally
       defineProperty(tag, '_parent', parent)
 
-    }, true) // allow null values
+    })
 
     // remove the redundant tags
     unmountRedundant(items, tags)

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -1,67 +1,65 @@
-
 /*
   lib/browser/tag/mkdom.js
 
   Includes hacks needed for the Internet Explorer version 9 and below
-
+  See: http://kangax.github.io/compat-table/es5/#ie8
+       http://codeplanet.io/dropping-ie8/
 */
-// http://kangax.github.io/compat-table/es5/#ie8
-// http://codeplanet.io/dropping-ie8/
-
 var mkdom = (function (checkIE) {
 
-  var rootEls = {
-      tr: 'tbody',
-      th: 'tr',
-      td: 'tr',
-      tbody: 'table',
-      thead: 'table',
-      tfoot: 'table',
-      col: 'colgroup'
-    },
+  var
     reToSrc = /<yield\s+to=(['"])?@\1\s*>([\S\s]+?)<\/yield\s*>/.source,
+    rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' },
     GENERIC = 'div'
 
   checkIE = checkIE && checkIE < 10
+  var tblTags = checkIE
+    ? SPECIAL_TAGS_REGEX : /^(?:t(?:body|head|foot|[rhd])|caption|col(?:group)?)$/
 
   // creates any dom element in a div, table, or colgroup container
   function _mkdom(templ, html) {
 
     var match = templ && templ.match(/^\s*<([-\w]+)/),
       tagName = match && match[1].toLowerCase(),
-      rootTag = rootEls[tagName] || GENERIC,
-      el = mkEl(rootTag)
-
-    el.stub = true
+      el = mkEl(GENERIC)
 
     // replace all the yield tags with the tag inner html
     templ = replaceYield(templ, html || '')
 
     /* istanbul ignore next */
-    if (checkIE && tagName && (match = tagName.match(SPECIAL_TAGS_REGEX)))
-      ie9elem(el, templ, tagName, !!match[1])
+    //if ((checkIE || !startsWith(tagName, 'opt')) && SPECIAL_TAGS_REGEX.test(tagName))
+    if (tblTags.test(tagName))
+      el = specialTags(el, templ, tagName)
     else
       el.innerHTML = templ
+
+    el.stub = true
 
     return el
   }
 
-  // creates tr, th, td, option, optgroup element for IE8-9
-  /* istanbul ignore next */
-  function ie9elem(el, html, tagName, select) {
+  // creates the root element for table and select child elements
+  // tr/th/td/thead/tfoot/tbody/caption/col/colgroup/option/optgroup
+  function specialTags(el, templ, tagName) {
+    var
+      select = tagName[0] === 'o',
+      parent = select ? 'select>' : 'table>'
 
-    var div = mkEl(GENERIC),
-      tag = select ? 'select>' : 'table>',
-      child
+    // trim() is important here, this ensures we don't have artifacts,
+    // so we can check if we have only one element inside the parent
+    el.innerHTML = '<' + parent + templ.trim() + '</' + parent
+    parent = el.firstChild
 
-    div.innerHTML = '<' + tag + html + '</' + tag
-
-    child = $(tagName, div)
-    if (child)
-      el.appendChild(child)
-
+    // returns the immediate parent if tr/th/td/col is the only element, if not
+    // returns the whole tree, as this can include additional elements
+    if (select) {
+      parent.selectedIndex = -1  // for IE9, compatible w/current riot behavior
+    } else {
+      var tname = rootEls[tagName]
+      if (tname && parent.children.length === 1) parent = $(tname, parent)
+    }
+    return parent
   }
-  // end ie9elem()
 
   /**
    * Replace the yield tag from any tag template with the innerHTML of the

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -41,7 +41,7 @@ module.exports = function(config) {
       build: 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')',
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
       testName: 'riotjs',
-      startConnect: true,
+      startConnect: false,
       recordVideo: false,
       recordScreenshots: false
     },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -41,7 +41,7 @@ module.exports = function(config) {
       build: 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')',
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
       testName: 'riotjs',
-      startConnect: false,
+      startConnect: true,
       recordVideo: false,
       recordScreenshots: false
     },

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -90,7 +90,7 @@ describe('Compiler Browser', function() {
       riot.compile(src, true)
     }
 
-    expect(Date.now() - begin).to.be.below(1300) // old compiler was not compiling this
+    expect(Date.now() - begin).to.be.below(1500) // compiler does more now
 
   })
 
@@ -1604,6 +1604,190 @@ it('raw contents', function() {
       if (!e) e = tag.root
       return e.getElementsByTagName(t)
     }
+  })
+
+  it('table/thead/tbody/tfoot used as root element of custom tags', function() {
+    var
+      tag = riot.mount('table-test')[0],
+      tbl
+
+    // set "tbl" to the table-test root element
+    expect(tag).to.not.be.empty()
+    tbl = tag.root
+    expect(tbl).to.not.be.empty()
+    tag.update()
+
+    testTable(tbl, 'table-caption', {
+      tbody: 1,
+      caption: true,
+      colgroup: true
+    })
+    testTable(tbl, 'table-colgroup', {
+      thead: 1,
+      tbody: 1,
+      colgroup: true
+    })
+    testTable(tbl, 'table-looped-col', {
+      thead: 1,
+      tbody: 1,
+      col: true
+    })
+    testTable(tbl, 'table-multi-col', {
+      thead: 1,
+      tbody: 1,
+      col: true
+    })
+    testTable(tbl, 'table-tfoot', {
+      tfoot: 1,
+      tbody: 1
+    })
+    testTable(tbl, 'table-tr-body-only', {
+      tr: 2
+    })
+    testTable(tbl, 'table-tr-alone', {
+      tr: 1
+    })
+    testTable(tbl, 'table-custom-thead-tfoot', {
+      thead: 1,
+      tfoot: 1,
+      tbody: 2,
+      colgroup: true
+    })
+
+    tags.push(tag)
+
+    // test the table and call the tests for the content
+    function testTable(root, name, info) {
+      var s, key, inf
+
+      root = root.querySelectorAll('table[riot-tag=' + name + ']')
+      s = name + '.length: '
+      expect(s + root.length).to.be(s + '1')
+      root = root[0]
+
+      // test content
+      for (key in info) { // eslint-disable-line
+        if (info[key] === true)
+          testOther(root, key)
+        else
+          testRows(root, key, info[key])
+      }
+    }
+
+    // test rows and cells for an element of thead/tfoot/tbody
+    function testRows(root, name, cnt) {
+      var s, i, r, c, rows, cells, templ
+
+      // check the count of this element
+      root = root.getElementsByTagName(name)
+      s = name + '.length: '
+      expect(s + root.length).to.be(s + cnt)
+      if (name === 'tr') {
+        name = 'tbody'
+        root = [{ rows: root }]
+        //...and leave cnt as-is, else adjust cnt to expected rows
+      } else cnt = name === 'tbody' ? 2 : 1
+
+      // check each element
+      for (i = 0; i < root.length; i++) {
+        // test the rows
+        rows = root[i].rows
+        expect(rows.length).to.be(cnt)
+        // test the cols
+        for (r = 0; r < rows.length; r++) {
+          c = name[1].toUpperCase()
+          s = r + 1
+          cells = rows[r].cells
+          templ = c === 'B' ? 'R' + s + '-C' : c + '-'
+          expect(cells.length).to.be(2)
+          expect(cells[0].innerHTML).to.contain(templ + '1')
+          expect(cells[1].innerHTML).to.contain(templ + '2')
+        }
+      }
+    }
+
+    // test caption, colgroup and col elements
+    function testOther(root, name) {
+      var cols, s = name + '.length: '
+
+      // we'll search the parent for <col>, later in the switch
+      if (name !== 'col') {
+        root = root.getElementsByTagName(name)
+        expect(s + root.length).to.be(s + '1')
+        root = root[0]
+      }
+      switch (name) {
+      case 'caption':
+        expect(root.innerHTML).to.contain('Title')
+        break
+      case 'colgroup':
+      case 'col':
+        cols = root.getElementsByTagName('col')
+        expect(cols).to.have.length(2)
+        expect(cols[0].width).to.be('150')
+        expect(cols[1].width).to.be('200')
+        break
+      default:
+        break
+      }
+    }
+  })
+
+  it('select as root element of custom riot tag', function () {
+    var
+      CHOOSE = 0,     // option alone
+      OPTION = 1,     // looped option
+      OPTGRP = 2,     // optgroup with options
+      list = {
+        'select-single-option': [0, CHOOSE],
+        'select-each-option': [1, OPTION],
+        'select-each-option-prompt': [2, CHOOSE, OPTION],
+        'select-each-two-options': [4, OPTION, OPTION],
+        'select-optgroup-each-option': [0, OPTGRP],
+        'select-optgroup-each-option-prompt': [0, CHOOSE, OPTGRP],
+        'select-two-optgroup-each-option': [3, OPTGRP, CHOOSE, OPTGRP],
+        'select-each-optgroup': [0, OPTGRP, OPTGRP]
+      },
+      sel, dat, tag = riot.mount('select-test')[0]
+
+    expect(tag).to.not.be.empty()
+    for (var name in list) {                 // eslint-disable-line guard-for-in
+      //console.log('Testing ' + name)
+      dat = list[name]
+      sel = tag.root.querySelector('select[riot-tag=' + name + ']')
+      expect(sel).to.not.be.empty()
+      if (sel.selectedIndex !== dat[0]) expect().fail(
+        name + '.selectIndex ' + sel.selectedIndex + ' expected to be ' + dat[0])
+      var s1 = listFromSel(sel)
+      var s2 = listFromDat(dat)
+      expect(s1).to.be(s2)
+    }
+
+    function listFromDat(dat) {
+      var op = [], s = 'Opt1,Opt2,Opt3'
+      for (i = 1; i < dat.length; i++) {
+        if (dat[i] === OPTGRP) op.push('G,' + s)
+        else if (dat[i] === OPTION) op.push(s)
+        else op.push('(choose)')
+      }
+      return op.join(',')
+    }
+    function listFromSel(el) {
+      var op = []
+      el = el.firstChild
+      while (el) {
+        if (el.tagName === 'OPTGROUP') {
+          op.push('G')
+          op = op.concat(listFromSel(el))
+        } else if (el.tagName === 'OPTION') {
+          op.push(el.text)
+        }
+        el = el.nextSibling
+      }
+      return op.join(',')
+    }
+
+    tags.push(tag)
   })
 
   it('Passing options to the compiler through riot.compile (v2.3.12)', function () {

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -36,6 +36,8 @@ loadTagsAndScripts([
   'tag/timetable.tag',
   'tag/raw-contents.tag',
   'tag/virtual-nested-unmount.tag',
+  'tag/table-test.tag',
+  'tag/select-test.tag',
   // mount order
   'tag/deferred-mount.tag',
 

--- a/test/tag/select-test.tag
+++ b/test/tag/select-test.tag
@@ -1,0 +1,73 @@
+<select-test>
+  <form id="select-test-form">
+    <!--One single option, without expressions-->
+    <select riot-tag="select-single-option"/>
+    <!--Looped option, no group-->
+    <select riot-tag="select-each-option"/>
+    <!--Single option + looped option, no group-->
+    <select riot-tag="select-each-option-prompt"/>
+    <!--Two looped options, no group-->
+    <select riot-tag="select-each-two-options"/>
+    <!--One group with one looped option-->
+    <select riot-tag="select-optgroup-each-option"/>
+    <!--Single option + one group with one looped option-->
+    <select riot-tag="select-optgroup-each-option-prompt"/>
+    <!--Two groups with one looped option each-->
+    <select riot-tag="select-two-optgroup-each-option"/>
+    <!--Looped group (2 items) with looped options-->
+    <select riot-tag="select-each-optgroup"/>
+  </form>
+  <script>
+  (window||global).theOptions = ['Opt1', 'Opt2', 'Opt3']
+  </script>
+</select-test>
+
+<select-single-option>
+  <option selected>(choose)</option>
+</select-single-option>
+
+<select-each-option>
+  <option each={ opt, i in theOptions } selected={ i == 1 }>{ opt }</option>
+</select-each-option>
+
+<select-each-option-prompt>
+  <option>(choose)
+  <option each={ opt, i in theOptions } selected={ i == 1 }>{ opt }</option>
+</select-each-option-prompt>
+
+<select-each-two-options>
+  <option each={ opt, i in theOptions }>{ opt }
+  <option each={ opt, i in theOptions } selected={ i == 1 }>{ opt }</option>
+</select-each-two-options>
+
+<select-optgroup-each-option>
+  <optgroup label="Group 1">
+    <option each={ opt in theOptions }>{ opt }
+  </optgroup>
+</select-optgroup-each-option>
+
+<select-optgroup-each-option-prompt>
+  <option selected>(choose)
+  <optgroup label="Group 1">
+    <option each={ opt in theOptions }>{ opt }
+  </optgroup>
+</select-optgroup-each-option-prompt>
+
+<select-two-optgroup-each-option>
+  <optgroup label="Group 1">
+    <option each={ opt in theOptions }>{ opt }
+  </optgroup>
+  <option selected>(choose)</option>
+  <optgroup label="Group 2">
+    <option each={ opt in theOptions }>{ opt }
+  </optgroup>
+</select-two-optgroup-each-option>
+
+<select-each-optgroup>
+  <optgroup each={ group in groups } label={ group }>
+    <option each={ opt in theOptions }>{ opt }
+  </optgroup>
+  <script>
+    this.groups = ['Group 1', 'Group 2']
+  </script>
+</select-each-optgroup>

--- a/test/tag/table-test.tag
+++ b/test/tag/table-test.tag
@@ -1,0 +1,148 @@
+<!--
+  The main container. It is not neccesary but holds common data and all the
+  the tags, so the test only needs one call to mount("table-test") to work.
+-->
+<table-test>
+
+  <table riot-tag="table-caption"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-colgroup"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-looped-col"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-multi-col"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-tfoot"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-tr-body-only"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-tr-alone"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <table riot-tag="table-custom-thead-tfoot"
+    header={ header }
+    footer={ footer } rows={ rows } widths={ widths }/>
+
+  <script>
+  this.widths = [150, 200]
+  this.header = ['H-1', 'H-2']
+  this.footer = ['F-1', 'F-2']
+  this.rows = [['R1-C1', 'R1-C2'], ['R2-C1', 'R2-C2']]
+  </script>
+</table-test>
+
+<!-- The nested riot tags -->
+
+<table-caption>
+  <caption>Title</caption>
+  <colgroup>
+    <col each={ width in opts.widths } width="{ width }">
+  </colgroup>
+  <tbody>
+    <tr each={ row in opts.rows }>
+      <td each={ cell in row }>{ cell }</td>
+    </tr>
+  </tbody>
+</table-caption>
+
+<table-colgroup>
+  <colgroup>
+    <col each={ width in opts.widths } width="{ width }">
+  </colgroup>
+  <thead>
+    <tr><th each={ cell in opts.header }>{ cell }</th></tr>
+  </thead>
+  <tbody>
+    <tr each={ row in opts.rows }>
+      <td each={ cell in row }>{ cell }</td>
+    </tr>
+  </tbody>
+</table-colgroup>
+
+<table-looped-col>
+  <col each={ width in opts.widths } width="{ width }">
+  <thead>
+    <tr><th each={ cell in opts.header }>{ cell }</th></tr>
+  </thead>
+  <tbody>
+    <tr each={ row in opts.rows }>
+      <td each={ cell in row }>{ cell }</td>
+    </tr>
+  </tbody>
+</table-looped-col>
+
+<!-- table starting with a multiple cols, without colgroup -->
+<table-multi-col>
+  <col width="{ opts.widths[0] }">
+  <col width="{ opts.widths[1] }">
+  <thead>
+    <tr><th each={ cell in opts.header }>{ cell }</th></tr>
+  </thead>
+  <tbody>
+    <tr each={ row in opts.rows }>
+      <td each={ cell in row }>{ cell }</td>
+    </tr>
+  </tbody>
+</table-multi-col>
+
+<!-- table starting with a tfoot -->
+<table-tfoot>
+  <tfoot>
+    <tr><td each={ cell in opts.footer }>{ cell }</td></tr>
+  </tfoot>
+  <tbody>
+    <tr each={ row in opts.rows }>
+      <td each={ cell in row }>{ cell }</td>
+    </tr>
+  </tbody>
+</table-tfoot>
+
+<!-- table with a looped TR, without TBODY -->
+<table-tr-body-only>
+  <tr each={ row in opts.rows }>
+    <td each={ cell in row }>{ cell }</td>
+  </tr>
+</table-tr-body-only>
+
+<!-- table with single literal TR, without expressions -->
+<table-tr-alone>
+  <tr><td>R1-C1</td><td>R1-C2</td></tr>
+</table-tr-alone>
+
+<!-- table with all the main elements as riot tags (2 tbody) -->
+<table-custom-thead-tfoot>
+  <colgroup riot-tag="tag-colgroup" widths={ opts.widths }/>
+  <thead riot-tag="tag-thead" rows={ opts.header }/>
+  <tfoot riot-tag="tag-tfoot" rows={ opts.footer }/>
+  <tbody riot-tag="tag-tbody" rows={ opts.rows }/>
+  <tbody riot-tag="tag-tbody" rows={ opts.rows }/>
+</table-custom-thead-tfoot>
+
+<!-- riot tags for the main table elements -->
+<tag-colgroup>
+  <col each={ width in opts.widths } width={ width }>
+</tag-colgroup>
+<tag-thead>
+  <tr><td each={ cell in opts.rows }>{ cell }</td></tr>
+</tag-thead>
+<tag-tfoot>
+  <tr><td each={ cell in opts.rows }>{ cell }</td></tr>
+</tag-tfoot>
+<tag-tbody>
+  <tr each={ row in opts.rows }>
+    <td each={ cell in row }>{ cell }</td>
+  </tr>
+</tag-tbody>


### PR DESCRIPTION
This PR adds support for using `TABLE` or `SELECT` elements as root in riot tags within .tag files.
In a .tag file:
```html
<table-custom>
  <thead riot-tag="tag-thead" rows={ opts.header }/>
  <tbody riot-tag="tag-tbody" rows={ opts.rows }/>
</table-custom>

<tag-thead>
  <tr><td each={ cell in opts.rows }>{ cell }</td></tr>
</tag-thead>

<tag-tbody>
  <tr each={ row in opts.rows }><td each={ cell in row }>{ cell }</td></tr>
</tag-tbody>
```
In the html page:
```html
<table riot-tag="table-custom"
  header="{ ['h1', 'h2', 'h3'] }" rows="{ ['c1', 'c2', 'c3'] }">
</table>
```
The HTML rendering is clearer, and it is compatible with browsers supported by riot, including IE9.