### PR TITLE
Revision of riot.mount and riot.tag

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -51,6 +51,7 @@ riot.tag = function(name, html, css, attrs, fn) {
     if (isFunction(css)) fn = css
     else styleManager.add(css)
   }
+  name = name.toLowerCase()
   __tagImpl[name] = { name: name, tmpl: html, attrs: attrs, fn: fn }
   return name
 }
@@ -62,10 +63,9 @@ riot.tag = function(name, html, css, attrs, fn) {
  * @param   { String }   css - custom tag css
  * @param   { String }   attrs - root tag attributes
  * @param   { Function } fn - user function
- * @param   { string }  [bpair] - brackets used in the compilation
  * @returns { String } name/id of the tag just created
  */
-riot.tag2 = function(name, html, css, attrs, fn, bpair) {
+riot.tag2 = function(name, html, css, attrs, fn) {
   if (css) styleManager.add(css)
   //if (bpair) riot.settings.brackets = bpair
   __tagImpl[name] = { name: name, tmpl: html, attrs: attrs, fn: fn }
@@ -90,8 +90,10 @@ riot.mount = function(selector, tagName, opts) {
   function addRiotTags(arr) {
     var list = ''
     each(arr, function (e) {
-      if (!/[^-\w]/.test(e))
-        list += ',*[' + RIOT_TAG_IS + '=' + e.trim() + '],*[' + RIOT_TAG + '=' + e.trim() + ']'
+      if (!/[^-\w]/.test(e)) {
+        e = e.trim().toLowerCase()
+        list += ',[' + RIOT_TAG_IS + '="' + e + '"],[' + RIOT_TAG + '="' + e + '"]'
+      }
     })
     return list
   }
@@ -108,7 +110,7 @@ riot.mount = function(selector, tagName, opts) {
       // have tagName? force riot-tag to be the same
       if (tagName && riotTag !== tagName) {
         riotTag = tagName
-        setAttr(root, RIOT_TAG, tagName)
+        setAttr(root, RIOT_TAG_IS, tagName)
       }
       var tag = mountTo(root, riotTag || root.tagName.toLowerCase(), opts)
 
@@ -136,7 +138,7 @@ riot.mount = function(selector, tagName, opts) {
       selector = allTags = selectAllTags()
     else
       // or just the ones named like the selector
-      selector += addRiotTags(selector.split(/, ?/))
+      selector += addRiotTags(selector.split(/, */))
 
     // make sure to pass always a selector
     // to the querySelectorAll function

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -16,7 +16,8 @@ function Tag(impl, conf, innerHTML) {
     propsInSyncWithParent = [],
     dom
 
-  if (fn && root._tag) root._tag.unmount(true)
+  // only call unmount if we have a valid __tagImpl (has name property)
+  if (impl.name && root._tag) root._tag.unmount(true)
 
   // not yet mounted
   this.isMounted = false

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1554,9 +1554,9 @@ it('raw contents', function() {
   it('the riot-tag attribute gets updated if a DOM node gets mounted using two or more different tags', function() {
     var div = document.createElement('div')
     tags.push(riot.mount(div, 'timetable')[0])
-    expect(div.getAttribute('riot-tag')).to.be('timetable')
+    expect(div.getAttribute('riot-tag') || div.getAttribute('data-is')).to.be('timetable')
     tags.push(riot.mount(div, 'test')[0])
-    expect(div.getAttribute('riot-tag')).to.be('test')
+    expect(div.getAttribute('riot-tag') || div.getAttribute('data-is')).to.be('test')
 
   })
 
@@ -1884,7 +1884,7 @@ it('raw contents', function() {
     var str = '<style-option><style>p {top:0}<\/style>\n<\/style-option>',
       result
     result = riot.compile(str, {'style': 'scoped-css'})
-    expect(result).to.contain('[riot-tag="style-option"] p {top:0}')
+    expect(result).to.match(/\[(?:riot-tag|data-is)="style-option"\] p ?\{top:0\}/)
   })
 
   it('allow passing riot.observale instances to the children tags', function() {
@@ -2129,6 +2129,32 @@ it('raw contents', function() {
     expect(els[0].innerHTML).to.contain('html5')
     expect(els[1].innerHTML).to.contain('too')
     tags.push(tag)
+  })
+
+  it('tag names are case insensitive (converted to lowercase) in `riot.mount`', function() {
+    var i, els = document.querySelectorAll('tag-data-is,[data-is="tag-data-is"]')
+    for (i = 0; i < els.length; i++) {
+      els[i].parentNode.removeChild(els[i])
+    }
+    injectHTML('<div data-is="tag-data-is"></div>')
+    injectHTML('<tag-DATA-Is></tag-DATA-Is>')
+    var tags = riot.mount('tag-Data-Is')
+
+    expect(tags.length).to.be(2)
+    expect(tags[0].root.getElementsByTagName('p').length).to.be(2)
+    expect(tags[1].root.getElementsByTagName('p').length).to.be(2)
+    tags.push(tags[0], tags[1])
+  })
+
+  it('the value of the `data-is` attribute needs lowercase names', function() {
+    var i, els = document.querySelectorAll('tag-data-is,[data-is="tag-data-is"]')
+    for (i = 0; i < els.length; i++) {
+      els[i].parentNode.removeChild(els[i])
+    }
+    injectHTML('<div data-is="tag-DATA-Is"></div>')
+    var tags = riot.mount('tag-Data-Is')
+
+    expect(tags.length).to.be(0)
   })
 
 })


### PR DESCRIPTION
Closes #1622 : Ambivalent case sensitivity when mounting
`riot.mount` allows optional spaces after the commas in its first parameter.
Using `data-is` attribute in `riot.mount.pushTags`
Removed unused parameter in `riot.tag2`
Removed dependency on impl.fn for unmount previous Tag instance in lib/browser/tag/tag.js, so you can call `riot.tag` without this parameter (its last one).
