### PR TITLE
refactor virtual functions and update for yielded loop content

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -54,44 +54,6 @@ function moveNestedTags(child, i) {
 }
 
 /**
- * Adds the elements for a virtual tag
- * @param { Tag } tag - the tag whose root's children will be inserted or appended
- * @param { Node } src - the node that will do the inserting or appending
- * @param { Tag } target - only if inserting, insert before this tag's first child
- */
-function addVirtual(tag, src, target) {
-  var el = tag._root, sib
-  tag._virts = []
-  while (el) {
-    sib = el.nextSibling
-    if (target)
-      src.insertBefore(el, target._root)
-    else
-      src.appendChild(el)
-
-    tag._virts.push(el) // hold for unmounting
-    el = sib
-  }
-}
-
-/**
- * Move virtual tag and all child nodes
- * @param { Tag } tag - first child reference used to start move
- * @param { Node } src  - the node that will do the inserting
- * @param { Tag } target - insert before this tag's first child
- * @param { Number } len - how many child nodes to move
- */
-function moveVirtual(tag, src, target, len) {
-  var el = tag._root, sib, i = 0
-  for (; i < len; i++) {
-    sib = el.nextSibling
-    src.insertBefore(el, target._root)
-    el = sib
-  }
-}
-
-
-/**
  * Manage tags having the 'each'
  * @param   { Object } dom - DOM node we need to loop
  * @param   { Tag } parent - parent tag instance where the dom node is contained
@@ -176,17 +138,16 @@ function _each(dom, parent, expr) {
 
         tag.mount()
         domToInsert = tag.stub || tag.root
-        if (isVirtual) tag._root = tag.root.firstChild // save reference for further moves or inserts
         // this tag must be appended
         if (i == tags.length) {
           if (isVirtual)
-            addVirtual(tag, frag)
+            makeVirtual(tag, frag)
           else frag.appendChild(domToInsert)
         }
         // this tag must be insert
         else {
           if (isVirtual)
-            addVirtual(tag, root, tags[i])
+            makeVirtual(tag, root, tags[i])
           else root.insertBefore(domToInsert, tags[i].root)
           oldItems.splice(i, 0, item)
         }
@@ -199,7 +160,7 @@ function _each(dom, parent, expr) {
       if (pos !== i && _mustReorder) {
         // update the DOM
         if (isVirtual)
-          moveVirtual(tag, root, tags[i], dom.childNodes.length)
+          moveVirtual(tag, root, tags[i])
         else root.insertBefore(tag.root, tags[i].root)
         // update the position attribute if it exists
         if (expr.pos)

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -171,7 +171,6 @@ function updateVirtual(expr, parent) {
   var conf = {root: expr.dom, parent: parent, hasImpl: true, ownAttrs: expr.ownAttrs}
   expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent, expr.nameHasExpression)
   expr.tag.mount()
-  expr.tag._root = expr.tag.root.firstChild
 
   // create placeholder in dom
   var ref = document.createTextNode('')
@@ -179,7 +178,7 @@ function updateVirtual(expr, parent) {
 
   // make tag virtual and insert
   var frag = document.createDocumentFragment()
-  addVirtual(expr.tag, frag)
+  makeVirtual(expr.tag, frag)
   ref.parentElement.replaceChild(frag, ref)
   expr.tag.update()
 

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -445,3 +445,48 @@ function mountTo(root, tagName, opts) {
 
   return tag
 }
+
+
+/**
+ * Adds the elements for a virtual tag
+ * @param { Tag } tag - the tag whose root's children will be inserted or appended
+ * @param { Node } src - the node that will do the inserting or appending
+ * @param { Tag } target - only if inserting, insert before this tag's first child
+ */
+function makeVirtual(tag, src, target) {
+  var head = document.createTextNode(''), tail = document.createTextNode(''), sib, el
+  tag._head = tag.root.insertBefore(head, tag.root.firstChild)
+  tag._tail = tag.root.appendChild(tail)
+  el = tag._head
+  tag._virts = []
+  while (el) {
+    sib = el.nextSibling
+    if (target)
+      src.insertBefore(el, target._head)
+    else
+      src.appendChild(el)
+
+    tag._virts.push(el) // hold for unmounting
+    el = sib
+  }
+}
+
+/**
+ * Move virtual tag and all child nodes
+ * @param { Tag } tag - first child reference used to start move
+ * @param { Node } src  - the node that will do the inserting
+ * @param { Tag } target - insert before this tag's first child
+ * @param { Number } len - how many child nodes to move
+ */
+function moveVirtual(tag, src, target) {
+  var el = tag._head, sib
+  while (el) {
+    sib = el.nextSibling
+    src.insertBefore(el, target._head)
+    el = sib
+    if (el == tag._tail) {
+      src.insertBefore(el, target._head)
+      break
+    }
+  }
+}

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1164,7 +1164,7 @@ describe('Compiler Browser', function() {
     tags.push(tag)
   })
 
-  it.only('only evalutes expressions once per update', function() {
+  it('only evalutes expressions once per update', function() {
     var tag = riot.mount('expression-eval-count')[0]
     expect(tag.count).to.be(1)
     tag.update()
@@ -1839,6 +1839,26 @@ it('raw contents', function() {
     expect(spans[1].innerHTML).to.be('virtuals yields expression')
     expect(divs[1].innerHTML).to.be('hello there')
 
+
+    tags.push(tag)
+  })
+
+  it('virtual tags with yielded content function in a loop', function() {
+    injectHTML('<virtual-yield-loop></virtual-yield-loop>')
+    var tag = riot.mount('virtual-yield-loop')[0]
+    var spans = tag.root.querySelectorAll('span')
+
+    expect(spans[0].innerHTML).to.be('one')
+    expect(spans[1].innerHTML).to.be('two')
+    expect(spans[2].innerHTML).to.be('three')
+
+    tag.items.reverse()
+    tag.update()
+    var spans = tag.root.querySelectorAll('span')
+
+    expect(spans[0].innerHTML).to.be('three')
+    expect(spans[1].innerHTML).to.be('two')
+    expect(spans[2].innerHTML).to.be('one')
 
     tags.push(tag)
   })

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -74,6 +74,7 @@ loadTagsAndScripts([
   'tag/reserved-names.tag',
 
   'tag/virtual-no-loop.tag',
+  'tag/virtual-yield-loop.tag',
 
   // these tags will be not autoinjected in the DOM
   // that's what `name = false` means

--- a/test/tag/virtual-yield-loop.tag
+++ b/test/tag/virtual-yield-loop.tag
@@ -1,0 +1,14 @@
+<virtual-yield-loop>
+    <virtual  riot-tag="virtual-yield-test" each={ item in items }>{ item.v }</virtual>
+
+    this.items = [
+        {v: 'one'},
+        {v: 'two'},
+        {v: 'three'}
+    ]
+</virtual-yield-loop>
+
+<virtual-yield-test>
+    <div>take up space</div>
+    <span><yield></yield></span>
+</virtual-yield-test>


### PR DESCRIPTION
moved virtual functions to `util.js`
renamed `addVirtual` to `makeVirtual` to better describe its purpose
removed `tag._root` and handle the dom placeholder creation in `makeVirtual`
dom placeholders are now `tag._head` and `tag._tail`
updated `moveVirtual` to use these instead of counter, this allows for yielded content which can vary in count
removed `it.only` that prevented the running the other tests
