### PR TITLE
Support for mixins which have getters and setters on their prototype

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -129,6 +129,8 @@ function Tag(impl, conf, innerHTML) {
         instance = new mix()
       } else instance = mix
 
+      var proto = Object.getPrototypeOf(instance)
+
       // build multilevel prototype inheritance chain property list
       do props = props.concat(Object.getOwnPropertyNames(obj || instance))
       while (obj = Object.getPrototypeOf(obj || instance))
@@ -139,7 +141,7 @@ function Tag(impl, conf, innerHTML) {
         // allow mixins to override other properties/parent mixins
         if (key != 'init') {
           // check for getters/setters
-          var descriptor = Object.getOwnPropertyDescriptor(instance, key)
+          var descriptor = Object.getOwnPropertyDescriptor(instance, key) || Object.getOwnPropertyDescriptor(proto, key)
           var hasGetterSetter = descriptor && (descriptor.get || descriptor.set)
 
           // apply method only if it does not already exist on the instance

--- a/test/specs/mixin.js
+++ b/test/specs/mixin.js
@@ -117,6 +117,24 @@ describe('Mixin', function() {
     tag.unmount()
   })
 
+  it('Will register a mixin whose prototype has getter/setter functions', function() {
+    injectHTML('<my-mixin></my-mixin>')
+    riot.tag('my-mixin', '<span>some tag</span>')
+
+    var tag = riot.mount('my-mixin')[0]
+
+    var mixinInstance = Object.create(getterSetterMixin)
+
+    tag.mixin(mixinInstance)
+
+    tag.value = true
+
+    expect(true).to.be(tag._value)
+    expect(true).to.be(tag.value)
+
+    tag.unmount()
+  })
+
   it('Will register a global mixin without name and mount a tag with global mixed-in attributes and methods', function() {
     riot.mixin(globalMixin)
     injectHTML('<my-mixin></my-mixin>')


### PR DESCRIPTION
In reference to #1885 and #1888, @5angel's patch is perfect for object instances where the getter and setter descriptors are defined directly on the instance.

We have a project where the source is written in es2015 and transpiled by Babel into es5.
We have mixin classes which have getters and setters, and Babel is defining them automatically on the class prototype ([example](http://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=es2015&code=class%20MyMixin%20%7B%0A%20%20get%20value()%20%7B%0A%20%20%20%20return%20this._value%3B%0A%20%20%7D%0A%20%20%0A%20%20set%20value(v)%20%7B%0A%20%20%20%20this._value%20%3D%20v%3B%0A%20%20%7D%0A%7D%0A%0Alet%20instance%20%3D%20new%20MyMixin()%3B)).

This PR creates support for this and includes the relevant test that now passes.