### PR TITLE
[WIP] Adds querySelector and querySelectorAll method to Tag

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -61,7 +61,8 @@ export default function Tag(impl, conf, innerHTML) {
     root = conf.root,
     tagName = conf.tagName || root.tagName.toLowerCase(),
     propsInSyncWithParent = [],
-    dom
+    dom,
+    queryCashe = {}
 
   // only call unmount if we have a valid __TAG_IMPL (has name property)
   if (impl.name && root._tag) root._tag.unmount(true)
@@ -129,6 +130,9 @@ export default function Tag(impl, conf, innerHTML) {
    */
   defineProperty(this, 'update', function tagUpdate(data) {
     if (isFunction(self.shouldUpdate) && !self.shouldUpdate()) return
+
+    // clear cache data of querySelectorAll
+    clearQueryCache()
 
     // make sure the data passed will not override
     // the component core methods
@@ -318,4 +322,25 @@ export default function Tag(impl, conf, innerHTML) {
       delete self.root._eventHandlers
     }
   })
+
+  function clearQueryCache() { queryCashe = {} }
+  function normalize(selector) {
+    const re = /^[a-zA-Z]+(\-[a-zA-Z]+)*$/
+    return selector.replace(re, m => `${ m }, [data-is="${ m }"]`)
+  }
+
+  function tagQuerySelector(sel, flag) {
+    return tagQuerySelectorAll(sel, flag)[0]
+  }
+
+  function tagQuerySelectorAll(sel, flag) {
+    const nodes = queryCashe[sel]
+      || (queryCashe[sel] = root.querySelectorAll(normalize(sel)))
+    return !flag ? nodes : Array.prototype.map.call(nodes, node => node._tag || undefined)
+  }
+
+  defineProperty(this, 'querySelector', tagQuerySelector)
+  defineProperty(this, 'querySelectorAll', tagQuerySelectorAll)
+  defineProperty(this, '$', tagQuerySelector)
+  defineProperty(this, '$$', tagQuerySelectorAll)
 }

--- a/test/specs/browser/core.spec.js
+++ b/test/specs/browser/core.spec.js
@@ -36,6 +36,7 @@ import '../../tag/form-controls.tag'
 import '../../tag/data-is.tag'
 import '../../tag/virtual-nested-component.tag'
 import '../../tag/dynamic-data-is.tag'
+import '../../tag/query-selector.tag'
 
 const expect = chai.expect,
   defaultBrackets = riot.settings.brackets
@@ -882,6 +883,43 @@ describe('Riot core', function() {
     var tag = riot.mount('named-data-ref')[0]
     expect(tag.refs.greeting.value).to.be.equal('Hello')
 
+    tag.unmount()
+  })
+
+  it('gets single node by querySelector', function() {
+    injectHTML('<query-selector></query-selector>')
+    var tag = riot.mount('query-selector')[0]
+    expect(tag.querySelector('.first').value).to.be.equal('a')
+    expect(tag.$('.first').value).to.be.equal('a')
+    tag.unmount()
+  })
+
+  it('gets multiple nodes by querySelectorAll', function() {
+    injectHTML('<query-selector></query-selector>')
+    var tag = riot.mount('query-selector')[0]
+    expect(tag.querySelectorAll('.first')[1].value).to.be.equal('b')
+    expect(tag.$$('.first')[1].value).to.be.equal('b')
+    tag.unmount()
+  })
+
+  it('returns Tag instance when it is a custom tag', function() {
+    injectHTML('<query-selector></query-selector>')
+    var tag = riot.mount('query-selector')[0]
+    expect(tag.$('.second', true).constructor.name).to.be.equal('Tag')
+    tag.unmount()
+  })
+
+  it('returns undefined when it is not a custom tag', function() {
+    injectHTML('<query-selector></query-selector>')
+    var tag = riot.mount('query-selector')[0]
+    expect(tag.$('.first', true)).to.be.undefined
+    tag.unmount()
+  })
+
+  it('returns tags which has data-is attr, too', function() {
+    injectHTML('<query-selector></query-selector>')
+    var tag = riot.mount('query-selector')[0]
+    expect(tag.$$('query-selector-sub')[1].getAttribute('value')).to.be.equal('y')
     tag.unmount()
   })
 

--- a/test/tag/query-selector.tag
+++ b/test/tag/query-selector.tag
@@ -1,0 +1,13 @@
+<query-selector>
+  <input class="first" value="a">
+  <input class="first" value="b">
+  <query-selector-sub class="second" value="x" />
+  <div data-is="query-selector-sub" value="y"></div>
+</query-selector>
+
+<query-selector-sub>
+  <p>{ opts.value }</p>
+  <script>
+    this.prop1 = 'Hi'
+  </script>
+</query-selector-sub>


### PR DESCRIPTION
This PR is made for discussion purpose basically. Don't merge it. See [the issue](https://github.com/riot/riot/issues/1783)

#### Pros
- `.querySelector()` is so familiar (no learning cost)
- looks like standard (kind of)
- no more `.tags` and `.refs`
- more shorter code

#### Cons
- big breaking change, (maybe too much)
- inconsistent behavior in the expression in the loop or yield
- performance concern
- not implemented on simple-dom (server side rendering)

#### Todos before merging

- discussion
- remove the code for `.tags`
- remove the code for `.refs`

----------

#### 1. Have you added test(s) for your patch?

Yes.

#### 2. Can you provide an example of your patch in use?

```html
<my-tag>
  <input class="first" value="a">
  <input class="first" value="b">
  <input-special class="second" value="x" />
  <div data-is="input-special" value="y" />
  <p>{ $('.first').value }</p>
  <script>
    this.querySelector('.first').value // a
    this.querySelectorAll('.first')[1].value // b

    this.$$('input-special')[0].value // x
    this.$$('input-special')[1].value // y

    this.$('.first') // DOM
    this.$('.first', true)// undefined
    this.$('.second') // DOM
    this.$('.second', true) // Tag
  </script>
</my-tag>
```

#### 3. Is this a breaking change?

Yes.