### PR TITLE
isObject w/o null

### DIFF
--- a/lib/browser/compiler/compile.js
+++ b/lib/browser/compiler/compile.js
@@ -78,7 +78,7 @@ riot.compile = (function () {
     if (typeof arg === T_STRING) {
 
       // 2nd parameter is optional, but can be null
-      if (fn && typeof fn === T_OBJECT) {
+      if (isObject(fn)) {
         opts = fn
         fn = false
       }

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -123,7 +123,7 @@ riot.mount = function(selector, tagName, opts) {
   // inject styles into DOM
   styleManager.inject()
 
-  if (typeof tagName === T_OBJECT) {
+  if (isObject(tagName)) {
     opts = tagName
     tagName = 0
   }

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -86,7 +86,7 @@ function Tag(impl, conf, innerHTML) {
     // inherit properties from the parent
     inheritFromParent()
     // normalize the tag properties in case an item object was initially passed
-    if (data && typeof item === T_OBJECT) {
+    if (data && isObject(item)) {
       normalizeData(data)
       item = data
     }

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -25,12 +25,13 @@ function isFunction(v) {
 }
 
 /**
- * Detect if the argument passed is an object
+ * Detect if the argument passed is an object, exclude null.
+ * NOTE: Use isObject(x) && !isArray(x) to excludes arrays.
  * @param   { * } v - whatever you want to pass to this function
  * @returns { Boolean } -
  */
 function isObject(v) {
-  return typeof v === T_OBJECT || false   // avoid IE problems
+  return v && typeof v === T_OBJECT         // typeof null is 'object'
 }
 
 /**


### PR DESCRIPTION
Exclude `null` (and anything falsy) from the test in `isObject`.
You will still need to use `!isArray()` if you want to differentiate arrays.