### PR TITLE
Add riot.render.tag function to create raw tag

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -20,14 +20,8 @@ require.extensions['.tag'] = function(module, filename) {
 // simple-dom helper
 var sdom = require('./sdom')
 
-function createTag(tagName, opts) {
-  var root = document.createElement(tagName),
-    tag = riot.mount(root, opts)[0]
-  return tag
-}
-
 riot.render = function(tagName, opts) {
-  var tag = createTag(tagName, opts),
+  var tag = riot.render.tag(tagName, opts),
     html = sdom.serialize(tag.root)
   // unmount the tag avoiding memory leaks
   tag.unmount()
@@ -35,5 +29,11 @@ riot.render = function(tagName, opts) {
 }
 
 riot.render.dom = function(tagName, opts) {
-  return createTag(tagName, opts).root
+  return riot.render.tag(tagName, opts).root
+}
+
+riot.render.tag = function(tagName, opts) {
+  var root = document.createElement(tagName),
+    tag = riot.mount(root, opts)[0]
+  return tag
 }


### PR DESCRIPTION
Possible implementation for #1683

Makes the `createTag` method public as `riot.render.tag`. This allows for advanced rendering uses where one needs external control of the tag and/or doesn't want the tag to be automatically unmounted.