### PR TITLE
Enhanced yield

### DIFF
--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -7,7 +7,6 @@
 */
 var mkdom = (function (checkIE) {
   var
-    reHasYield  = /<yield\b/i,
     reYieldAll  = /<yield\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
     reYieldCls  = /<yield\s+to=[^>]+>[\S\s]*?<\/yield\s*>\s*/ig,
     reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
@@ -84,7 +83,7 @@ var mkdom = (function (checkIE) {
   */
   function replaceYield(templ, html) {
     // do nothing if no yield
-    if (!reHasYield.test(templ)) return templ
+    if (!/<yield\b/i.test(templ)) return templ
 
     // be careful with #1343 - string on the source having `$1`
     var n = 1

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -6,28 +6,43 @@
        http://codeplanet.io/dropping-ie8/
 */
 var mkdom = (function (checkIE) {
-
   var
-    reToSrc = /<yield\s+to=(['"])?@\1\s*>([\S\s]+?)<\/yield\s*>/.source,
-    rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' },
-    GENERIC = 'div'
+    reHasYield  = /<yield\b/i,
+    reYieldAll  = /<yield\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
+    reYieldCls  = /<yield\s+to=[^>]+>[\S\s]*?<\/yield\s*>\s*/ig,
+    reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
+    rsYieldSrc  = '<yield\\s+to=[\'"]@[\'"]\\s*>([\\S\\s]*?)</yield\\s*>',
+    rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' }
 
   checkIE = checkIE && checkIE < 10
   var tblTags = checkIE
     ? SPECIAL_TAGS_REGEX : /^(?:t(?:body|head|foot|[rhd])|caption|col(?:group)?)$/
 
-  // creates any dom element in a div, table, or colgroup container
-  function _mkdom(templ, html) {
+  /**
+   * Creates a DOM element to wrap the given content. Normally an `DIV`, but can be
+   * also a `TABLE`, `SELECT`, `TBODY`, `TR`, or `COLGROUP` element.
+   *
+   * @param   {string} impl   - Tag implementation with the template and root attributes
+   * @param   {string} [html] - HTML content that comes from the DOM element where you
+   *           will mount the tag, mostly the original tag in the page
+   * @param   {object} [attr] - Plain object where to store the root attributes
+   * @returns {HTMLElement} DOM element with _templ_ merged through `YIELD` with the _html_.
+   */
+  function _mkdom(impl, html, attr) {
 
-    var match = templ && templ.match(/^\s*<([-\w]+)/),
+    var templ = impl.tmpl,
+      match   = templ && templ.match(/^\s*<([-\w]+)/),
       tagName = match && match[1].toLowerCase(),
-      el = mkEl(GENERIC)
+      el = mkEl('div')
+
+    if (!html) html = ''
+
+    if (impl.attrs) attr.attrs = replaceYield(impl.attrs, html)
 
     // replace all the yield tags with the tag inner html
-    templ = replaceYield(templ, html || '')
+    templ = replaceYield(templ, html)
 
     /* istanbul ignore next */
-    //if ((checkIE || !startsWith(tagName, 'opt')) && SPECIAL_TAGS_REGEX.test(tagName))
     if (tblTags.test(tagName))
       el = specialTags(el, templ, tagName)
     else
@@ -38,8 +53,10 @@ var mkdom = (function (checkIE) {
     return el
   }
 
-  // creates the root element for table and select child elements
-  // tr/th/td/thead/tfoot/tbody/caption/col/colgroup/option/optgroup
+  /*
+    Creates the root element for table or select child elements:
+    tr/th/td/thead/tfoot/tbody/caption/col/colgroup/option/optgroup
+  */
   function specialTags(el, templ, tagName) {
     var
       select = tagName[0] === 'o',
@@ -61,28 +78,31 @@ var mkdom = (function (checkIE) {
     return parent
   }
 
-  /**
-   * Replace the yield tag from any tag template with the innerHTML of the
-   * original tag in the page
-   * @param   { String } templ - tag implementation template
-   * @param   { String } html  - original content of the tag in the DOM
-   * @returns { String } tag template updated without the yield tag
-   */
+  /*
+    Replace the yield tag from any tag template with the innerHTML of the
+    original tag in the page
+  */
   function replaceYield(templ, html) {
     // do nothing if no yield
-    if (!/<yield\b/i.test(templ)) return templ
+    if (!reHasYield.test(templ)) return templ
 
     // be careful with #1343 - string on the source having `$1`
-    var n = 0
-    templ = templ.replace(/<yield\s+from=['"]([-\w]+)['"]\s*(?:\/>|>\s*<\/yield\s*>)/ig,
-      function (str, ref) {
-        var m = html.match(RegExp(reToSrc.replace('@', ref), 'i'))
-        ++n
-        return m && m[2] || ''
-      })
+    var n = 1
+    templ = templ.replace(reYieldDest, function (_, ref, def) {
+      var m = html.match(RegExp(rsYieldSrc.replace('@', ref), 'i'))
+      n = 0
+      return (m ? m[1] : def) || ''
+    })
 
     // yield without any "from", replace yield in templ with the innerHTML
-    return n ? templ : templ.replace(/<yield\s*(?:\/>|>\s*<\/yield\s*>)/gi, html)
+    if (n || reHasYield.test(templ)) {
+      if (html) html = html.replace(reYieldCls, '').trim()
+      templ = templ.replace(reYieldAll, function (_, def) {
+        return html || def || ''
+      })
+    }
+
+    return templ
   }
 
   return _mkdom

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -7,6 +7,7 @@
 */
 var mkdom = (function (checkIE) {
   var
+    reHasYield  = /<yield\b/i,
     reYieldAll  = /<yield\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
     reYieldCls  = /<yield\s+to=[^>]+>[\S\s]*?<\/yield\s*>\s*/ig,
     reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
@@ -83,7 +84,7 @@ var mkdom = (function (checkIE) {
   */
   function replaceYield(templ, html) {
     // do nothing if no yield
-    if (!/<yield\b/i.test(templ)) return templ
+    if (!reHasYield.test(templ)) return templ
 
     // be careful with #1343 - string on the source having `$1`
     var n = 1

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -12,6 +12,7 @@ function Tag(impl, conf, innerHTML) {
     fn = impl.fn,
     tagName = root.tagName.toLowerCase(),
     attr = {},
+    implAttr = {},
     propsInSyncWithParent = [],
     dom
 
@@ -38,7 +39,8 @@ function Tag(impl, conf, innerHTML) {
     if (tmpl.hasExpr(val)) attr[el.name] = val
   })
 
-  dom = mkdom(impl.tmpl, innerHTML)
+  dom = mkdom(impl, innerHTML, implAttr)
+  implAttr = implAttr.attrs || ''
 
   // options
   function updateOpts() {
@@ -144,8 +146,8 @@ function Tag(impl, conf, innerHTML) {
 
     // update the root adding custom attributes coming from the compiler
     // it fixes also #1087
-    if (impl.attrs || hasImpl) {
-      walkAttributes(impl.attrs, function (k, v) { setAttr(root, k, v) })
+    if (implAttr || hasImpl) {
+      walkAttributes(implAttr, function (k, v) { setAttr(root, k, v) })
       parseExpressions(self.root, self, expressions)
     }
 

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -752,7 +752,7 @@ describe('Compiler Browser', function() {
 
     var tag = riot.mount('inner-html')[0]
 
-    expect(normalizeHTML(tag.root.innerHTML)).to.be('<h1>Hello,   World  <inner value="ciao mondo"><p> ciao mondo </p></inner></h1>')
+    expect(normalizeHTML(tag.root.innerHTML)).to.be('<h1>Hello, World  <inner value="ciao mondo"><p> ciao mondo </p></inner></h1>')
     tags.push(tag)
 
   })
@@ -788,6 +788,23 @@ describe('Compiler Browser', function() {
     tags.push(tag)
   })
 
+  it('<yield from> name can be unquoted, without <yield to> default to its content', function () {
+    var html = [
+      '<yield-from-default>',
+      ' <yield to="icon">my-icon</yield>',
+      ' <yield to="hello">Hello $1 $2</yield>',
+      ' <yield to="loop">[⁗foo⁗,\'bar\']</yield>',
+      '</yield-from-default>'
+    ]
+
+    injectHTML(html.join('\n'))
+    expect($('yield-from-default')).not.to.be(null)
+    var tag = riot.mount('yield-from-default')[0]
+    html = '<p>(no options)</p><p>Hello $1 $2 <span class="my-icon"></span></p><p>foo</p><p>bar</p>'
+    expect(normalizeHTML(tag.root.innerHTML)).to.be(html)
+    tags.push(tag)
+  })
+
   it('multiple mount <yield> tag', function() {
 
     riot.mount('inner-html')
@@ -796,7 +813,7 @@ describe('Compiler Browser', function() {
     riot.mount('inner-html')
     tag = riot.mount('inner-html')[0]
 
-    expect(normalizeHTML(tag.root.innerHTML)).to.be('<h1>Hello,   World  <inner value="ciao mondo"><p> ciao mondo </p></inner></h1>')
+    expect(normalizeHTML(tag.root.innerHTML)).to.be('<h1>Hello, World  <inner value="ciao mondo"><p> ciao mondo </p></inner></h1>')
     tags.push(tag)
 
   })

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -114,7 +114,10 @@ loadTagsAndScripts([
     path: 'tag/yield-multi2.tag',
     name: false
   },
-
+  {
+    path: 'tag/yield-from-default.tag',
+    name: false
+  },
   // the following tags will be injected having custom attributes
   {
     path: 'tag/named-select.tag',

--- a/test/tag/yield-from-default.tag
+++ b/test/tag/yield-from-default.tag
@@ -1,0 +1,5 @@
+<yield-from-default>
+  <yield from=options><p>(no options)</p></yield>
+  <p><yield from=hello>Hi</yield> <span class="<yield from=icon/>"></span></p>
+  <p each={ item in <yield from=loop/> }>{ item }</p>
+</yield-from-default>


### PR DESCRIPTION
This PR enhances the `yield` keyword allowing:

- Have named yields along with the anonymous yield. Named yields are replaced first.
- Default content. If the source does not exist, or it has whitespace only, uses the content of the target `yield` tag.
- Unquoted names in the target. E.g. `<yield from=name />`
- Use of `yield` in root attributes. Can be used to solve #1239 and #1513 in a performant way, as it is a "hard" replacement (i.e. no involved expression).

[This plunker](http://plnkr.co/edit/cMTRfj?p=preview) have some examples of use.

@GianlucaGuarini , for me this works well, but can be too much functionality to be simple or performant. Please tell me if I must cut some feature or this does not work in your tests.