### PR TITLE
added: Support to disable named elements on loops

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -103,6 +103,7 @@ function _each(dom, parent, expr) {
   remAttr(dom, 'each')
 
   var mustReorder = typeof getAttr(dom, 'no-reorder') !== T_STRING || remAttr(dom, 'no-reorder'),
+    disableParsingNamed = typeof getAttr(dom, 'no-named-elements') === T_STRING && !remAttr(dom, 'no-named-elements'),
     tagName = getTagName(dom),
     impl = __tagImpl[tagName] || { tmpl: getOuterHTML(dom) },
     useRoot = SPECIAL_TAGS_REGEX.test(tagName),
@@ -169,6 +170,7 @@ function _each(dom, parent, expr) {
         tag = new Tag(impl, {
           parent: parent,
           isLoop: true,
+          disableParsingNamed: disableParsingNamed,
           hasImpl: !!__tagImpl[tagName],
           root: useRoot ? root : dom.cloneNode(),
           item: item

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -4,6 +4,7 @@ function Tag(impl, conf, innerHTML) {
     opts = inherit(conf.opts) || {},
     parent = conf.parent,
     isLoop = conf.isLoop,
+    disableParsingNamed = conf.disableParsingNamed,
     hasImpl = conf.hasImpl,
     item = cleanUpData(conf.item),
     expressions = [],
@@ -186,7 +187,7 @@ function Tag(impl, conf, innerHTML) {
 
     // parse the named dom nodes in the looped child
     // adding them to the parent as well
-    if (isLoop)
+    if (isLoop && !disableParsingNamed)
       parseNamedElements(self.root, self.parent, null, true)
 
     // if it's not a child tag we can trigger its mount event
@@ -285,6 +286,7 @@ function Tag(impl, conf, innerHTML) {
 
 
   // named elements available for fn
-  parseNamedElements(dom, this, childTags)
+  if (!disableParsingNamed)
+    parseNamedElements(dom, this, childTags)
 
 }

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -983,6 +983,13 @@ describe('Compiler Browser', function() {
     tags.push(tag)
   })
 
+  it('no-named-elements attr prevents dynamically named elements in a loop', function() {
+    var tag = riot.mount('loop-no-named')[0]
+    expect(tag.first).to.be(undefined)
+    expect(tag.two).to.be(undefined)
+    tags.push(tag)
+  })
+
   it('style injection to single style tag', function() {
     var styles = getRiotStyles()
 

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -33,6 +33,7 @@ loadTagsAndScripts([
   'tag/table-thead-tfoot.tag',
   'tag/table-thead-tfoot-nested.tag',
   'tag/loop-named.tag',
+  'tag/loop-no-named.tag',
   'tag/loop-single-tags.tag',
   'tag/timetable.tag',
   'tag/raw-contents.tag',

--- a/test/tag/loop-no-named.tag
+++ b/test/tag/loop-no-named.tag
@@ -1,0 +1,8 @@
+<loop-no-named>
+  <div each={ name, i in list } no-named-elements>
+  { name }
+    <div id={ name } value={ i }>
+  </div>
+
+  this.list = [ 'first', 'two' ];
+</loop-no-named>


### PR DESCRIPTION
#### Content

When you add an id or name to an element, it gets automatically added to the context for easy access (http://riotjs.com/guide/#named-elements).

But, that feature turns out to be a big performance hit on loops.

Here is an example of a loop of 500 elements with ids:
https://plnkr.co/edit/FPOPNLVXoXaIr9LnaRVj?p=preview

It takes about 400ms to 2s to render in my machine. : S

The same exact html without ids on the elements of the loop:
https://plnkr.co/edit/GdWFFekcbvBvW2bdCdSq?p=preview

Renders in about 10-20ms.

This pr adds support to disabling that automatic bounding of named elements via a 'no-named-elements' attribute:

`<div id={ id } each={ items } no-named-elements></div>`

We could argue that we just shouldn't use ids on loops, but there might be scenarios where we just have to (e.g. third party libraries that depend on ids).

We could also workaround this issue by preventing the UI from having so many elements, but working with hundreds of nodes doesn't sound like an unreasonable front end use case, and again, there might be an scenario when this isn't possible (e.g. a search widget where the backend api can't provide paginated results and we just filter on the UI).

#### Code

1. Have you added test(s) for your patch? If not, why not?
Yes.

2. Can you provide an example of your patch in use?

Example with the new riot+compiler.js, that uses the attribute to disable the named elements:
http://plnkr.co/edit/lV2c26h1HW0q9CK7Ssvt?p=preview

Example with the new riot+compiler.js, that doesn't use the attribute to disable the named elements:
https://plnkr.co/edit/E4w0PJECkT1zBvtVXN9b?p=preview

3. Is this a breaking change?
No.