### PR TITLE
Closes #1374

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -109,7 +109,7 @@ function _each(dom, parent, expr) {
     root = dom.parentNode,
     ref = document.createTextNode(''),
     child = getTag(dom),
-    isOption = /^option$/i.test(tagName), // the option tags must be treated differently
+    isOption = tagName.toLowerCase() === 'option', // the option tags must be treated differently
     tags = [],
     oldItems = [],
     hasKeys,
@@ -133,8 +133,6 @@ function _each(dom, parent, expr) {
     var items = tmpl(expr.val, parent),
       // create a fragment to hold the new DOM nodes to inject in the parent tag
       frag = document.createDocumentFragment()
-
-
 
     // object loop. any changes cause full redraw
     if (!isArray(items)) {
@@ -177,6 +175,7 @@ function _each(dom, parent, expr) {
         }, dom.innerHTML)
 
         tag.mount()
+
         if (isVirtual) tag._root = tag.root.firstChild // save reference for further moves or inserts
         // this tag must be appended
         if (i == tags.length || !tags[i]) { // fix 1581
@@ -188,7 +187,7 @@ function _each(dom, parent, expr) {
         else {
           if (isVirtual)
             addVirtual(tag, root, tags[i])
-          else root.insertBefore(tag.root, tags[i].root)
+          else root.insertBefore(tag.root, tags[i].root) // #1374 some browsers reset selected here
           oldItems.splice(i, 0, item)
         }
 
@@ -228,7 +227,21 @@ function _each(dom, parent, expr) {
     unmountRedundant(items, tags)
 
     // insert the new nodes
-    if (isOption) root.appendChild(frag)
+    if (isOption) {
+      root.appendChild(frag)
+
+      // #1374 <select> <option selected={true}> </select>
+      if (root.length) {
+        var si, op = root.options
+
+        root.selectedIndex = si = -1
+        for (i = 0; i < op.length; i++) {
+          if (op[i].selected = op[i].__selected) {
+            if (si < 0) root.selectedIndex = si = i
+          }
+        }
+      }
+    }
     else root.insertBefore(frag, ref)
 
     // set the 'tags' property of the parent tag

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -71,8 +71,10 @@ function update(expressions, tag) {
       value = tmpl(expr.expr, tag),
       parent = expr.dom.parentNode
 
-    if (expr.bool)
+    if (expr.bool) {
       value = !!value
+      if (attrName === 'selected') dom.__selected = value   // #1374
+    }
     else if (value == null)
       value = ''
 
@@ -151,13 +153,8 @@ function update(expressions, tag) {
       dom.style.display = value ? 'none' : ''
 
     } else if (expr.bool) {
-      if (value) {
-        // #1374 <select> <option selected={true}> </select>
-        if (attrName === 'selected' && dom.nodeName === 'OPTION' && parent) {
-          parent.value = dom.value
-        }
-        setAttr(dom, attrName, attrName)
-      }
+      dom[attrName] = value
+      if (value) setAttr(dom, attrName, attrName)
 
     } else if (value === 0 || value && typeof value !== T_OBJECT) {
       // <img src="{ expr }">

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -549,6 +549,9 @@ describe('Compiler Browser', function() {
 
     expect(html).to.match(/<select><option value="1">Peter<\/option><option value="2">Sherman<\/option><option value="3">Laura<\/option><\/select>/)
 
+    //expect(options[0].selected).to.be(false)
+    expect(options[1].selected).to.be(true)
+    expect(options[2].selected).to.be(false)
     expect(options.selectedIndex).to.be(1)
     tags.push(tag)
 


### PR DESCRIPTION
For `select`s with non-looped options, `selectedIndex` cannot be set to -1 and Safari 5.1 fails to set the selected value.

This closes #1647 as well.