### PR TITLE
Introduced Editors section to README and added sublime-tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ HTML syntax is the de facto language on the web and it's designed for building u
 
 ### Editors / Editor Plugins (Syntax highlighting, autcompletion, etc...)
 - [riot (Atom Package)](https://atom.io/packages/riot)
+- [language-riot-tag (Atom Package)](https://github.com/dekimasoon/language-riot-tag)
+  - Note: Designed for html, not jade.
 - [sublime-tag (Sublime Text)](https://github.com/crisward/sublime-tag)
 
 ### Credits

--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ HTML syntax is the de facto language on the web and it's designed for building u
 - [Yeoman generator - Generator riot mobile](https://www.npmjs.com/package/generator-riot-mobile)
 - [Yeoman generator - Generator riot element](https://www.npmjs.com/package/generator-riot-element)
 - [Riot for TypeScript](https://github.com/nippur72/RiotTS)
-- [Sublime Syntax Highlighting for Riot Tag Files - Jade & HTML](https://github.com/crisward/sublime-tag)
-- [VS Code Syntax Highlighting for Riot Tag Files - Jade & HTML](https://github.com/crisward/riot-tag)
 - [Riot loader plugin for RequireJS](https://github.com/amenadiel/requirejs-riot)
 - [Riot loader plugin for JSPM/SystemJS](https://github.com/amenadiel/systemjs-riot)
 
@@ -191,6 +189,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
   - Based on Vue's official Sublime Text highlighter
   - Note: Designed for html, not jade.
 - [sublime-tag (Sublime Text)](https://github.com/crisward/sublime-tag)
+- [riot-tag (Visual Studio)](https://github.com/crisward/riot-tag)
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
 ### Editors / Editor Plugins (Syntax highlighting, autcompletion, etc...)
 - [riot (Atom Package)](https://atom.io/packages/riot)
 - [language-riot-tag (Atom Package)](https://github.com/dekimasoon/language-riot-tag)
+  - Based on Vue's official Sublime Text highlighter
   - Note: Designed for html, not jade.
 - [sublime-tag (Sublime Text)](https://github.com/crisward/sublime-tag)
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ HTML syntax is the de facto language on the web and it's designed for building u
 ### Miscellaneous
 - [Q&A with RiotJS author Tero Piirainen](http://www.triplet.fi/blog/q-and-a-with-riotjs-author-tero-piirainen/)
 - [riot-detector (Chrome Extension)](https://chrome.google.com/webstore/detail/riot-detector/cnnmjeggdmicjojlnjghdgkdlijiobke)
+
+### Editors / Editor Plugins (Syntax highlighting, autcompletion, etc...)
 - [riot (Atom Package)](https://atom.io/packages/riot)
+- [sublime-tag (Sublime Text)](https://github.com/crisward/sublime-tag)
 
 ### Credits
 


### PR DESCRIPTION

I moved Atom Editor's riot package and sublime-tag both into a new Editors section. I added it after Miscellaneous to maintain order as best as possible, although arguably Miscellaneous should come after., I am mainly doing this in response to issue #946.