### PR TITLE
Don't update input value unless expression is different, save cursor …

### DIFF
--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -102,7 +102,7 @@ function update(expressions, tag) {
 
     // ~~#1612: look for changes in dom.value when updating the value~~
     if (attrName === 'value') {
-      dom.value = value
+      if (dom.value != value) dom.value = value
       return
     }
 

--- a/test/specs/browser/compiler.js
+++ b/test/specs/browser/compiler.js
@@ -2261,4 +2261,44 @@ it('raw contents', function() {
     })
   })
 
+  it('carrot position is preserved when input is same as calculated value', function() {
+    var tag = riot.mount('input-values')[0]
+
+    var newValue = "some new text"
+    tag.i.value = newValue
+    tag.i.focus()
+    setCarrotPos(tag.i, 4)
+
+    tag.message = newValue
+    tag.update()
+
+    expect(getCarrotPos(tag.i)).to.be(4)
+
+    tags.push(tag)
+  })
 })
+
+function getCarrotPos(dom) {
+  if (dom.selectionStart != null)
+    return dom.selectionStart
+
+  if (document.selection == null)
+    return null
+
+  var range = document.selection.createRange()
+  range.moveStart('character', -dom.value.length)
+  return range.text.length
+}
+
+function setCarrotPos(dom, pos) {
+  if (dom.setSelectionRange != null) {
+    dom.setSelectionRange(pos, pos)
+    return
+  }
+
+  var range = dom.createTextRange()
+  range.collapse(true)
+  range.moveEnd('character', pos)
+  range.moveStart('character', pos)
+  range.select()
+}


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?
Yes


2. Can you provide an example of your patch in use?
No, but it's a pretty small change.  
Here's an example of the behavior without the patch:  http://jsfiddle.net/wf7bkvur/119/

3. Is this a breaking change?
Personally, I think not; I would expect preserving text cursor position when the actual value of an input would not change to be the expected behavior in almost all cases.

#### Content

The idea is simple and the code tells all:  if an input's value expression would result in a value that is equivalent to its actual value, don't set it explicitly.  This preserves the input's current cursor position.

This probably does not come up very often, but is crucial behavior for a controlled input.  Sometimes, I want to control an input via dataflow only.  I'm willing to accept that I may need to control an input's cursor position manually in special cases, but the extreme common case is that I "accept" an input's change into my model and want to reflect it back without losing cursor position.

http://jsfiddle.net/wf7bkvur/119/

