### PR TITLE
fix tag.updateOpts impl

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -100,6 +100,11 @@ export default function Tag(impl, conf, innerHTML) {
         opts[toCamel(el.name)] = hasTmpl ? tmpl(val, ctx) : val
       })
     }
+
+    // recover those with expressions
+    each(Object.keys(attr), function(name) {
+      opts[toCamel(name)] = tmpl(attr[name], ctx)
+    })
   }
 
   function normalizeData(data) {


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?

  Nope, it is fix for regression in riot next version.

2. Can you provide an example of your patch in use?

  Without the patch the following won't work as expected:

  ```
  <my-item>
    var tag = this
    tag.on('update', function () {
      console.log(tag.opts.myData.id)
      // the above will render 1, 2, 3 on initial mount/update
      // however when removeItem() is invoked bellow,  it will render 1, 2 (not 2,3 as expected)
    })
  </my-item>

  <my-items-list>
    <script>
       var tag = this
       tag.collection = [ {id: 1}, {id: 2}, {id: 3} ]
       tag.removeItem = function () {
          tag.collection.splice(0, 1) // this will re-render my-item loop but will not update myData opts value of existing tags
       }
    </script>
    <my-item each={itemData in collection} myData={itemData} />
    <button onclick={removeItem}>remove</button>
  </my-items-list>
  ```

3. Is this a breaking change?

  Nope

#### Content

Well while I've been play testing riotjs@next I found the above odd behavior which wasn't present in riot 2.x so I invested some time to debug and resolve the issue.

In short the problem comes when given collection is rendered via `each` attribute and then one item from the collection is removed. 

What happens is that already mounted Tags get updated with respective `tag._item` values however their `tag.opts` aren't which usually breaks things when `tag.opts` are used to propagate data.

----

PS. I'm not sure is this the right solution, so please advice, thanks in advance :)