### PR TITLE
removed: the __ prefix for the boolean attributes

### DIFF
--- a/lib/browser/global-variables.js
+++ b/lib/browser/global-variables.js
@@ -26,8 +26,18 @@ var riot = { version: 'WIP', settings: {} },
   T_FUNCTION = 'function',
   // special native tags that cannot be treated like the others
   SPECIAL_TAGS_REGEX = /^(?:t(?:body|head|foot|[rhd])|caption|col(?:group)?|opt(?:ion|group))$/,
+  /**
+   * Matches boolean HTML attributes in the riot tag definition.
+   * With a long list like this, a regex is faster than `[].indexOf` in most browsers.
+   * @const {RegExp}
+   * @see [attributes.md](https://github.com/riot/compiler/blob/dev/doc/attributes.md)
+   */
+  BOOL_ATTRS = RegExp(
+    '^(?:disabled|checked|readonly|required|allowfullscreen|auto(?:focus|play)|' +
+    'compact|controls|default|formnovalidate|hidden|ismap|itemscope|loop|' +
+    'multiple|muted|no(?:resize|shade|validate|wrap)?|open|reversed|seamless|' +
+'selected|sortable|truespeed|typemustmatch)$'),
   RESERVED_WORDS_BLACKLIST = ['_item', '_id', '_parent', 'update', 'root', 'mount', 'unmount', 'mixin', 'isMounted', 'isLoop', 'tags', 'parent', 'opts', 'trigger', 'on', 'off', 'one'],
-
   // version# for IE 8-11, 0 for others
   IE_VERSION = (window && window.document || {}).documentMode | 0,
 

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -26,7 +26,7 @@ function parseExpressions(root, tag, expressions, includeRoot) {
     // attribute expressions
     var allAttrs = [], nameExps = []
     each(dom.attributes, function(attr) {
-      var name = attr.name, bool = name.split('__')[1]
+      var name = attr.name, bool = BOOL_ATTRS.test(name)
       var hasExp = tmpl.hasExpr(attr.value)
 
       if (name === 'name' || name === 'id') {


### PR DESCRIPTION
It closes https://github.com/riot/riot/issues/276 but It also needs a compiler update, @aMarCruz could you please create a beta version of the riot-compiler@3.0.0 removing this feature from it please?