### PR TITLE
add settings flag preventListAutoReOrdering

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -115,6 +115,10 @@ function _each(dom, parent, expr) {
     hasKeys,
     isVirtual = dom.tagName == 'VIRTUAL'
 
+  if (riot.settings.preventListAutoReOrdering === true) {
+    mustReorder = false
+  }
+
   // parse the each expression
   expr = tmpl.loopKeys(expr)
 


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?

  No, didn't found any suitable test to use as base.

2. Can you provide an example of your patch in use?

  It is a simple settings flag which eliminates the need to put `no-reorder` attribute to `each` iterated items.

  For example this:

  ```
  <my-tag>
    <div each={item in items} no-reorder>
    </div>
    <div each={item2 in items2} no-reorder>
    </div>
  </my-tag>
  ```

  Can be simplified via `riot.settings.preventAutoListOrdering`, ie:

  ```
  riot.settings.preventAutoListOrdering = true

  <my-tag>
    <div each={item in items}>
    </div>
    <div each={item2 in items2}>
    </div>
  </my-tag>
  ```

3. Is this a breaking change?

Nope, riot works as it is unless the flag is set.