### PR TITLE
Added ability to have multiple global mixins

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -9,23 +9,30 @@ riot.util = { brackets: brackets, tmpl: tmpl }
  * Create a mixin that could be globally shared across all the tags
  */
 riot.mixin = (function() {
-  var mixins = {}
+  var mixins = {},
+    globals = mixins[GLOBAL_MIXIN] = {},
+    _id = 0
 
   /**
    * Create/Return a mixin by its name
-   * @param   { String } name - mixin name (global mixin if missing)
-   * @param   { Object } mixin - mixin logic
-   * @returns { Object } the mixin logic
+   * @param   { String }  name - mixin name (global mixin if object)
+   * @param   { Object }  mixin - mixin logic
+   * @param   { Boolean } g - is global?
+   * @returns { Object }  the mixin logic
    */
-  return function(name, mixin) {
+  return function(name, mixin, g) {
+    // Unnamed global
     if (isObject(name)) {
-      mixin = name
-      mixins[GLOBAL_MIXIN] = extend(mixins[GLOBAL_MIXIN] || {}, mixin)
+      riot.mixin('__unnamed_'+_id++, name, true)
       return
     }
 
-    if (!mixin) return mixins[name]
-    mixins[name] = mixin
+    var store = g ? globals : mixins
+
+    // Getter
+    if (!mixin) return store[name]
+    // Setter
+    store[name] = extend(store[name] || {}, mixin)
   }
 
 })()

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -144,9 +144,12 @@ function Tag(impl, conf, innerHTML) {
 
     updateOpts()
 
-    // add global mixin
+    // add global mixins
     var globalMixin = riot.mixin(GLOBAL_MIXIN)
-    if (globalMixin) self.mixin(globalMixin)
+    if (globalMixin)
+      for (var i in globalMixin)
+        if (globalMixin.hasOwnProperty(i))
+          self.mixin(globalMixin[i])
 
     // initialiation
     if (impl.fn) impl.fn.call(self, opts)

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -70,8 +70,18 @@ describe('Mixin', function() {
     }
   }
 
-  it('Will register a global mixin and mount a tag with global mixed-in attributes and methods', function() {
+  var globalMixin2 = {
+    init: function() {
+      this.globalAttr2 = 'initialized2'
+    },
+    getGlobal2: function() {
+      return 'global2'
+    }
+  }
+
+  it('Will register a global mixin without name and mount a tag with global mixed-in attributes and methods', function() {
     riot.mixin(globalMixin)
+    console.log(riot.mixin('__global_mixin'))
     injectHTML('<my-mixin></my-mixin>')
     riot.tag('my-mixin', '<span>some tag</span>')
 
@@ -79,6 +89,48 @@ describe('Mixin', function() {
 
     expect('initialized').to.be(tag.globalAttr)
     expect('global').to.be(tag.getGlobal())
+    tag.unmount()
+  })
+
+  it('Will register multiple global mixin without name and mount a tag with global mixed-in attributes and methods', function() {
+    riot.mixin(globalMixin)
+    riot.mixin(globalMixin2)
+    injectHTML('<my-mixin></my-mixin>')
+    riot.tag('my-mixin', '<span>some tag</span>')
+
+    var tag = riot.mount('my-mixin')[0]
+
+    expect('initialized').to.be(tag.globalAttr)
+    expect('initialized2').to.be(tag.globalAttr2)
+    expect('global').to.be(tag.getGlobal())
+    expect('global2').to.be(tag.getGlobal2())
+    tag.unmount()
+  })
+
+  it('Will register a global mixin with name and mount a tag with global mixed-in attributes and methods', function() {
+    riot.mixin('global', globalMixin, true)
+    injectHTML('<my-mixin></my-mixin>')
+    riot.tag('my-mixin', '<span>some tag</span>')
+
+    var tag = riot.mount('my-mixin')[0]
+
+    expect('initialized').to.be(tag.globalAttr)
+    expect('global').to.be(tag.getGlobal())
+    tag.unmount()
+  })
+
+  it('Will register multiple global mixin with name and mount a tag with global mixed-in attributes and methods', function() {
+    riot.mixin('global', globalMixin, true)
+    riot.mixin('global2', globalMixin2, true)
+    injectHTML('<my-mixin></my-mixin>')
+    riot.tag('my-mixin', '<span>some tag</span>')
+
+    var tag = riot.mount('my-mixin')[0]
+
+    expect('initialized').to.be(tag.globalAttr)
+    expect('initialized2').to.be(tag.globalAttr2)
+    expect('global').to.be(tag.getGlobal())
+    expect('global2').to.be(tag.getGlobal2())
     tag.unmount()
   })
 


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?
Yes.

2. Can you provide an example of your patch in use?
No, but already discussed here: https://github.com/riot/riot/issues/1699

3. Is this a breaking change?
No

#### Content

I've added the ability to have multiple global mixins. With the previous implementation you couldn't have multiple `init` constructors when multiple mixins were defined.

`riot.mixin` introduced a 3rd parameter called `g` (sorry for the naming, comes from regex g modifier) which stands for if the mixin is global. I did this because I wanted to be able to name the mixin, so I can reference it later if I need to modify. I've did this by creating `mixins[GLOBAL_MIXIN]` by default as an empty object to store global objects there.

```javascript
var mixin = {
    init: function(){
        console.log('I will run.')
    }
}
var mixin2 = {
    init: function(){
        console.log('Now I will also run.')
    }
}
riot.mount('global', mixin, true)
riot.mount('global2', mixin2, true)

// Retrieve a global mixin object:
riot.mixin('global', false, true) === mixin
```

I've made backward compatible, so old usage will work.

```javascript
riot.mount(mixin)
```

I've did a recursive call there, so kinda "polyfilled" old calls to the new one, and generated a name for it.

At tag level I've loop through the **GLOBAL_MIXIN** object and called `this.mixin` on every mixin object.

I'll update docs after you decide to accept this mod.