### PR TITLE
Added support for class (function) mixins

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -37,7 +37,13 @@ riot.mixin = (function() {
       return store[name]
     }
     // Setter
-    store[name] = extend(store[name] || {}, mixin)
+    if (isFunction(mixin)) {
+      extend(mixin.prototype, store[name] || {})
+      store[name] = mixin
+    }
+    else {
+      store[name] = extend(store[name] || {}, mixin)
+    }
   }
 
 })()

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -282,4 +282,16 @@ describe('Mixin', function() {
     tag.unmount()
   })
 
+  it('register a function mixin to Riot and load mixin to a tag', function() {
+    injectHTML('<my-mixin></my-mixin>')
+
+    riot.mixin('functMixin', FunctMixin) // register mixin
+    riot.tag('my-mixin', '<span>some tag</span>', function(opts) {
+      this.mixin('functMixin') // load mixin
+    })
+
+    var tag = riot.mount('my-mixin')[0]
+    expect(tag.type).to.be('func')
+    tag.unmount()
+  })
 })


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?
No, because existing tests are failing on dev branch before I write my tests. Could I be missing dependencies?

2. Can you provide an example of your patch in use?
Notice how Object mixins work correctly, but class mixins do not.
  - [Bug Example](http://plnkr.co/edit/qpIxSU8xNvRdXm6lfE2L?p=preview)

3. Is this a breaking change?
No

#### Content

In the riot.mixin function:
When setting a store value with the new mixin, if the mixin is of type `function` (ie a class) then extend the functions prototype with the existing store value properties (or a blank object if undefined) and set the store value with the extended class (function).

