### PR TITLE
Inherit on mount

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -171,7 +171,7 @@ function Tag(impl, conf, innerHTML) {
           self.mixin(globalMixin[i])
 
     // children in loop should inherit from true parent
-    if (!isLoop && self._parent) {
+    if (self._parent) {
       inheritFrom(self._parent)
     }
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -64,16 +64,16 @@ function Tag(impl, conf, innerHTML) {
     }
   }
 
-  function inheritFromParent () {
-    if (!self.parent || !isLoop) return
-    each(Object.keys(self.parent), function(k) {
+  function inheritFrom(target) {
+    each(Object.keys(target), function(k) {
       // some properties must be always in sync with the parent tag
       var mustSync = !RESERVED_WORDS_BLACKLIST.test(k) && contains(propsInSyncWithParent, k)
+
       if (typeof self[k] === T_UNDEF || mustSync) {
         // track the property to keep in sync
         // so we can keep it updated
         if (!mustSync) propsInSyncWithParent.push(k)
-        self[k] = self.parent[k]
+        self[k] = target[k]
       }
     })
   }
@@ -89,8 +89,10 @@ function Tag(impl, conf, innerHTML) {
     // make sure the data passed will not override
     // the component core methods
     data = cleanUpData(data)
-    // inherit properties from the parent
-    inheritFromParent()
+    // inherit properties from the parent in loop
+    if (isLoop) {
+      inheritFrom(self.parent)
+    }
     // normalize the tag properties in case an item object was initially passed
     if (data && isObject(item)) {
       normalizeData(data)
@@ -134,7 +136,8 @@ function Tag(impl, conf, innerHTML) {
       // loop the keys in the function prototype or the all object keys
       each(props, function(key) {
         // bind methods to self
-        if (key != 'init' && !self[key]) {
+        // allow mixins to override other properties/parent mixins
+        if (key != 'init') {
           // check for getters/setters
           var descriptor = Object.getOwnPropertyDescriptor(instance, key)
           var hasGetterSetter = descriptor && (descriptor.get || descriptor.set)
@@ -166,6 +169,11 @@ function Tag(impl, conf, innerHTML) {
       for (var i in globalMixin)
         if (globalMixin.hasOwnProperty(i))
           self.mixin(globalMixin[i])
+
+    // children in loop should inherit from true parent
+    if (!isLoop && self._parent) {
+      inheritFrom(self._parent)
+    }
 
     // initialiation
     if (impl.fn) impl.fn.call(self, opts)

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -1449,6 +1449,14 @@ it('raw contents', function() {
     tags.push(tag)
   })
 
+  it('children in a loop inherit properties on mount', function() {
+    var tag = riot.mount('loop-inherit-mount')[0]
+
+    tag.root.getElementsByTagName('button')[0].dispatchEvent(new CustomEvent('click'))
+
+    expect(tag.tags.child.result).to.be('test')
+  })
+
   it('loop tags get rendered correctly also with conditional attributes', function(done) {
     var tag = riot.mount('loop-conditional')[0]
 

--- a/test/specs/browser/tags-bootstrap.js
+++ b/test/specs/browser/tags-bootstrap.js
@@ -13,6 +13,7 @@ loadTagsAndScripts([
   'tag/loop-events.tag',
   'tag/loop-sync-options-nested.tag',
   'tag/loop-inherit.tag',
+  'tag/loop-inherit-mount.tag',
   'tag/loop-root.tag',
   'tag/loop-double-curly-brackets.tag',
   'tag/loop-conditional.tag',

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -264,7 +264,6 @@ describe('Mixin', function() {
 
     expect(tag._riot_id).to.be(tag.getId())
     expect(tag.tags['sub-mixin']).not.to.be('undefined')
-
     expect(tag.tags['sub-mixin']._riot_id).to.be(tag.tags['sub-mixin'].getId())
     expect(tag.getId()).not.to.be(tag.tags['sub-mixin'].getId())
     tag.unmount()

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -264,6 +264,7 @@ describe('Mixin', function() {
 
     expect(tag._riot_id).to.be(tag.getId())
     expect(tag.tags['sub-mixin']).not.to.be('undefined')
+
     expect(tag.tags['sub-mixin']._riot_id).to.be(tag.tags['sub-mixin'].getId())
     expect(tag.getId()).not.to.be(tag.tags['sub-mixin'].getId())
     tag.unmount()

--- a/test/tag/loop-inherit-mount.tag
+++ b/test/tag/loop-inherit-mount.tag
@@ -1,0 +1,23 @@
+<loop-inherit-mount>
+  <button type="button" onclick="{add}">add</button>
+  <div each="{list}">
+    <loop-inherit-mount-child name="child"></loop-inherit-mount-child>
+  </div>
+  <script>
+    this.list = []
+
+    add() {
+      this.list.push({
+        test: 'test'
+      })
+    }
+  </script>
+</loop-inherit-mount>
+
+<loop-inherit-mount-child>
+  <script>
+    this.one('mount', function () {
+      this.result = this.test
+    })
+  </script>
+</loop-inherit-mount-child>


### PR DESCRIPTION
This pull request fixes the behavior I mentioned in #1897 

Despite the apparent simplicity of the aforementioned issue, it goes deeper into the logic of the tag lifecycle than I thought.
Basically, tags in a loop are only passed parent properties when 'update' is called, not 'mount', so any logic regarding them will fail if it listens to the latter.
But you can't do so on the 'parent' tag, you'll need the real '_parent' property cached by the each loop.
This, in turn, makes nested mixins fail, because they only apply if target property doesn't exist... which is now being inherited from '_parent'.

