### PR TITLE
Demo added to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
 - [Another Riot Todo MVC](http://nippur72.github.io/riotjs-todomvc/#/)
 - [Cheft isomorphic by express](https://github.com/cheft/cheft)
 - [electron-riot - Riot in an electron application](https://github.com/mike-ward/electron-riot)
+- [An express, riot, jade, webpack simple boilerplate](https://github.com/revington/frontend-boilerplate)
 
 ### Tutorials
 - [Building Apps with Riot, ES6 and Webpack](http://blog.srackham.com/posts/riot-es6-webpack-apps/)


### PR DESCRIPTION
Why?
I have spend some time trying to figure out how to architect my application in a way that:
* Bundled: JS, html, etc
* I can use ES6 modules
* Javascript and markup not in the same file (the tag file) and I can still use the compiler
* I can split my application into several SPA to avoid downloading a big, heavy, monolithic application to the client. 
* Components can be reused
* With my current stack: jade, express...

Because I did not found any simple example I built my own.
