### PR TITLE
Hyperloop

### DIFF
--- a/lib/browser/common/util/check.js
+++ b/lib/browser/common/util/check.js
@@ -4,9 +4,19 @@ import {
   T_FUNCTION,
   T_UNDEF,
   RE_SVG_TAGS,
+  RE_SPECIAL_TAGS,
   RE_BOOL_ATTRS,
   RE_RESERVED_NAMES
 } from './../global-variables'
+
+/**
+ * Check whether a DOM node is a special tag
+ * @param   { String } name -
+ * @returns { Boolean } -
+ */
+export function isSpecialTag(name) {
+  return RE_SPECIAL_TAGS.test(name)
+}
 
 /**
  * Check whether a DOM node must be considered a part of an svg document
@@ -39,9 +49,13 @@ export function isFunction(value) {
  * Check if passed argument is an object, exclude null
  * NOTE: use isObject(x) && !isArray(x) to excludes arrays.
  * @param   { * } value -
+ * @param   { Boolean } allowNull - is null allowed?
  * @returns { Boolean } -
  */
-export function isObject(value) {
+export function isObject(value, allowNull) {
+  if (!allowNull && value === null)
+    return false
+
   return value && typeof value === T_OBJECT // typeof null is 'object'
 }
 

--- a/lib/browser/common/util/dom-helpers.js
+++ b/lib/browser/common/util/dom-helpers.js
@@ -123,3 +123,23 @@ export function isInStub(dom) {
   }
   return false
 }
+
+/**
+ * Shorter and fast way to select multiple nodes in the DOM
+ * @param   { String } selector - DOM selector
+ * @param   { Object } ctx - DOM node where the targets of our search will is located
+ * @returns { Object } dom nodes found
+ */
+export function $$(selector, ctx) {
+  return (ctx || document).querySelectorAll(selector)
+}
+
+/**
+ * Shorter and fast way to select a single node in the DOM
+ * @param   { String } selector - unique dom selector
+ * @param   { Object } ctx - DOM node where the target of our search will is located
+ * @returns { Object } dom node found
+ */
+export function $(selector, ctx) {
+  return (ctx || document).querySelector(selector)
+}

--- a/lib/browser/common/util/misc.js
+++ b/lib/browser/common/util/misc.js
@@ -1,4 +1,7 @@
-import { isWritable } from './check'
+import {
+  isArray,
+  isWritable
+} from './check'
 
 /**
  * Specialized function for looping an array-like collection with `each={}`
@@ -52,7 +55,7 @@ export function startsWith(str, value) {
  * @param   { Object } el - object where the new property will be set
  * @param   { String } key - object key where the new property will be stored
  * @param   { * } value - value of the new property
- * @param   { Object } options - set the propery overriding the default options
+ * @param   { Object } [options] - set the propery overriding the default options
  * @returns { Object } - the initial object
  */
 export function defineProperty(el, key, value, options) {
@@ -87,4 +90,58 @@ export function extend(src) {
     }
   }
   return src
+}
+
+/**
+ * Simple object prototypal inheritance
+ * @param   { Object } parent - parent object
+ * @returns { Object } child instance
+ */
+export function inherit(parent) {
+  function Child() {}
+  Child.prototype = parent
+  return new Child()
+}
+
+/**
+ * Set the property of an object for a given key. If something already
+ * exists there, then it becomes an array containing both the old and new value.
+ * @param { Object } obj - object on which to set the property
+ * @param { String } key - property name
+ * @param { Object } value - the value of the property to be set
+ * @param { Boolean } ensureArray - ensure that the property remains an array
+ */
+export function arrayishAdd(obj, key, value, ensureArray) {
+  var dest = obj[key]
+  var isArr = isArray(dest)
+
+  if (dest && dest === value) return
+
+  // if the key was never set, set it once
+  if (!dest && ensureArray) obj[key] = [value]
+  else if (!dest) obj[key] = value
+  // if it was an array and not yet set
+  else if (!isArr || isArr && !contains(dest, value)) {
+    if (isArr) dest.push(value)
+    else obj[key] = [dest, value]
+  }
+}
+
+/**
+ * Removes an item from an object at a given key. If the key points to an array,
+ * then the item is just removed from the array.
+ * @param { Object } obj - object on which to remove the property
+ * @param { String } key - property name
+ * @param { Object } value - the value of the property to be removed
+ * @param { Boolean } ensureArray - ensure that the property remains an array
+*/
+export function arrayishRemove(obj, key, value, ensureArray) {
+  if (isArray(obj[key])) {
+    each(obj[key], function(item, i) {
+      if (item === value) obj[key].splice(i, 1)
+    })
+    if (!obj[key].length) delete obj[key]
+    else if (obj[key].length == 1 && !ensureArray) obj[key] = obj[key][0]
+  } else
+    delete obj[key] // otherwise just delete the key
 }

--- a/lib/browser/common/util/tag-helpers.js
+++ b/lib/browser/common/util/tag-helpers.js
@@ -3,11 +3,15 @@ import {
 } from './dom-helpers'
 
 import {
+  arrayishAdd,
+  arrayishRemove,
   contains,
   each
 } from './misc'
 
 import {
+  isString,
+  isUndefined,
   isArray
 } from './check'
 
@@ -25,12 +29,18 @@ import { tmpl } from 'riot-tmpl'
 
 /**
  * Detect the tag implementation by a DOM node
- * @param   { Object } dom - DOM node we need to parse to get its tag implementation
+ * @param   { Object|String } node - a DOM node or a string we need to parse to get it's tag implementation
  * @returns { Object } it returns an object containing the implementation of a custom tag (template and boot function)
  */
-export function getTag(dom) {
-  return dom.tagName && __TAG_IMPL[getAttr(dom, RIOT_TAG_IS) ||
-    getAttr(dom, RIOT_TAG) || dom.tagName.toLowerCase()]
+export function getTagImpl(node) {
+  return isString(node) ?
+    __TAG_IMPL[node] :
+    // parse attributes from dom element
+    node.tagName && __TAG_IMPL[
+      getAttr(node, RIOT_TAG_IS) ||
+      getAttr(node, RIOT_TAG) ||
+      node.tagName.toLowerCase()
+    ]
 }
 
 /**
@@ -117,7 +127,7 @@ export function unmountAll(expressions) {
  * @returns { String } name to identify this dom node in riot
  */
 export function getTagName(dom, skipName) {
-  var child = getTag(dom),
+  var child = getTagImpl(dom),
     namedTag = !skipName && getAttr(dom, 'name'),
     tagName = namedTag && !tmpl.hasExpr(namedTag) ?
                 namedTag :
@@ -140,80 +150,6 @@ export function cleanUpData(data) {
     if (!RE_RESERVED_NAMES.test(key)) o[key] = data[key]
   }
   return o
-}
-
-/**
- * Shorter and fast way to select multiple nodes in the DOM
- * @param   { String } selector - DOM selector
- * @param   { Object } ctx - DOM node where the targets of our search will is located
- * @returns { Object } dom nodes found
- */
-export function $$(selector, ctx) {
-  return (ctx || document).querySelectorAll(selector)
-}
-
-/**
- * Shorter and fast way to select a single node in the DOM
- * @param   { String } selector - unique dom selector
- * @param   { Object } ctx - DOM node where the target of our search will is located
- * @returns { Object } dom node found
- */
-export function $(selector, ctx) {
-  return (ctx || document).querySelector(selector)
-}
-
-/**
- * Simple object prototypal inheritance
- * @param   { Object } parent - parent object
- * @returns { Object } child instance
- */
-export function inherit(parent) {
-  function Child() {}
-  Child.prototype = parent
-  return new Child()
-}
-
-/**
- * Set the property of an object for a given key. If something already
- * exists there, then it becomes an array containing both the old and new value.
- * @param { Object } obj - object on which to set the property
- * @param { String } key - property name
- * @param { Object } value - the value of the property to be set
- * @param { Boolean } ensureArray - ensure that the property remains an array
- */
-export function arrayishAdd(obj, key, value, ensureArray) {
-  var dest = obj[key]
-  var isArr = isArray(dest)
-
-  if (dest && dest === value) return
-
-  // if the key was never set, set it once
-  if (!dest && ensureArray) obj[key] = [value]
-  else if (!dest) obj[key] = value
-  // if it was an array and not yet set
-  else if (!isArr || isArr && !contains(dest, value)) {
-    if (isArr) dest.push(value)
-    else obj[key] = [dest, value]
-  }
-}
-
-/**
- * Removes an item from an object at a given key. If the key points to an array,
- * then the item is just removed from the array.
- * @param { Object } obj - object on which to remove the property
- * @param { String } key - property name
- * @param { Object } value - the value of the property to be removed
- * @param { Boolean } ensureArray - ensure that the property remains an array
-*/
-export function arrayishRemove(obj, key, value, ensureArray) {
-  if (isArray(obj[key])) {
-    each(obj[key], function(item, i) {
-      if (item === value) obj[key].splice(i, 1)
-    })
-    if (!obj[key].length) delete obj[key]
-    else if (obj[key].length == 1 && !ensureArray) obj[key] = obj[key][0]
-  } else
-    delete obj[key] // otherwise just delete the key
 }
 
 /**
@@ -244,29 +180,36 @@ export function mountTo(root, tagName, opts) {
   return tag
 }
 
+/**
+ * Unmount redundant tags
+ * @param { Array } items - array containing the current items to loop
+ * @param { Array } tags - array containing all the children tags
+ * @param { String } tagName - key used to identify the type of tag
+ * @param { Object } parent - parent tag to remove the child from
+ */
+export function unmountRedundant(items, tags, tagName, parent) {
+  let
+    i = tags.length,
+    j = items.length,
+    t
+
+  while (i > j) {
+    t = tags[--i]
+    tags.splice(i, 1)
+    t.unmount()
+    arrayishRemove(parent.tags, tagName, t, true)
+  }
+}
 
 /**
  * Adds the elements for a virtual tag
- * @param { Tag } tag - the tag whose root's children will be inserted or appended
- * @param { Node } src - the node that will do the inserting or appending
- * @param { Tag } target - only if inserting, insert before this tag's first child
+ * @param { Tag } tag - the tag whose root's children will be inserted
+ * @param { Node } target - the node to insert to
  */
-export function makeVirtual(tag, src, target) {
-  var head = document.createTextNode(''), tail = document.createTextNode(''), sib, el
-  tag._head = tag.root.insertBefore(head, tag.root.firstChild)
-  tag._tail = tag.root.appendChild(tail)
-  el = tag._head
-  tag._virts = []
-  while (el) {
-    sib = el.nextSibling
-    if (target)
-      src.insertBefore(el, target._head)
-    else
-      src.appendChild(el)
+export function makeVirtual(tag, target) {
+  tag._virts = tag._virts || Array.prototype.slice.call(tag.root.childNodes)
 
-    tag._virts.push(el) // hold for unmounting
-    el = sib
-  }
+  tag._virts.forEach(node => target.appendChild(node))
 }
 
 /**
@@ -306,4 +249,42 @@ export function selectTags(tags) {
       let name = t.trim().toLowerCase()
       return list + `,[${RIOT_TAG_IS}="${name}"]`
     }, '')
+}
+
+/**
+ * Convert the item looped into an object used to extend the child tag properties
+ * @param   { Object } exprObj - object containing the keys used to extend the children tags
+ * @param   { * } key - value to assign to the new object returned
+ * @param   { * } pos - value containing the position of the item in the array
+ * @param   { Object } base - prototype object for the new item
+ * @returns { Object } - new object containing the values of the original item
+ *
+ * The variables 'key' and 'pos' are arbitrary.
+ * They depend on the collection type looped (Array, Object)
+ * and on the expression used on the each tag
+ *
+ */
+export function mkitem(exprObj, key, pos, base) {
+  const item = base ? Object.create(base) : {}
+  item[exprObj.key] = key
+  if (exprObj.pos)
+    item[exprObj.pos] = pos
+  return item
+}
+
+/**
+ * Move the nested custom tags in non custom loop tags
+ * @param { Object } child - non custom loop tag
+ * @param { Number } i - current position of the loop tag
+ */
+export function moveNestedTags(child, i) {
+  Object.keys(child.tags).forEach(function(tagName) {
+    var tag = child.tags[tagName]
+    if (isArray(tag))
+      each(tag, function (t) {
+        moveChildTag(t, tagName, i)
+      })
+    else
+      moveChildTag(tag, tagName, i)
+  })
 }

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -1,167 +1,129 @@
 import {
-  T_STRING,
-  T_OBJECT,
-  __TAG_IMPL,
-  RE_SPECIAL_TAGS,
-  FIREFOX
+  FIREFOX,
+  __TAG_IMPL
 } from './../common/global-variables'
-
-import {
-  isArray,
-  remAttr,
-  getAttr,
-  getTagName,
-  getTag,
-  arrayishAdd,
-  arrayishRemove,
-  defineProperty,
-  getOuterHTML,
-  moveChildTag,
-  each,
-  makeVirtual,
-  moveVirtual
-} from './../common/util'
 
 import { tmpl } from 'riot-tmpl'
 import Tag from './tag'
 
-/**
- * Convert the item looped into an object used to extend the child tag properties
- * @param   { Object } expr - object containing the keys used to extend the children tags
- * @param   { * } key - value to assign to the new object returned
- * @param   { * } val - value containing the position of the item in the array
- * @param   { Object } base - prototype object for the new item
- * @returns { Object } - new object containing the values of the original item
- *
- * The variables 'key' and 'val' are arbitrary.
- * They depend on the collection type looped (Array, Object)
- * and on the expression used on the each tag
- *
- */
-export function mkitem(expr, key, val, base) {
-  var item = base ? Object.create(base) : {}
-  item[expr.key] = key
-  if (expr.pos) item[expr.pos] = val
-  return item
-}
+import {
+  isUndefined,
+  isString,
+  isObject,
+  isSpecialTag,
+  getTagName,
+  getTagImpl,
+  getOuterHTML,
+  mkitem,
+  getAttr,
+  remAttr,
+  arrayishAdd,
+  arrayishRemove,
+  defineProperty,
+  isArray,
+  makeVirtual,
+  moveNestedTags
+} from './../common/util'
 
-/**
- * Unmount the redundant tags
- * @param   { Array } items - array containing the current items to loop
- * @param   { Array } tags - array containing all the children tags
- * @param   { String } tagName - key used to identify the type of tag
- * @param   { Object } parent - parent tag to remove the child from
- */
-export function unmountRedundant(items, tags, tagName, parent) {
-
-  var i = tags.length,
-    j = items.length,
-    t
-
-  while (i > j) {
-    t = tags[--i]
-    tags.splice(i, 1)
-    t.unmount()
-    arrayishRemove(parent.tags, tagName, t, true)
-  }
-}
-
-/**
- * Move the nested custom tags in non custom loop tags
- * @param   { Object } child - non custom loop tag
- * @param   { Number } i - current position of the loop tag
- */
-export function moveNestedTags(child, i) {
-  Object.keys(child.tags).forEach(function(tagName) {
-    var tag = child.tags[tagName]
-    if (isArray(tag))
-      each(tag, function (t) {
-        moveChildTag(t, tagName, i)
-      })
-    else
-      moveChildTag(tag, tagName, i)
-  })
-}
-
-/**
- * Manage tags having the 'each'
- * @param   { Object } dom - DOM node we need to loop
- * @param   { Tag } parent - parent tag instance where the dom node is contained
- * @param   { String } expr - string contained in the 'each' attribute
- * @returns { Object } expression object for this each loop
- */
-export default function _each(dom, parent, expr) {
-
-  // remove the each property from the original tag
+export default function each(dom, parent, expr) {
   remAttr(dom, 'each')
 
-  var mustReorder = typeof getAttr(dom, 'no-reorder') !== T_STRING || remAttr(dom, 'no-reorder'),
+  const
+    noReorder = isString(getAttr(dom, 'no-reorder')),
+    child = getTagImpl(dom),
     tagName = getTagName(dom),
     impl = __TAG_IMPL[tagName] || { tmpl: getOuterHTML(dom) },
-    useRoot = RE_SPECIAL_TAGS.test(tagName),
+    useRoot = isSpecialTag(tagName),
+    exprObj = tmpl.loopKeys(expr),
+    ifExpr = getAttr(dom, 'if'),
+    isVirtual = dom.tagName == 'VIRTUAL',
+    // #1374 FireFox bug in <option selected={expression}>
+    isOptionFF = FIREFOX && tagName.toLowerCase() === 'option'
+
+  let
     root = dom.parentNode,
     ref = document.createTextNode(''),
-    child = getTag(dom),
-    isOption = tagName.toLowerCase() === 'option', // the option tags must be treated differently
-    tags = [],
-    oldItems = [],
-    hasKeys,
-    isVirtual = dom.tagName == 'VIRTUAL'
+    hasKeys
 
-  // parse the each expression
-  expr = tmpl.loopKeys(expr)
-  expr.isLoop = true
-
-  var ifExpr = getAttr(dom, 'if')
-  if (ifExpr) remAttr(dom, 'if')
+  remAttr(dom, 'if')
+  remAttr(dom, 'no-reorder')
 
   // insert a marked where the loop tags will be injected
   root.insertBefore(ref, dom)
   root.removeChild(dom)
 
-  expr.update = function updateEach() {
-    // get the new items collection
-    var items = tmpl(expr.val, parent),
-      // create a fragment to hold the new DOM nodes to inject in the parent tag
-      frag = document.createDocumentFragment()
-    root = ref.parentNode
+  let
+    itemsPrevious = [],
+    tagsPrevious = []
 
-    // object loop. any changes cause full redraw
-    if (!isArray(items)) {
-      hasKeys = items || false
-      items = hasKeys ?
-        Object.keys(items).map(function (key) {
-          return mkitem(expr, key, items[key])
-        }) : []
+  const
+    tagsMounted = {},
+    tagsPending = {}
+
+  exprObj.isLoop = true
+
+  function unmountById(riotId) {
+    let tag = tagsMounted[riotId]
+    tag.unmount()
+    arrayishRemove(parent.tags, tagName, tag, true)
+    delete tagsMounted[riotId]
+  }
+
+  exprObj.unmount = function unmountEach() {
+    Object.keys(tagsMounted).forEach(unmountById)
+  }
+
+  exprObj.update = function updateEach() {
+    let root = ref.parentNode
+
+    let
+      itemsUpdated = tmpl(exprObj.val, parent),
+      tagsUpdated = []
+
+    // objects cause full redraw
+    if (!isArray(itemsUpdated)) {
+      hasKeys = itemsUpdated || false
+      itemsUpdated = hasKeys
+        ? Object
+          .keys(itemsUpdated)
+          .map(key => {
+            return mkitem(exprObj, key, itemsUpdated[key])
+          })
+        : []
     }
 
     if (ifExpr) {
-      items = items.filter(function(item, i) {
-        var context = mkitem(expr, item, i, parent)
+      itemsUpdated = itemsUpdated.filter((item, i) => {
+        let context = mkitem(exprObj, item, i, parent)
         return !!tmpl(ifExpr, context)
       })
     }
 
-    // loop all the new items
-    items.forEach(function(item, i) {
-      // reorder only if the items are objects
+    const frag = document.createDocumentFragment()
 
-      var
-        _mustReorder = mustReorder && typeof item == T_OBJECT && !hasKeys,
-        oldPos = oldItems.indexOf(item),
-        pos = ~oldPos && _mustReorder ? oldPos : i,
-        // does a tag exist in this position?
-        tag = tags[pos], domToInsert
+    // do not move the nodes whose items didn't change position
+    let skipTo = -1
 
-      item = !hasKeys && expr.key ? mkitem(expr, item, i) : item
+    itemsUpdated.forEach((item, i) => {
+      // cache the original item
+      const _item = item
+      // with "no-order" flag we always use previous tags
+      const usePrevious = tagsPrevious.length > i &&
+        (noReorder || itemsPrevious[i] === item)
 
-      // new tag
-      if (
-        !_mustReorder && !tag // with no-reorder we just update the old tags
-        ||
-        _mustReorder && !~oldPos || !tag // by default we always try to reorder the DOM elements
-      ) {
+      if (usePrevious && skipTo === i - 1)
+        skipTo = i
 
+      let tag = usePrevious ? tagsPrevious[i] :
+        // check if this item was already linked
+        isObject(item) && tagsMounted[item._riot_id]
+
+      // extend item to account for "key" bindings
+      if (!hasKeys && exprObj.key)
+        item = mkitem(exprObj, item, i)
+
+      if (!tag) {
+        // new tag
         tag = new Tag(impl, {
           parent,
           isLoop: true,
@@ -170,79 +132,76 @@ export default function _each(dom, parent, expr) {
           item
         }, dom.innerHTML)
 
+        // link the original item to it's tag
+        if (isObject(_item))
+          defineProperty(_item, '_riot_id', tag._riot_id)
+
+        tagsMounted[tag._riot_id] = tag
+
         tag.mount()
-        domToInsert = tag.root
-        // this tag must be appended
-        if (i == tags.length) {
-          if (isVirtual)
-            makeVirtual(tag, frag)
-          else frag.appendChild(domToInsert)
-        }
-        // this tag must be insert
-        else {
-          if (isVirtual)
-            makeVirtual(tag, root, tags[i])
-          else root.insertBefore(domToInsert, tags[i].root)
-          oldItems.splice(i, 0, item)
-        }
 
-        tags.splice(i, 0, tag)
-        if (child) arrayishAdd(parent.tags, tagName, tag, true)
-        pos = i // handled here so no move
-      } else tag.update(item)
+        if (child)
+          arrayishAdd(parent.tags, tagName, tag, true)
 
-      // reorder the tag if it's not located in its previous position
-      if (pos !== i && _mustReorder) {
-        // update the DOM
-        if (isVirtual)
-          moveVirtual(tag, root, tags[i], dom.childNodes.length)
-        else if (tags[i].root.parentNode) root.insertBefore(tag.root, tags[i].root)
-        // update the position attribute if it exists
-        if (expr.pos)
-          tag[expr.pos] = i
-        // move the old tag instance
-        tags.splice(i, 0, tags.splice(pos, 1)[0])
-        // move the old item
-        oldItems.splice(i, 0, oldItems.splice(pos, 1)[0])
-        // if the loop tags are not custom
-        // we need to move all their custom tags into the right position
-        if (!child && tag.tags) moveNestedTags(tag, i)
+        // cache parent tag internally
+        defineProperty(tag, '_parent', parent)
+        // this will be used in events bound to this node
+        tag._item = item
+      } else {
+        tag.update(item)
+
+        if (!child && tag.tags)
+        // non-custom tags should have their nested tags moved
+          moveNestedTags(tag, i)
       }
 
-      // cache the original item to use it in the events bound to this node
-      // and its children
-      tag._item = item
-      // cache the real parent tag internally
-      defineProperty(tag, '_parent', parent)
+      tagsUpdated.push(tag)
 
+      tagsPending[tag._riot_id] = true
+
+      if (skipTo !== i) {
+        isVirtual ?
+          makeVirtual(tag, frag) :
+          frag.appendChild(tag.root)
+      }
     })
 
-    // remove the redundant tags
-    unmountRedundant(items, tags, tagName, parent)
+    let target = ref
 
-    // insert the new nodes
-    root.insertBefore(frag, ref)
-    if (isOption) {
+    // insert new nodes
+    if (skipTo >= 0) {
+      let tag = tagsPrevious[skipTo]
 
-      // #1374 FireFox bug in <option selected={expression}>
-      if (FIREFOX && !root.multiple) {
-        for (var n = 0; n < root.length; n++) {
-          if (root[n].__riot1374) {
-            root.selectedIndex = n  // clear other options
-            delete root[n].__riot1374
-            break
-          }
+      target = !tag._virts ?
+        tag.root.nextSibling :
+        tag._virts[tag._virts.length - 1].nextSibling
+    }
+
+    root.insertBefore(frag, target)
+
+    // unmount redundant
+    Object
+      .keys(tagsMounted)
+      .filter(riotId => isUndefined(tagsPending[riotId]))
+      .forEach(unmountById)
+    // clear updated
+    Object
+      .keys(tagsPending)
+      .forEach(riotId => delete tagsPending[riotId])
+
+    tagsPrevious = tagsUpdated.slice()
+    itemsPrevious = itemsUpdated.slice()
+
+    if (isOptionFF && !root.multiple) {
+      for (let i = 0; i < root.length; ++i) {
+        if (root[i].__riot1374) {
+          root.selectedIndex = i // clear other options
+          delete root[i].__riot1374
+          break
         }
       }
     }
-
-    // clone the items array
-    oldItems = items.slice()
   }
 
-  expr.unmount = function() {
-    each(tags, function(t) { t.unmount() })
-  }
-
-  return expr
+  return exprObj
 }

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -9,7 +9,7 @@ import {
   walkNodes,
   getAttr,
   each,
-  getTag,
+  getTagImpl,
   initChildTag
 } from './../common/util'
 
@@ -48,7 +48,7 @@ export function parseExpressions(root, tag, expressions, includeRoot) {
 
     // if this is a tag, stop traversing here.
     // we ignore the root, since parseExpressions is called while we're mounting that root
-    var tagImpl = getTag(dom)
+    var tagImpl = getTagImpl(dom)
     if (tagImpl && (dom !== root || includeRoot)) {
       var conf = {root: dom, parent: tag, hasImpl: true}
       parent.children.push(initChildTag(tagImpl, conf, dom.innerHTML, tag))

--- a/test/specs/browser/each.spec.js
+++ b/test/specs/browser/each.spec.js
@@ -26,6 +26,7 @@ import '../../tag/loop-cols.tag'
 import '../../tag/loop-child.tag'
 import '../../tag/loop-combo.tag'
 import '../../tag/loop-reorder.tag'
+import '../../tag/loop-reorder-inner.tag'
 import '../../tag/loop-manip.tag'
 import '../../tag/loop-object.tag'
 import '../../tag/loop-tag-instances.tag'
@@ -538,6 +539,20 @@ describe('Riot each', function() {
     tag.update()
     expect(tag.root.querySelectorAll('span')[0].className).to.be.equal('nr-5')
     expect(tag.root.querySelectorAll('div')[0].className).to.be.equal('nr-0')
+
+    tag.unmount()
+  })
+
+  it('loop reorder dom nodes with inner content intact', function() {
+
+    injectHTML('<loop-reorder-inner></loop-reorder-inner>')
+
+    var tag = riot.mount('loop-reorder-inner')[0]
+
+    expect(tag.root.querySelectorAll('span')[0].style.color).to.be.equal('red')
+    tag.items.reverse()
+    tag.update()
+    expect(tag.root.querySelectorAll('span')[1].style.color).to.be.equal('red')
 
     tag.unmount()
   })

--- a/test/tag/loop-reorder-inner.tag
+++ b/test/tag/loop-reorder-inner.tag
@@ -1,0 +1,14 @@
+<loop-reorder-inner>
+
+    <div each="{item in items}"><span>{item}</span></div>
+    <button onclick={swap}>swap</button>
+
+    this.items = ['one', 'two']
+    this.on('mount', function() {
+    this.root.querySelector('span').style.color = 'red'
+    })
+    swap() {
+    this.items.reverse()
+    }
+
+</loop-reorder-inner>

--- a/test/tag/loop-sync-options.tag
+++ b/test/tag/loop-sync-options.tag
@@ -13,10 +13,13 @@
 
 <loop-sync-options-child>
 
-  this.on('update mount', function() {
+  function updateOpts() {
     this.val = opts.data.val
     this.bool = opts.data.bool
     this.num = opts.data.num
-  })
+  }
+
+  this.on('mount', updateOpts)
+  this.on('update', updateOpts)
 
 </loop-sync-options-child>


### PR DESCRIPTION
What's new:
* moved `utils` around a bit
* clearer code
* no `forEach` for reorder, items get keyed with tag ids
* loop now skips unchanged nodes at the start
* `makeVirtual` a lot simpler now
* fixed each test that used spaced events

What to improve:
* smarter skipping (skip at both ends, optimize for small changes in sets)
* object loop speed up (can also apply keying for objects inside objects)
