### PR TITLE
Closes #1625

### DIFF
--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -69,38 +69,44 @@ function update(expressions, tag) {
     var dom = expr.dom,
       attrName = expr.attr,
       value = tmpl(expr.expr, tag),
-      parent = expr.dom.parentNode,
-      isValueAttr = attrName == 'value'
+      parent = expr.dom.parentNode
 
     if (expr.bool)
-      value = value ? attrName : false
+      value = !!value
     else if (value == null)
       value = ''
 
-    // leave out riot- prefixes from strings inside textarea
-    // fix #815: any value -> string
-    if (parent && parent.tagName == 'TEXTAREA') {
-      value = ('' + value).replace(/riot-/g, '')
-      // change textarea's value
-      parent.value = value
-    }
-
-    // no change
-    if (
-      !attrName && dom.nodeValue == value || // was the value of the text node changed?
-      isValueAttr && dom.value == value || // was the value of this dom node changed?
-      !isValueAttr && expr.value === value // was the expression value still the same?
-    ) return
-    expr.value = value
-
-    // text node
+    // textarea and text nodes has no attribute name
     if (!attrName) {
-      dom.nodeValue = '' + value    // #815 related
+      // about #815 w/o replace: the browser converts the value to a string,
+      // the comparison by "==" does too, but not in the server
+      value += ''
+      // test for parent avoids error with invalid assignment to nodeValue
+      if (parent && dom.nodeValue != value) {
+        if (parent.tagName === 'TEXTAREA') {
+          parent.value = value                    // #1113
+          if (!IE_VERSION) dom.nodeValue = value  // #1625 IE throws here, nodeValue
+        }                                         // will be available on 'updated'
+        else dom.nodeValue = value
+      }
       return
     }
 
+    // #1612: look for changes in dom.value when updating the value
+    if (attrName === 'value') {
+      if (dom.value != value) dom.value = value
+      return
+    }
+
+    // was the expression value still the same?
+    if (expr.value === value) {
+      return
+    }
+    expr.value = value
+
     // remove original attribute
     remAttr(dom, attrName)
+
     // event handler
     if (isFunction(value)) {
       setEventHandler(attrName, value, dom, tag)
@@ -137,32 +143,27 @@ function update(expressions, tag) {
         dom.inStub = true
       }
     // show / hide
-    } else if (/^(show|hide)$/.test(attrName)) {
-      if (attrName == 'hide') value = !value
+    } else if (attrName === 'show') {
       dom.style.display = value ? '' : 'none'
 
-    // field value
-    } else if (attrName == 'value') {
-      dom.value = value
+    } else if (attrName === 'hide') {
+      dom.style.display = value ? 'none' : ''
 
-    // <img src="{ expr }">
-    } else if (startsWith(attrName, RIOT_PREFIX) && attrName != RIOT_TAG) {
-      if (value)
-        setAttr(dom, attrName.slice(RIOT_PREFIX.length), value)
-
-    } else {
-      // <select> <option selected={true}> </select>
-      if (attrName == 'selected' && parent && /^(SELECT|OPTGROUP)$/.test(parent.nodeName) && value)
-        parent.value = dom.value
-
-      if (expr.bool) {
-        dom[attrName] = value
-        if (!value) return
+    } else if (expr.bool) {
+      if (value) {
+        // #1374 <select> <option selected={true}> </select>
+        if (attrName === 'selected' && dom.nodeName === 'OPTION' && parent) {
+          parent.value = dom.value
+        }
+        setAttr(dom, attrName, attrName)
       }
 
-      if (value === 0 || value && typeof value !== T_OBJECT)
-        setAttr(dom, attrName, value)
-
+    } else if (value === 0 || value && typeof value !== T_OBJECT) {
+      // <img src="{ expr }">
+      if (startsWith(attrName, RIOT_PREFIX) && attrName != RIOT_TAG) {
+        attrName = attrName.slice(RIOT_PREFIX.length)
+      }
+      setAttr(dom, attrName, value)
     }
 
   })

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -528,11 +528,12 @@ describe('Compiler Browser', function() {
   it('loop option tag', function() {
     var tag = riot.mount('loop-option')[0],
       root = tag.root,
-      option = root.getElementsByTagName('select')[0]
+      options = root.getElementsByTagName('select')[0],
+      html = normalizeHTML(root.innerHTML).replace(/ selected="selected"/, '')
 
-    expect(normalizeHTML(root.innerHTML)).to.match(/<select><option value="1">Peter<\/option><option selected="(selected|true)" value="2">Sherman<\/option><option value="3">Laura<\/option><\/select>/)
+    expect(html).to.match(/<select><option value="1">Peter<\/option><option value="2">Sherman<\/option><option value="3">Laura<\/option><\/select>/)
 
-    expect(option.selectedIndex).to.be(1)
+    expect(options.selectedIndex).to.be(1)
     tags.push(tag)
 
   })
@@ -548,9 +549,10 @@ describe('Compiler Browser', function() {
 
   it('loop optgroup tag', function() {
     var tag = riot.mount('loop-optgroup')[0],
-      root = tag.root
+      root = tag.root,
+      html = normalizeHTML(root.innerHTML).replace(/(value="\d") (selected="selected")/, '$2 $1')
 
-    expect(normalizeHTML(root.innerHTML)).to.match(/<select><optgroup label="group 1"><option value="1">Option 1.1<\/option><option value="2">Option 1.2<\/option><\/optgroup><optgroup label="group 2"><option value="3">Option 2.1<\/option><option selected="(selected|true)" value="4">Option 2.2<\/option><\/optgroup><\/select>/)
+    expect(html).to.match(/<select><optgroup label="group 1"><option value="1">Option 1.1<\/option><option value="2">Option 1.2<\/option><\/optgroup><optgroup label="group 2"><option value="3">Option 2.1<\/option><option selected="selected" value="4">Option 2.2<\/option><\/optgroup><\/select>/)
 
     tags.push(tag)
 
@@ -558,10 +560,11 @@ describe('Compiler Browser', function() {
 
   it('loop optgroup tag (outer option, no closing option tags)', function() {
     var tag = riot.mount('loop-optgroup2')[0],
-      root = tag.root
+      root = tag.root,
+      html = normalizeHTML(root.innerHTML).replace(/(value="\d") (disabled="disabled")/g, '$2 $1')
 
-    expect(normalizeHTML(root.innerHTML)).to
-      .match(/<select><option selected="selected">&lt;Select Option&gt; ?(<\/option>)?<optgroup label="group 1"><option value="1">Option 1.1 ?(<\/option>)?<option (?:value="2"|disabled="disabled") (?:value="2"|disabled="disabled")>Option 1.2 ?(<\/option>)?<\/optgroup><optgroup label="group 2"><option value="3">Option 2.1 ?(<\/option>)?<option (?:value="4"|disabled="disabled") (?:value="4"|disabled="disabled")>Option 2.2 ?<\/option><\/optgroup><\/select>/)
+    expect(html).to
+      .match(/<select><option selected="selected">&lt;Select Option&gt; ?(<\/option>)?<optgroup label="group 1"><option value="1">Option 1.1 ?(<\/option>)?<option disabled="disabled" value="2">Option 1.2 ?(<\/option>)?<\/optgroup><optgroup label="group 2"><option value="3">Option 2.1 ?(<\/option>)?<option disabled="disabled" value="4">Option 2.2 ?<\/option><\/optgroup><\/select>/)
 
     tags.push(tag)
 
@@ -2041,6 +2044,21 @@ it('raw contents', function() {
     expect(tag.x.value).to.be('3')
     expect(tag.y.value).to.be('44')
     expect(tag.z.value).to.be('23')
+
+    tags.push(tag)
+  })
+
+  it('render tag: input,option,textarea tags having expressions as value', function() {
+    injectHTML('<form-controls></form-controls>')
+    var val = 'my-value',
+      tag = riot.mount('form-controls', { text: val })[0],
+      root = tag.root
+
+    expect(root.querySelector('input[type="text"]').value).to.be(val)
+    expect(root.querySelector('select option[selected]').value).to.be(val)
+    expect(root.querySelector('textarea[name="txta1"]').value).to.be(val)
+    expect(root.querySelector('textarea[name="txta2"]').value).to.be('')
+    expect(root.querySelector('textarea[name="txta2"]').placeholder).to.be(val)
 
     tags.push(tag)
   })

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -122,6 +122,10 @@ loadTagsAndScripts([
     path: 'tag/yield-from-default.tag',
     name: false
   },
+  {
+    path: 'tag/form-controls.tag',
+    name: false
+  },
   // the following tags will be injected having custom attributes
   {
     path: 'tag/named-select.tag',

--- a/test/specs/server/node.js
+++ b/test/specs/server/node.js
@@ -99,7 +99,8 @@ describe('Node/io.js', function() {
     var $ = cheerio.load(frm)
     expect($('input[type="text"]').val()).to.be('my-value')
     expect($('select option:selected').val()).to.be('my-value')
-    expect($('textarea').val()).to.be('my-value')
+    expect($('textarea[name="txta1"]').val()).to.be('my-value')
+    expect($('textarea[name="txta2"]').val()).to.be('')
   })
 
 })

--- a/test/tag/form-controls.tag
+++ b/test/tag/form-controls.tag
@@ -10,7 +10,9 @@
     <option selected value={ opts.text }>my-value</option>
   </select>
 
-  <textarea>{ opts.text }</textarea>
+  <textarea name="txta1">{ opts.text }</textarea>
+
+  <textarea name="txta2" placeholder={ opts.text }></textarea>
 
   <label>
     <input type="radio" onclick={ check }> Click me


### PR DESCRIPTION
Refactorization of lib/browser/tag/update.js.
In IE the value of `nodeValue` cannot be replaced, it will be available on the 'updated' event.
Prevents error in IE with `placeholder` and empty values in textarea.

See placeholder error with IE in http://plnkr.co/edit/rCXyuXFnlSjC0voKF36Y