### PR TITLE
Compare to ractivejs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | Framework              | Version    | Minified Size (gzip) |
 |------------------------|------------|----------------------|
 | Ember                  | 2.3.0      | 112.9kb              |
+| Ractive                | 0.7.3      | 54.47kb              |
 | Angular                | 1.5.0      | 53.17kb              |
 | Polymer                | 1.2.4      | 53.0kb               |
 | React                  | 0.14.7     | 38.56kb              |


### PR DESCRIPTION
I updated the README.md to add a comparison to [Ractive.js](http://www.ractivejs.org/), another reasonably popular JS framework with similar goals.

I got the size by downloading the `0.7.3` minified version and gzipping it locally.