### PR TITLE
yield partial regression

### DIFF
--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -22,25 +22,19 @@ var mkdom = (function (checkIE) {
    * Creates a DOM element to wrap the given content. Normally an `DIV`, but can be
    * also a `TABLE`, `SELECT`, `TBODY`, `TR`, or `COLGROUP` element.
    *
-   * @param   {string} impl   - Tag implementation with the template and root attributes
+   * @param   {string} templ  - The template coming from the custom tag definition
    * @param   {string} [html] - HTML content that comes from the DOM element where you
    *           will mount the tag, mostly the original tag in the page
-   * @param   {object} [attr] - Plain object where to store the root attributes
    * @returns {HTMLElement} DOM element with _templ_ merged through `YIELD` with the _html_.
    */
-  function _mkdom(impl, html, attr) {
-
-    var templ = impl.tmpl,
+  function _mkdom(templ, html) {
+    var
       match   = templ && templ.match(/^\s*<([-\w]+)/),
       tagName = match && match[1].toLowerCase(),
       el = mkEl('div')
 
-    if (!html) html = ''
-
-    if (impl.attrs) attr.attrs = replaceYield(impl.attrs, html)
-
     // replace all the yield tags with the tag inner html
-    templ = replaceYield(templ, html)
+    templ = replaceYield(templ, html || '')
 
     /* istanbul ignore next */
     if (tblTags.test(tagName))
@@ -72,8 +66,9 @@ var mkdom = (function (checkIE) {
     if (select) {
       parent.selectedIndex = -1  // for IE9, compatible w/current riot behavior
     } else {
+      // avoids insertion of cointainer inside container (ex: tbody inside tbody)
       var tname = rootEls[tagName]
-      if (tname && parent.childNodes.length === 1) parent = $(tname, parent)
+      if (tname && parent.childElementCount === 1) parent = $(tname, parent)
     }
     return parent
   }

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -32,7 +32,7 @@ var mkdom = (function _mkdom() {
       el = mkEl('div')
 
     // replace all the yield tags with the tag inner html
-    templ = replaceYield(templ, html || '')
+    templ = replaceYield(templ, html)
 
     /* istanbul ignore next */
     if (tblTags.test(tagName))

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -5,18 +5,16 @@
   See: http://kangax.github.io/compat-table/es5/#ie8
        http://codeplanet.io/dropping-ie8/
 */
-var mkdom = (function (checkIE) {
+var mkdom = (function _mkdom() {
   var
     reHasYield  = /<yield\b/i,
     reYieldAll  = /<yield\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
-    reYieldCls  = /<yield\s+to=[^>]+>[\S\s]*?<\/yield\s*>\s*/ig,
-    reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
-    rsYieldSrc  = '<yield\\s+to=[\'"]@[\'"]\\s*>([\\S\\s]*?)</yield\\s*>',
-    rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' }
-
-  checkIE = checkIE && checkIE < 10
-  var tblTags = checkIE
-    ? SPECIAL_TAGS_REGEX : /^(?:t(?:body|head|foot|[rhd])|caption|col(?:group)?)$/
+    reYieldSrc  = /<yield\s+to=['"]([^'">]*)['"]\s*>([\S\s]*?)<\/yield\s*>/ig,
+    reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig
+  var
+    rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' },
+    tblTags = IE_VERSION && IE_VERSION < 10
+      ? SPECIAL_TAGS_REGEX : /^(?:t(?:body|head|foot|[rhd])|caption|col(?:group)?)$/
 
   /**
    * Creates a DOM element to wrap the given content. Normally an `DIV`, but can be
@@ -82,24 +80,22 @@ var mkdom = (function (checkIE) {
     if (!reHasYield.test(templ)) return templ
 
     // be careful with #1343 - string on the source having `$1`
-    var n = 1
-    templ = templ.replace(reYieldDest, function (_, ref, def) {
-      var m = html.match(RegExp(rsYieldSrc.replace('@', ref), 'i'))
-      n = 0
-      return (m ? m[1] : def) || ''
-    })
+    var src = {}
 
-    // yield without any "from", replace yield in templ with the innerHTML
-    if (n || reHasYield.test(templ)) {
-      if (html) html = html.replace(reYieldCls, '').trim()
-      templ = templ.replace(reYieldAll, function (_, def) {
-        return html || def || ''
-      })
-    }
+    html = html && html.replace(reYieldSrc, function (_, ref, text) {
+      src[ref] = src[ref] || text   // preserve first definition
+      return ''
+    }).trim()
 
     return templ
+      .replace(reYieldDest, function (_, ref, def) {  // yield with from - to attrs
+        return src[ref] || def || ''
+      })
+      .replace(reYieldAll, function (_, def) {        // yield without any "from"
+        return html || def || ''
+      })
   }
 
   return _mkdom
 
-})(IE_VERSION)
+})()

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -9,7 +9,6 @@ function Tag(impl, conf, innerHTML) {
     expressions = [],
     childTags = [],
     root = conf.root,
-    fn = impl.fn,
     tagName = root.tagName.toLowerCase(),
     attr = {},
     implAttr = {},
@@ -40,8 +39,7 @@ function Tag(impl, conf, innerHTML) {
     if (tmpl.hasExpr(val)) attr[el.name] = val
   })
 
-  dom = mkdom(impl, innerHTML, implAttr)
-  implAttr = implAttr.attrs || ''
+  dom = mkdom(impl.tmpl, innerHTML)
 
   // options
   function updateOpts() {
@@ -152,7 +150,7 @@ function Tag(impl, conf, innerHTML) {
     if (globalMixin) self.mixin(globalMixin)
 
     // initialiation
-    if (fn) fn.call(self, opts)
+    if (impl.fn) impl.fn.call(self, opts)
 
     // parse layout after init. fn may calculate args for nested custom tags
     parseExpressions(dom, self, expressions)
@@ -162,10 +160,10 @@ function Tag(impl, conf, innerHTML) {
 
     // update the root adding custom attributes coming from the compiler
     // it fixes also #1087
-    if (implAttr || hasImpl) {
-      walkAttributes(implAttr, function (k, v) { setAttr(root, k, v) })
+    if (impl.attrs)
+      walkAttributes(impl.attrs, function (k, v) { setAttr(root, k, v) })
+    if (impl.attrs || hasImpl)
       parseExpressions(self.root, self, expressions)
-    }
 
     if (!self.parent || isLoop) self.update(item)
 


### PR DESCRIPTION
Drops support for `yield` into the root attributes because performance lost.
All other nice features are preserved, like default content.