### PR TITLE
Throw error when referencing an unregistered mixin

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -30,7 +30,12 @@ riot.mixin = (function() {
     var store = g ? globals : mixins
 
     // Getter
-    if (!mixin) return store[name]
+    if (!mixin) {
+      if (typeof store[name] === T_UNDEF) {
+        throw new Error('Unregistered mixin: ' + name)
+      }
+      return store[name]
+    }
     // Setter
     store[name] = extend(store[name] || {}, mixin)
   }


### PR DESCRIPTION
Before this, `this.mixin('nonexistent-mixin')` threw `Uncaught TypeError: Cannot convert undefined or null to object`. Now it will throw `Uncaught Error: Unknown mixin: nonexistent-mixin`.