### PR TITLE
Don't render custom tag wrappers by default. Option

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -123,7 +123,7 @@ riot.mount = function(selector, tagName, opts) {
       else if (!riot.settings.renderTagWrappers) {
         riotTag = (riotTag || root.tagName).toLowerCase()
         root = root.parentNode
-        setAttr(root, RIOT_TAG, riotTag)
+        setAttr(root, RIOT_TAG_IS, riotTag)
       }
 
       var tag = mountTo(root, riotTag || root.tagName.toLowerCase(), opts)

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -120,7 +120,7 @@ riot.mount = function(selector, tagName, opts) {
         setAttr(root, RIOT_TAG_IS, tagName)
         setAttr(root, RIOT_TAG, tagName) // this will be removed in riot 3.0.0
       }
-      else if (!riot.settings.renderTagWrappers) {
+      else if (!riot.settings.renderCustomTagWrappers) {
         riotTag = (riotTag || root.tagName).toLowerCase()
         root = root.parentNode
         setAttr(root, RIOT_TAG_IS, riotTag)

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -120,6 +120,12 @@ riot.mount = function(selector, tagName, opts) {
         setAttr(root, RIOT_TAG_IS, tagName)
         setAttr(root, RIOT_TAG, tagName) // this will be removed in riot 3.0.0
       }
+      else if (!riot.settings.renderTagWrappers) {
+        riotTag = (riotTag || root.tagName).toLowerCase()
+        root = root.parentNode
+        setAttr(root, RIOT_TAG, riotTag)
+      }
+
       var tag = mountTo(root, riotTag || root.tagName.toLowerCase(), opts)
 
       if (tag) tags.push(tag)

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -70,7 +70,8 @@ function _each(dom, parent, expr) {
 
   var mustReorder = typeof getAttr(dom, 'no-reorder') !== T_STRING || remAttr(dom, 'no-reorder'),
     tagName = getTagName(dom),
-    impl = __tagImpl[tagName] || { tmpl: getOuterHTML(dom) },
+    tagImpl = __tagImpl[tagName],
+    impl = tagImpl || { tmpl: getOuterHTML(dom) },
     useRoot = SPECIAL_TAGS_REGEX.test(tagName),
     root = dom.parentNode,
     ref = document.createTextNode(''),
@@ -79,7 +80,8 @@ function _each(dom, parent, expr) {
     tags = [],
     oldItems = [],
     hasKeys,
-    isVirtual = dom.tagName == 'VIRTUAL'
+    isVirtualByDefault = tagImpl && !riot.settings.renderTagWrappers,
+    isVirtual = isVirtualByDefault || isVirtualTag(dom)
 
   // parse the each expression
   expr = tmpl.loopKeys(expr)

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -80,7 +80,7 @@ function _each(dom, parent, expr) {
     tags = [],
     oldItems = [],
     hasKeys,
-    isVirtualByDefault = tagImpl && !riot.settings.renderTagWrappers,
+    isVirtualByDefault = tagImpl && !riot.settings.renderCustomTagWrappers,
     isVirtual = isVirtualByDefault || isVirtualTag(dom)
 
   // parse the each expression

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -95,7 +95,7 @@ function update(expressions, tag) {
       // if it hasn't been mounted yet, do that now.
       } else {
         expr.mount()
-        if (!riot.settings.renderTagWrappers || expr.root.tagName == 'VIRTUAL') {
+        if (!riot.settings.renderCustomTagWrappers || expr.root.tagName == 'VIRTUAL') {
           var frag = document.createDocumentFragment()
           makeVirtual(expr, frag)
           expr.root.parentElement.replaceChild(frag, expr.root)

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -95,8 +95,7 @@ function update(expressions, tag) {
       // if it hasn't been mounted yet, do that now.
       } else {
         expr.mount()
-
-        if (expr.root.tagName == 'VIRTUAL') {
+        if (!riot.settings.renderTagWrappers || expr.root.tagName == 'VIRTUAL') {
           var frag = document.createDocumentFragment()
           makeVirtual(expr, frag)
           expr.root.parentElement.replaceChild(frag, expr.root)

--- a/lib/browser/tag/util.js
+++ b/lib/browser/tag/util.js
@@ -517,6 +517,15 @@ function mountTo(root, tagName, opts) {
   return tag
 }
 
+/**
+ * Returns whether a dom node is a virtual tag or not
+ * @param  { Object } dom - tag dom node
+ * @returns { boolean } true if the dom node is a virtual tag, false otherwise
+ */
+function isVirtualTag(dom) {
+  return dom.tagName == 'VIRTUAL'
+}
+
 
 /**
  * Adds the elements for a virtual tag


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?

Tests need updating. Have no familiarity with how to.

2. Can you provide an example of your patch in use?

http://plnkr.co/edit/kOsGFd8Chh619U16WBCX?p=preview

3. Is this a breaking change?

Yes. To preserve old 2.x behavior, e.g. if required during migration to 3.x, use `riot.settings.renderCustomTagWrappers = true` once at start

#### Content

Provide a short description about what you have changed:

By default, custom tag wrapper tags are not rendered in the output. To preserve old 2.x behavior, e.g. if required during migration to 3.x, put `riot.settings.renderCustomTagWrappers = true` once at start.

Justification:

1. Custom tag wrapper tags have no clearly defined behavior in the HTML spec
2. Rendering them in the output has no notable benefits
3. Not rendering them allows user to "drop in" custom tags more easily for mock html sections, simplifies the developer's conceptualization of their output and how it will render, and more easily allows bunches of child elements to be inserted at once.
4. Having this feature by default allows these benefits to be enjoyed by more people and familiarity with it allows them to be enjoyed more predictably, more easily and more often