### PR TITLE
Support for hot reloading

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -36,6 +36,7 @@ export var settings = brackets.settings
 export var util = {
   tmpl: tmpl,
   brackets: brackets,
+  styleManager: styleManager,
   styleNode: styleManager.styleNode
 }
 
@@ -124,9 +125,11 @@ export function tag(name, tmpl, css, attrs, fn) {
  * @returns { String } name/id of the tag just created
  */
 export function tag2(name, tmpl, css, attrs, fn) {
-  if (css) styleManager.add(css)
+  if (css) styleManager.add(css, name)
   //if (bpair) riot.settings.brackets = bpair
+  var exists = !!__TAG_IMPL[name]
   __TAG_IMPL[name] = { name, tmpl, attrs, fn }
+  if (exists && riot.util.hotReloader) riot.util.hotReloader(name)
   return name
 }
 

--- a/lib/browser/tag/if.js
+++ b/lib/browser/tag/if.js
@@ -1,6 +1,6 @@
 import { remAttr, unmountAll } from '../util'
 import { tmpl } from 'riot-tmpl'
-import parseExpressions from './parse'
+import { parseExpressions } from './parse'
 import update from './update'
 
 export default function IfExpr(dom, parentTag, expr) {

--- a/lib/browser/tag/named.js
+++ b/lib/browser/tag/named.js
@@ -13,7 +13,6 @@ export default function NamedExpr(dom, attrName, attrValue, parent) {
   this.attr = attrName
   this.rawValue = attrValue
   this.parent = parent
-  this.customParent = getImmediateCustomParentTag(parent)
   this.hasExp = tmpl.hasExpr(attrValue)
   this.firstRun = true
 }
@@ -27,19 +26,21 @@ NamedExpr.prototype.update = function() {
   // if nothing changed, we're done
   if (!this.firstRun && value === this.value) return
 
+  var customParent = this.parent && getImmediateCustomParentTag(this.parent)
+
   // if the named element is a custom tag, then we set the tag itself, rather than DOM
   var tagOrDom = this.tag || this.dom
 
   // the name changed, so we need to remove it from the old key (if present)
-  if (!isBlank(this.value))
-    arrayishRemove(this.customParent, this.value, tagOrDom)
+  if (!isBlank(this.value) && customParent)
+    arrayishRemove(customParent, this.value, tagOrDom)
 
   if (isBlank(value)) {
     // if the value is blank, we remove it
     remAttr(this.dom, this.attr)
   } else {
     // add it to the parent tag, and set the actual DOM attr
-    arrayishAdd(this.customParent, value, tagOrDom)
+    if (customParent) arrayishAdd(customParent, value, tagOrDom)
     setAttr(this.dom, this.attr, value)
   }
   this.value = value
@@ -48,9 +49,9 @@ NamedExpr.prototype.update = function() {
 
 NamedExpr.prototype.unmount = function() {
   var tagOrDom = this.tag || this.dom
-  if (!isBlank(this.value))
-    arrayishRemove(this.customParent, this.value, tagOrDom)
+  var customParent = this.parent && getImmediateCustomParentTag(this.parent)
+  if (!isBlank(this.value) && customParent)
+    arrayishRemove(customParent, this.value, tagOrDom)
   delete this.dom
   delete this.parent
-  delete this.customParent
 }

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -5,11 +5,12 @@ import { tmpl } from 'riot-tmpl'
 import { RIOT_TAG, BOOL_ATTRS } from '../global-variables'
 import { walk, getAttr, each, getTag, initChildTag, remAttr } from '../util'
 
-export default function parseExpressions(root, tag, expressions, includeRoot) {
+export function parseExpressions(root, tag, expressions, includeRoot) {
   var base = {parent: {children: expressions}}
 
   walk(root, function(dom, ctx) {
     var type = dom.nodeType, parent = ctx.parent, attr, expr, childTag
+    if (!includeRoot && dom === root) return {parent: parent}
 
     // text node
     if (type == 3 && dom.parentNode.tagName != 'STYLE' && tmpl.hasExpr(dom.nodeValue))
@@ -30,33 +31,10 @@ export default function parseExpressions(root, tag, expressions, includeRoot) {
       return false
     }
 
-    // attribute expressions
-    var allAttrs = [], nameExps = []
-    each(dom.attributes, function(attr) {
-      var name = attr.name, bool = BOOL_ATTRS.test(name)
-      var hasExp = tmpl.hasExpr(attr.value)
-
-      if (name === 'name' || name === 'id') {
-        expr = new NamedExpr(dom, name, attr.value, tag)
-        parent.children.push(expr)
-        nameExps.push(expr)
-        allAttrs.push(expr)
-        return
-      }
-
-      expr = {dom: dom, expr: attr.value, attr: attr.name, bool: bool}
-      allAttrs.push(expr) // stores all attributes, even without expressions
-
-      if (!hasExp) return // no expressions here
-      parent.children.push(expr)
-      if (bool) { remAttr(dom, name); return false }
-    })
-
     if (expr = getAttr(dom, RIOT_TAG)) {
       if (tmpl.hasExpr(expr)) {
-        attr = {isRtag: true, expr: expr, dom: dom, children: []}
-        parent.children.push(attr)
-        parent = attr
+        parent.children.push({isRtag: true, expr: expr, dom: dom})
+        return false
       }
     }
 
@@ -64,16 +42,35 @@ export default function parseExpressions(root, tag, expressions, includeRoot) {
     // we ignore the root, since parseExpressions is called while we're mounting that root
     var tagImpl = getTag(dom)
     if (tagImpl && (dom !== root || includeRoot)) {
-      var conf = {root: dom, parent: tag, hasImpl: true, ownAttrs: allAttrs}
-      childTag = initChildTag(tagImpl, conf, dom.innerHTML, tag)
-
-      parent.children.push(childTag)
-      each(nameExps, function(ex) { ex.tag = childTag })
+      var conf = {root: dom, parent: tag, hasImpl: true}
+      parent.children.push(initChildTag(tagImpl, conf, dom.innerHTML, tag))
       return false
     }
+
+    // attribute expressions
+    parseAttributes(dom, dom.attributes, tag, function(attr, expr) {
+      if (!expr) return
+      parent.children.push(expr)
+    })
 
     // whatever the parent is, all child elements get the same parent.
     // If this element had an if-attr, that's the parent for all child elements
     return {parent: parent}
   }, base)
+}
+
+// Calls `fn` for every attribute on an element. If that attr has an expression,
+// it is also passed to fn.
+export function parseAttributes(dom, attrs, tag, fn) {
+  each(attrs, function(attr) {
+    var name = attr.name, bool = BOOL_ATTRS.test(name), expr
+
+    if (name === 'name' || name === 'id') {
+      expr = new NamedExpr(dom, name, attr.value, tag)
+    } else if (tmpl.hasExpr(attr.value)) {
+      expr = {dom: dom, expr: attr.value, attr: attr.name, bool: bool}
+    }
+
+    fn(attr, expr)
+  })
 }

--- a/lib/browser/tag/styleManager.js
+++ b/lib/browser/tag/styleManager.js
@@ -4,7 +4,8 @@ import { WIN } from '../global-variables'
 var styleNode,
 // Create cache and shortcut to the correct property
   cssTextProp,
-  stylesToInject = ''
+  byName = {},
+  remainder = []
 
 // skip the following code on the server
 if (WIN) {
@@ -35,19 +36,21 @@ export default {
    * Save a tag style to be later injected into DOM
    * @param   { String } css [description]
    */
-  add: function(css) {
-    if (WIN) stylesToInject += css
+  add: function(css, name) {
+    if (name) byName[name] = css
+    else remainder.push(css)
   },
   /**
    * Inject all previously saved tag styles into DOM
    * innerHTML seems slow: http://jsperf.com/riot-insert-style
    */
   inject: function() {
-    if (stylesToInject && WIN) {
-      if (cssTextProp) cssTextProp.cssText += stylesToInject
-      else styleNode.innerHTML += stylesToInject
-      stylesToInject = ''
-    }
+    if (!WIN) return
+    var style = Object.keys(byName)
+      .map(function(k) { return byName[k] })
+      .concat(remainder).join('\n')
+    if (cssTextProp) cssTextProp.cssText = style
+    else styleNode.innerHTML = style
   }
 }
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -1,5 +1,6 @@
 import observable from 'riot-observable'
-import parseExpressions from './parse'
+import { parseExpressions, parseAttributes } from './parse'
+import NamedExpr from './named'
 import update from './update'
 import { tmpl } from 'riot-tmpl'
 import mkdom from './mkdom'
@@ -45,12 +46,12 @@ export default function Tag(impl, conf, innerHTML) {
     parent = conf.parent,
     isLoop = conf.isLoop,
     hasImpl = conf.hasImpl,
-    ownAttrs = conf.ownAttrs, // attributes on this tag (evaluated in parent context)
     item = cleanUpData(conf.item),
+    instAttrs = [], // All attributes on the Tag when it's first parsed
+    implAttrs = [], // expressions on this type of Tag
     expressions = [],
     root = conf.root,
     tagName = conf.tagName || root.tagName.toLowerCase(),
-    attr = {},
     propsInSyncWithParent = [],
     dom
 
@@ -70,36 +71,21 @@ export default function Tag(impl, conf, innerHTML) {
   // protect the "tags" property from being overridden
   defineProperty(this, 'tags', {})
 
-  // grab attributes
-  each(root.attributes, function(el) {
-    var val = el.value
-    // remember attributes with expressions only
-    if (tmpl.hasExpr(val)) attr[el.name] = val
-  })
-
   dom = mkdom(impl.tmpl, innerHTML)
 
-  // options
+  // We need to update opts for this tag. That requires updating the expressions
+  // in any attributes on the tag, and then copying the result onto opts.
   function updateOpts() {
+    // anonymous `each` tags treat `dom` and `root` differently. In this case
+    // (and only this case) we don't need to do updateOpts, because the regular parse
+    // will update those attrs. Plus, anonymous tags don't need opts anyway
+    if (isLoop && !hasImpl) return
+
     var ctx = hasImpl && isLoop ? self : parent || self
-
-    // If we're nested beneath another tag, then our attributes are evaluated
-    // in that parent context. Here, we copy them onto opts.
-    if (ownAttrs) {
-      each(ownAttrs || [], function(expr) {
-        // if the attribute doesn't actually have an expression, there
-        // won't be a value. Just use the string itself in this case.
-        var v = expr.hasOwnProperty('value') ? expr.value : expr.expr
-        opts[toCamel(expr.attr)] = v
-      })
-
-    } else {
-      each(root.attributes, function(el) {
-        var val = el.value, hasTmpl = tmpl.hasExpr(val)
-        if (hasTmpl && ownAttrs) return // already handled above
-        opts[toCamel(el.name)] = hasTmpl ? tmpl(val, ctx) : val
-      })
-    }
+    each(instAttrs, function(attr) {
+      if (attr.expr) update([attr.expr], ctx)
+      opts[toCamel(attr.name)] = attr.expr ? attr.expr.value : attr.value
+    })
   }
 
   function normalizeData(data) {
@@ -180,12 +166,7 @@ export default function Tag(impl, conf, innerHTML) {
   })
 
   defineProperty(this, 'mount', function tagMount(forceUpdate) {
-
-    updateOpts()
-
-    // keep a reference to the tag just created
-    // so we will be able to mount this tag multiple times
-    root._tag = this
+    root._tag = this // keep a reference to the tag just created
 
     // add global mixin
     var globalMixin = mixin(GLOBAL_MIXIN)
@@ -194,18 +175,27 @@ export default function Tag(impl, conf, innerHTML) {
         if (globalMixin.hasOwnProperty(i))
           self.mixin(globalMixin[i])
 
+    // Read all the attrs on this instance. This give us the info we need for updateOpts
+    parseAttributes(root, root.attributes, parent, function(attr, expr) {
+      if (hasImpl && expr instanceof NamedExpr) expr.tag = self
+      attr.expr = expr
+      instAttrs.push(attr)
+    })
+
     // initialiation
+    updateOpts()
     if (impl.fn) impl.fn.call(self, opts)
 
     // update the root adding custom attributes coming from the compiler
-    // it fixes also #1087
-    if (impl.attrs)
-      walkAttributes(impl.attrs, function (k, v) { setAttr(root, k, v) })
-    if (impl.attrs || hasImpl)
-      parseExpressions(self.root, self, expressions)
+    implAttrs = []
+    walkAttributes(impl.attrs, function (k, v) { implAttrs.push({name: k, value: v}) })
+    parseAttributes(root, implAttrs, self, function(attr, expr) {
+      if (expr) expressions.push(expr)
+      else setAttr(root, attr.name, attr.value)
+    })
 
     // parse layout after init. fn may calculate args for nested custom tags
-    parseExpressions(dom, self, expressions)
+    parseExpressions(dom, self, expressions, false)
 
     self.update(item)
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -61,7 +61,11 @@ export default function Tag(impl, conf, innerHTML) {
   // not yet mounted
   this.isMounted = false
   root.isLoop = isLoop
-  this._hasImpl = hasImpl
+  this._internal = {
+    hasImpl: hasImpl,
+    origAttrs: instAttrs,
+    innerHTML: innerHTML
+  }
 
   // create a unique id to this tag
   // it could be handy to use it also to improve the virtual dom rendering speed

--- a/lib/browser/util.js
+++ b/lib/browser/util.js
@@ -207,7 +207,7 @@ export function initChildTag(child, opts, innerHTML, parent) {
  */
 export function getImmediateCustomParentTag(tag) {
   var ptag = tag
-  while (!ptag._hasImpl) {
+  while (!ptag._internal.hasImpl) {
     if (!ptag.parent) break
     ptag = ptag.parent
   }

--- a/lib/browser/util.js
+++ b/lib/browser/util.js
@@ -356,6 +356,7 @@ export function walk(dom, fn, context) {
  * @param   { Function } fn - callback function to apply on any attribute found
  */
 export function walkAttributes(html, fn) {
+  if (!html) return
   var m,
     re = /([-\w]+) ?= ?(?:"([^"]*)|'([^']*)|({[^}]*}))/g
 

--- a/test/specs/browser/core.spec.js
+++ b/test/specs/browser/core.spec.js
@@ -427,24 +427,6 @@ describe('Riot core', function() {
     tag.unmount()
   })
 
-
-  it('top level attr manipulation having expression', function() {
-
-    injectHTML('<top-level-attr></top-level-attr>')
-
-    riot.tag('top-level-attr', '{opts.value}')
-
-    var tag = riot.mount('top-level-attr')[0]
-
-    tag.root.setAttribute('value', '{1+1}')
-    tag.update()
-
-    expect(tag.root.innerHTML).to.be.equal('2')
-
-    tag.unmount()
-
-  })
-
   it('preserve attributes from tag definition', function() {
 
 
@@ -659,13 +641,6 @@ describe('Riot core', function() {
     expect(tag.root.getAttribute('data-noquote')).to.be.equal('quotes') // not quoted
     expect(tag.root.getAttribute('data-nqlast')).to.be.equal('quotes') // last attr with no quotes
     expect(tag.root.style.fontSize).to.be.equal('2em') // TODO: how to test riot-prefix?
-
-    var opts = tag.root._tag.opts
-    if (opts)
-      expect(opts.riotStyle).to.match(/font-size:\s?2em/i)
-    else
-      console.log('top-attributes._tag.opts not found!')
-
     tag.unmount()
   })
 


### PR DESCRIPTION
I have a basic version of hot reloading that supports styles and tags I wanted to open a PR for discussion while testing it out. This isn't yet ready to be merged.

These commits just refactor Riot's internals a bit to support hot reloading. The actual reloader is here:
https://gist.github.com/rogueg/19bfdafe256c74d741c7cae8439e546b

It works pretty much how I described in #1836. The one major caveat is that when a tag reloads, all child tags will lose their state. I'm not sure if that will be annoying.
