### PR TITLE
add flag `settings.preventHandlerAutoUpdates`

### DIFF
--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -29,6 +29,10 @@ function setEventHandler(name, handler, dom, tag) {
 
     e.item = item
 
+    if (riot.settings.preventHandlerAutoUpdates) {
+      return handler.call(tag, e)
+    }
+
     // prevent default behaviour (by default)
     if (handler.call(tag, e) !== true && !/radio|check/.test(dom.type)) {
       if (e.preventDefault) e.preventDefault()


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?

  No, didn't found any suitable test to use as base.

2. Can you provide an example of your patch in use?

  The patch is just a simple `settings` flag which won't invoke `tag.update()` after invoking any event handler. For example the following code:

  ```
  <my-tag>
    <script>
       this.handler = function (e) {
         e.preventUpdate = true
         // custom logic which involves manual tag.update()
       }
    </script>
    <button onclick={handler} />
  </my-tag>

  <my-tag2>
    <script>
       this.handler = function (e) {
         e.preventUpdate = true
         // custom logic which involves manual tag.update()
       }
    </script>
    <button onclick={handler} />
  </my-tag2>
  ```

  Can be simplified by a general setting `riot.settings.preventHandlerAutoUpdates`, ie

  ```
  riot.settings.preventHandlerAutoUpdates = true

  <my-tag>
    <script>
       this.handler = function (e) {
         // custom logic which involves manual tag.update()
       }
    </script>
    <button onclick={handler} />
  </my-tag>
  ```

  The idea is to prevent `tag.update()` invocation after event handlers which thereafter provides a solid ground to build custom implementation of tag updating (ie via one way or two way bindings)

3. Is this a breaking change?

  Nope, by default riot is working as it does - after every invoke of event handler it will call `tag.update`.