### PR TITLE
data-is support

### DIFF
--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -17,6 +17,7 @@ var riot = { version: 'WIP', settings: {} },
   // riot specific prefixes
   RIOT_PREFIX = 'riot-',
   RIOT_TAG = RIOT_PREFIX + 'tag',
+  RIOT_TAG_IS = 'data-is',
 
   // for typeof == '' comparisons
   T_STRING = 'string',

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -91,7 +91,7 @@ riot.mount = function(selector, tagName, opts) {
     var list = ''
     each(arr, function (e) {
       if (!/[^-\w]/.test(e))
-        list += ',*[' + RIOT_TAG + '=' + e.trim() + ']'
+        list += ',*[' + RIOT_TAG_IS + '=' + e.trim() + '],*[' + RIOT_TAG + '=' + e.trim() + ']'
     })
     return list
   }
@@ -103,7 +103,7 @@ riot.mount = function(selector, tagName, opts) {
 
   function pushTags(root) {
     if (root.tagName) {
-      var riotTag = getAttr(root, RIOT_TAG)
+      var riotTag = getAttr(root, RIOT_TAG_IS) || getAttr(root, RIOT_TAG)
 
       // have tagName? force riot-tag to be the same
       if (tagName && riotTag !== tagName) {

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -80,7 +80,8 @@ function setAttr(dom, name, val) {
  * @returns { Object } it returns an object containing the implementation of a custom tag (template and boot function)
  */
 function getTag(dom) {
-  return dom.tagName && __tagImpl[getAttr(dom, RIOT_TAG) || dom.tagName.toLowerCase()]
+  return dom.tagName && __tagImpl[getAttr(dom, RIOT_TAG_IS) ||
+    getAttr(dom, RIOT_TAG) || dom.tagName.toLowerCase()]
 }
 /**
  * Add a child tag to its parent into the `tags` object

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -2079,4 +2079,14 @@ it('raw contents', function() {
     tags.push(tag)
   })
 
+  it('support `data-is` in addition to `riot-tag` for html5 compliance', function() {
+    injectHTML('<div data-is="tag-data-is"></div>')
+    var tag = riot.mount('tag-data-is')[0]
+    var els = tag.root.getElementsByTagName('p')
+    expect(els.length).to.be(2)
+    expect(els[0].innerHTML).to.contain('html5')
+    expect(els[1].innerHTML).to.contain('too')
+    tags.push(tag)
+  })
+
 })

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -127,6 +127,10 @@ loadTagsAndScripts([
     path: 'tag/form-controls.tag',
     name: false
   },
+  {
+    path: 'tag/data-is.tag',
+    name: false
+  },
   // the following tags will be injected having custom attributes
   {
     path: 'tag/named-select.tag',

--- a/test/tag/data-is.tag
+++ b/test/tag/data-is.tag
@@ -1,0 +1,6 @@
+<tag-data-is>
+  <p>I'm html5 compliant</p>
+  <p data-is="tag-data-is-nested"/>
+</tag-data-is>
+
+<tag-data-is-nested>Mee too!</tag-data-is-nested>


### PR DESCRIPTION
Adds support to the attribute `data-is` for html5 compliance.
`riot-tag` is still supported to maintain compatibility.
Example:
```html
<!-- tag definitions -->
<tag-data-is>
  <p>I'm html5 compliant</p>
  <p data-is="tag-data-is-nested"/>
</tag-data-is>

<tag-data-is-nested>Mee too!</tag-data-is-nested>
```
Usage:
```html
<div data-is="tag-data-is"></div>
```

Closes #1342, #1636 and attends the petition from dwyl/learn-riot#8