### PR TITLE
more cleanup

### DIFF
--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -51,9 +51,9 @@ function parseExpressions(root, tag, expressions) {
     // we ignore the root, since parseExpressions is called while we're mounting that root
     var tagImpl = getTag(dom)
     if (tagImpl && dom !== root) {
-      attr = {dom: dom, impl: tagImpl,
+      attr = {dom: dom, impl: tagImpl, isTag: true,
         ownAttrs: allAttrs, nameHasExpression: nameHasExpression}
-      if (dom.tagName == 'VIRTUAL') attr.isVirtual = true; else attr.isTag = true
+      if (dom.tagName == 'VIRTUAL') attr.isVirtual = true
 
       parent.children.push(attr)
       return false

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -89,7 +89,6 @@ function update(expressions, tag) {
 
     if (expr.isIf) return updateIf(expr, old, value, tag)
     if (expr.isTag) return updateTagRef(expr, tag)
-    if (expr.isVirtual) return updateVirtual(expr, tag)
     if (expr.isLoop) return expr.update()
     if (expr.isNamed) return updateNamed(expr, old, value, tag)
 
@@ -158,26 +157,13 @@ function updateTagRef(expr, parent) {
   var conf = {root: expr.dom, parent: parent, hasImpl: true, ownAttrs: expr.ownAttrs}
   expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent, expr.nameHasExpression)
   expr.tag.mount()
-  expr.tag.update()
-}
 
-function updateVirtual(expr, parent) {
-  if (expr.tag) {
-    expr.tag.update()
-    return
+  if (expr.isVirtual) {
+    var frag = document.createDocumentFragment()
+    makeVirtual(expr.tag, frag)
+    expr.tag.root.parentElement.replaceChild(frag, expr.tag.root)
   }
-
-  // create tag
-  var conf = {root: expr.dom, parent: parent, hasImpl: true, ownAttrs: expr.ownAttrs}
-  expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent, expr.nameHasExpression)
-  expr.tag.mount()
-
-  // make tag virtual and insert
-  var frag = document.createDocumentFragment()
-  makeVirtual(expr.tag, frag)
-  expr.tag.root.parentElement.replaceChild(frag, expr.tag.root)
   expr.tag.update()
-
 }
 
 // If expressions add or remove DOM, as well as control the flow of updates.

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -476,7 +476,6 @@ function makeVirtual(tag, src, target) {
  * @param { Tag } tag - first child reference used to start move
  * @param { Node } src  - the node that will do the inserting
  * @param { Tag } target - insert before this tag's first child
- * @param { Number } len - how many child nodes to move
  */
 function moveVirtual(tag, src, target) {
   var el = tag._head, sib


### PR DESCRIPTION
remove `updateVirtual` and do the logic in `updateTagRef`
significant code reduction and eliminates the extra `expr.isVirtual` comparison in `update`
I don't suspect there are any down sides to having multiple 'is' attributes on a children attribute object?
unused parameter removed from jsdoc