### PR TITLE
Fix tag update opts

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -100,6 +100,11 @@ export default function Tag(impl, conf, innerHTML) {
         opts[toCamel(el.name)] = hasTmpl ? tmpl(val, ctx) : val
       })
     }
+
+    // recover those with expressions
+    each(Object.keys(attr), function(name) {
+      opts[toCamel(name)] = tmpl(attr[name], ctx)
+    })
   }
 
   function normalizeData(data) {

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -282,5 +282,11 @@ export default function Tag(impl, conf, innerHTML) {
     self.isMounted = false
     delete self.root._tag
 
+    if (self.root._eventHandlers) {
+      each(Object.keys(self.root._eventHandlers), function (eventName) {
+        self.root.removeEventListener(eventName, self.root._eventHandlers[eventName])
+      })
+      delete self.root._eventHandlers
+    }
   })
 }

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -32,7 +32,6 @@ import {
  */
 export function setEventHandler(name, handler, dom, tag) {
   var handlerWrapper = function(e) {
-
     var ptag = tag._parent,
       item = tag._item
 
@@ -64,11 +63,13 @@ export function setEventHandler(name, handler, dom, tag) {
     return
   }
   var eventName = name.replace(/^on/, '')
-  if (dom.$eventHandlers && dom.$eventHandlers[eventName]) {
-    dom.removeEventListener(eventName, dom.$eventHandlers[eventName])
+  if (dom._eventHandlers && dom._eventHandlers[eventName]) {
+    dom.removeEventListener(eventName, dom._eventHandlers[eventName])
   }
-  if (!dom.$eventHandlers) dom.$eventHandlers = {}
-  dom.$eventHandlers[eventName] = handlerWrapper
+  if (!dom._eventHandlers) {
+    dom._eventHandlers = {}
+  }
+  dom._eventHandlers[eventName] = handlerWrapper
   dom.addEventListener(eventName, handlerWrapper, false)
 }
 

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -64,7 +64,7 @@ export function setEventHandler(name, handler, dom, tag) {
     return
   }
   var eventName = name.replace(/^on/, '')
-  if (dom.$event_handlers && dom.$eventHandlers[eventName]) {
+  if (dom.$eventHandlers && dom.$eventHandlers[eventName]) {
     dom.removeEventListener(eventName, dom.$eventHandlers[eventName])
   }
   if (!dom.$eventHandlers) dom.$eventHandlers = {}

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -31,8 +31,7 @@ import {
  * @param { Tag } tag - tag instance
  */
 export function setEventHandler(name, handler, dom, tag) {
-
-  dom[name] = function(e) {
+  var handlerWrapper = function(e) {
 
     var ptag = tag._parent,
       item = tag._item
@@ -60,7 +59,17 @@ export function setEventHandler(name, handler, dom, tag) {
     }
 
   }
-
+  if (!dom.addEventListener) {
+    dom[name] = handlerWrapper
+    return
+  }
+  var eventName = name.replace(/^on/, '')
+  if (dom.$event_handlers && dom.$eventHandlers[eventName]) {
+    dom.removeEventListener(eventName, dom.$eventHandlers[eventName])
+  }
+  if (!dom.$eventHandlers) dom.$eventHandlers = {}
+  dom.$eventHandlers[eventName] = handlerWrapper
+  dom.addEventListener(eventName, handlerWrapper, false)
 }
 
 /**

--- a/test/specs/browser/core.spec.js
+++ b/test/specs/browser/core.spec.js
@@ -516,7 +516,7 @@ describe('Riot core', function() {
 
     expect(tag['fancy-name'].innerHTML).to.be.equal('john')
 
-    tag.root.getElementsByTagName('p')[0].onclick({})
+    tag.root.getElementsByTagName('p')[0].dispatchEvent(new Event('click'))
 
     expect(tag['fancy-name'].innerHTML).to.be.equal('john')
 
@@ -553,12 +553,12 @@ describe('Riot core', function() {
 
     currentItem = tag.items[0]
     currentIndex = 0
-    divTags[0].onclick({})
+    divTags[0].dispatchEvent(new Event('click'))
     tag.items.reverse()
     tag.update()
     currentItem = tag.items[0]
     currentIndex = 0
-    divTags[0].onclick({})
+    divTags[0].dispatchEvent(new Event('click'))
 
     expect(callbackCalls).to.be.equal(2)
 
@@ -792,7 +792,7 @@ describe('Riot core', function() {
     var tag = riot.mount('riot-tmp')[0]
 
     expect(tag.updateCount).to.be.equal(0)
-    tag.tags.inner[0].btn.onclick({})
+    tag.tags.inner[0].btn.dispatchEvent(new Event('click'))
     expect(tag.updateCount).to.be.equal(0)
     tag.unmount()
 

--- a/test/specs/browser/each.spec.js
+++ b/test/specs/browser/each.spec.js
@@ -178,25 +178,25 @@ describe('Riot each', function() {
     // remove item make sure item passed is correct
     for (var i = 0; i < tag.items.length; i++) {
       var curItem = tag.removes[0],
-        ev = {},
+        ev = new Event('click'),
         el = root.getElementsByTagName('dt')[0]
-      el.onclick(ev)
+      el.dispatchEvent(ev)
       expect(curItem).to.be.equal(ev.item)
     }
 
     children = root.getElementsByTagName('li')
     Array.prototype.forEach.call(children, function(child) {
-      child.onclick({})
+      child.dispatchEvent(new Event('click'))
     })
     expect(children.length).to.be.equal(5)
 
     // no update is required here
-    button.onclick({})
+    button.dispatchEvent(new Event('click'))
     children = root.getElementsByTagName('li')
     expect(children.length).to.be.equal(10)
 
     Array.prototype.forEach.call(children, function(child) {
-      child.onclick({})
+      child.dispatchEvent(new Event('click'))
     })
 
     expect(normalizeHTML(root.getElementsByTagName('ul')[0].innerHTML)).to.be.equal('<li>0 item #0 </li><li>1 item #1 </li><li>2 item #2 </li><li>3 item #3 </li><li>4 item #4 </li><li>5 item #5 </li><li>6 item #6 </li><li>7 item #7 </li><li>8 item #8 </li><li>9 item #9 </li>')
@@ -206,7 +206,7 @@ describe('Riot each', function() {
     children = root.getElementsByTagName('li')
     expect(children.length).to.be.equal(10)
     Array.prototype.forEach.call(children, function(child) {
-      child.onclick({})
+      child.dispatchEvent(new Event('click'))
     })
 
     expect(normalizeHTML(root.getElementsByTagName('ul')[0].innerHTML)).to.be.equal('<li>0 item #9 </li><li>1 item #8 </li><li>2 item #7 </li><li>3 item #6 </li><li>4 item #5 </li><li>5 item #4 </li><li>6 item #3 </li><li>7 item #2 </li><li>8 item #1 </li><li>9 item #0 </li>'.trim())
@@ -217,7 +217,7 @@ describe('Riot each', function() {
     tag.update()
 
     Array.prototype.forEach.call(children, function(child) {
-      child.onclick({})
+      child.dispatchEvent(new Event('click'))
     })
 
     expect(normalizeHTML(root.getElementsByTagName('ul')[0].innerHTML)).to.be.equal('<li>0 item #9 </li><li>1 item #1 </li><li>2 item #7 </li><li>3 item #6 </li><li>4 item #5 </li><li>5 item #4 </li><li>6 item #3 </li><li>7 item #2 </li><li>8 item #8 </li><li>9 item #0 </li>'.trim())
@@ -247,11 +247,11 @@ describe('Riot each', function() {
 
     // 1st test
     testItem = { outerCount: 'out', outerI: 0 }
-    tag.root.getElementsByTagName('inner-loop-events')[0].onclick({})
+    tag.root.getElementsByTagName('inner-loop-events')[0].dispatchEvent(new Event('click'))
     // 2nd test inner contents
     testItem = { innerCount: 'in', innerI: 0 }
-    tag.root.getElementsByTagName('button')[1].onclick({})
-    tag.root.getElementsByTagName('li')[0].onclick({})
+    tag.root.getElementsByTagName('button')[1].dispatchEvent(new Event('click'))
+    tag.root.getElementsByTagName('li')[0].dispatchEvent(new Event('click'))
 
     expect(eventsCounter).to.be.equal(3)
 
@@ -290,7 +290,7 @@ describe('Riot each', function() {
     expect(tag.tags['looped-child'].length).to.be.equal(3)
 
     expect(root.getElementsByTagName('looped-child')[0].style.color).to.be.equal('red')
-    root.getElementsByTagName('looped-child')[0].getElementsByTagName('button')[0].onclick({})
+    root.getElementsByTagName('looped-child')[0].getElementsByTagName('button')[0].dispatchEvent(new Event('click'))
     expect(root.getElementsByTagName('looped-child')[0].style.color).to.be.equal('blue')
 
     tag.unmount()
@@ -783,7 +783,7 @@ describe('Riot each', function() {
       tag.tags['loop-inherit-item'][0].root.onmouseenter({})
       expect(tag.wasHovered).to.be.equal(true)
       expect(tag.root.getElementsByTagName('div').length).to.be.equal(4)
-      tag.tags['loop-inherit-item'][0].root.onclick({})
+      tag.tags['loop-inherit-item'][0].root.dispatchEvent(new Event('click'))
       expect(tag.tags['loop-inherit-item'][0].wasClicked).to.be.equal(true)
 
       tag.unmount()
@@ -811,7 +811,7 @@ describe('Riot each', function() {
         children = tag.root.getElementsByTagName('loop-nested-strings-array-item')
       expect(children.length).to.be.equal(4)
       children = tag.root.getElementsByTagName('loop-nested-strings-array-item')
-      children[0].onclick({})
+      children[0].dispatchEvent(new Event('click'))
       expect(children.length).to.be.equal(4)
       expect(normalizeHTML(children[0].innerHTML)).to.be.equal('<p>b</p>')
       expect(normalizeHTML(children[1].innerHTML)).to.be.equal('<p>a</p>')
@@ -825,7 +825,7 @@ describe('Riot each', function() {
     injectHTML('<loop-numbers-nested></loop-numbers-nested>')
     var tag = riot.mount('loop-numbers-nested')[0]
     expect(tag.root.getElementsByTagName('ul')[0].getElementsByTagName('li').length).to.be.equal(4)
-    tag.root.getElementsByTagName('ul')[0].getElementsByTagName('li')[0].onclick({})
+    tag.root.getElementsByTagName('ul')[0].getElementsByTagName('li')[0].dispatchEvent(new Event('click'))
     expect(tag.root.getElementsByTagName('ul')[0].getElementsByTagName('li').length).to.be.equal(2)
     tag.unmount()
   })
@@ -864,7 +864,7 @@ describe('Riot each', function() {
     }
 
     expect(bodies[0].getElementsByTagName('tr')[0].style.backgroundColor).to.be.equal('white')
-    tag.root.getElementsByTagName('button')[0].onclick({})
+    tag.root.getElementsByTagName('button')[0].dispatchEvent(new Event('click'))
     expect(bodies[0].getElementsByTagName('tr')[0].style.backgroundColor).to.be.equal('lime')
 
     tag.unmount()

--- a/test/specs/browser/transclusion.spec.js
+++ b/test/specs/browser/transclusion.spec.js
@@ -138,7 +138,7 @@ describe('Riot transclusion', function() {
 
     expect(normalizeHTML(tag.root.innerHTML)).to.be.equal('<h1>Hello, from the parent</h1><yield-child><h1>Greeting</h1><i>from the child</i><div class="selected"><b>wooha</b></div></yield-child>')
 
-    tag.root.getElementsByTagName('i')[0].onclick({})
+    tag.root.getElementsByTagName('i')[0].dispatchEvent(new Event('click'))
 
     tag.unmount()
 
@@ -166,7 +166,7 @@ describe('Riot transclusion', function() {
 
     expect(child3.root.getElementsByTagName('h2')[0].innerHTML.trim()).to.be.equal('subtitle4')
 
-    child3.root.getElementsByTagName('i')[0].onclick({})
+    child3.root.getElementsByTagName('i')[0].dispatchEvent(new Event('click'))
 
     tag.unmount()
 


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?

  Nope, it is fix for regression in riot next version.

2. Can you provide an example of your patch in use?

  Without the patch the following won't work as expected:

  ```
  <my-item>
    var tag = this
    tag.on('update', function () {
      console.log(tag.opts.myData.id)
      // the above will render 1, 2, 3 on initial mount/update
      // however when removeItem() is invoked bellow,  it will render 1, 2 (not 2,3 as expected)
    })
  </my-item>

  <my-items-list>
    <script>
       var tag = this
       tag.collection = [ {id: 1}, {id: 2}, {id: 3} ]
       tag.removeItem = function () {
          tag.collection.splice(0, 1) // this will re-render my-item loop but will not update myData opts value of existing tags
       }
    </script>
    <my-item each={itemData in collection} myData={itemData} />
    <button onclick={removeItem}>remove</button>
  </my-items-list>
  ```

3. Is this a breaking change?

  Nope

#### Content

Well while I've been play testing riotjs@next I found the above odd behavior which wasn't present in riot 2.x so I invested some time to debug and resolve the issue.

In short the problem comes when given collection is rendered via `each` attribute and then one item from the collection is removed. 

What happens is that already mounted Tags get updated with respective `tag._item` values however their `tag.opts` aren't which usually breaks things when `tag.opts` are used to propagate data.