### PR TITLE
Originscope for Yield Tag

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -204,7 +204,7 @@ riot.update = function() {
 /**
  * Create the riot-yield tag
  */
-riot.tag2('riot-yield', '', '', '', function(){});
+riot.tag2('riot-yield', '', '', '', function() {})
 
 /**
  * Export the Virtual DOM

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -202,6 +202,11 @@ riot.update = function() {
 }
 
 /**
+ * Create the riot-yield tag
+ */
+riot.tag2('riot-yield', '', '', '', function(){});
+
+/**
  * Export the Virtual DOM
  */
 riot.vdom = __virtualDom

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -10,7 +10,9 @@ var mkdom = (function _mkdom() {
     reHasYield  = /<yield\b/i,
     reYieldAll  = /<yield\s*(?:\/>|>([\S\s]*?)<\/yield\s*>|>)/ig,
     reYieldSrc  = /<yield\s+to=['"]([^'">]*)['"]\s*>([\S\s]*?)<\/yield\s*>/ig,
-    reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig
+    reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
+    reYieldTagAll  = /(<yield[^>]*originscope[^>]*(?:\/>|>))([\S\s]*?)(<\/yield\s*>)/ig,
+    reYieldTagDest = /(<yield[^>]+from=['"]?([-\w]+)['"]?[^>]*(?:\/>|>))([\S\s]*?)(<\/yield\s*>)/ig
   var
     rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' },
     tblTags = IE_VERSION && IE_VERSION < 10
@@ -93,6 +95,12 @@ var mkdom = (function _mkdom() {
       })
       .replace(reYieldAll, function (_, def) {        // yield without any "from"
         return html || def || ''
+      })
+      .replace(reYieldTagDest, function (_, openTag, ref, def) {
+        return openTag.replace(/<yield/, '<riot-yield') + (src[ref] || def || '') + '</riot-yield>'
+      })
+      .replace(reYieldTagAll, function (_, openTag, def) {
+        return openTag.replace(/<yield/, '<riot-yield') + (html || def || '') + '</riot-yield>'
       })
   }
 

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -113,7 +113,10 @@ function Tag(impl, conf, innerHTML) {
     // inherit properties from the tag which holds the original yield html
     if (tagName === 'riot-yield' && this.opts.originscope) {
       var origin = findOrigin(self)
-      inheritFrom(origin)
+      // origin can be undefined when the top-level tag is a container
+      // in this case there are no properties to inherit
+      if (origin != undefined)
+        inheritFrom(origin)
     }
     // normalize the tag properties in case an item object was initially passed
     if (data && isObject(item)) {
@@ -237,7 +240,10 @@ function Tag(impl, conf, innerHTML) {
     // parse the named nodes to connect origin and yield tag
     if (tagName === 'riot-yield' && this.opts.originscope) {
       var origin = findOrigin(self)
-      parseNamedElements(this.root, origin, null, true)
+      // origin can be undefined when the top-level tag is a container
+      // in this case there are no named nodes to connect
+      if (origin != undefined)
+        parseNamedElements(this.root, origin, null, true)
     }
 
     // if it's not a child tag we can trigger its mount event

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -41,7 +41,7 @@ function Tag(impl, conf, innerHTML) {
   })
 
   // replace the empty default template of the riot-yield tag with the actual html
-  if(impl.name == 'riot-yield')
+  if (impl.name == 'riot-yield')
     impl.tmpl = innerHTML
 
   dom = mkdom(impl.tmpl, innerHTML)
@@ -81,12 +81,12 @@ function Tag(impl, conf, innerHTML) {
       }
     })
   }
-  
+
   function findOrigin(self) {
     // find the origin distance
     var p = self.parent
     //check if the parent is a riot-yield tag itself
-    while(p.root.tagName.toLowerCase() == 'riot-yield'){
+    while (p.root.tagName.toLowerCase() == 'riot-yield') {
       // we have to take the grandparent because every
       // riot-yield tag adds another layer
       p = p.parent.parent
@@ -111,7 +111,7 @@ function Tag(impl, conf, innerHTML) {
       inheritFrom(self.parent)
     }
     // inherit properties from the tag which holds the original yield html
-    if(tagName === 'riot-yield' && this.opts.originscope) {
+    if (tagName === 'riot-yield' && this.opts.originscope) {
       var origin = findOrigin(self)
       inheritFrom(origin)
     }
@@ -235,7 +235,7 @@ function Tag(impl, conf, innerHTML) {
       parseNamedElements(self.root, self.parent, null, true)
 
     // parse the named nodes to connect origin and yield tag
-    if(tagName === 'riot-yield' && this.opts.originscope) {
+    if (tagName === 'riot-yield' && this.opts.originscope) {
       var origin = findOrigin(self)
       parseNamedElements(this.root, origin, null, true)
     }

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -77,6 +77,19 @@ function Tag(impl, conf, innerHTML) {
       }
     })
   }
+  
+  function findOrigin(self) {
+    // find the origin distance
+    var p = self.parent
+    //check if the parent is a riot-yield tag itself
+    while(p.root.tagName.toLowerCase() == 'riot-yield'){
+      // we have to take the grandparent because every
+      // riot-yield tag adds another layer
+      p = p.parent.parent
+    }
+    //the parent of the last riot-yield tag should be the origin
+    return p.parent
+  }
 
   /**
    * Update the tag expressions and options
@@ -92,6 +105,11 @@ function Tag(impl, conf, innerHTML) {
     // inherit properties from the parent in loop
     if (isLoop) {
       inheritFrom(self.parent)
+    }
+    // inherit properties from the tag which holds the original yield html
+    if(tagName === 'riot-yield' && this.opts.originscope) {
+      var origin = findOrigin(self)
+      inheritFrom(origin)
     }
     // normalize the tag properties in case an item object was initially passed
     if (data && isObject(item)) {
@@ -211,6 +229,12 @@ function Tag(impl, conf, innerHTML) {
     // adding them to the parent as well
     if (isLoop)
       parseNamedElements(self.root, self.parent, null, true)
+
+    // parse the named nodes to connect origin and yield tag
+    if(tagName === 'riot-yield' && this.opts.originscope) {
+      var origin = findOrigin(self)
+      parseNamedElements(this.root, origin, null, true)
+    }
 
     // if it's not a child tag we can trigger its mount event
     if (!self.parent || self.parent.isMounted) {

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -40,6 +40,10 @@ function Tag(impl, conf, innerHTML) {
     if (tmpl.hasExpr(val)) attr[el.name] = val
   })
 
+  // replace the empty default template of the riot-yield tag with the actual html
+  if(impl.name == 'riot-yield')
+    impl.tmpl = innerHTML
+
   dom = mkdom(impl.tmpl, innerHTML)
 
   // options


### PR DESCRIPTION
Hey guys,
after running into the yield scope trap last week (https://github.com/riot/riot/issues/1965), I tried to write a patch to solve the problem. It took me a few days to find out how riot works, but I think I found a solution which should not break anything existing.
1. Have you added test(s) for your patch? If not, why not?
   No, because I wanted to find out first, if you consider merging the feature at all (I do not know yet how to write test for riot). Meanwhile, I wrote a demo site to test the functionality.
2. Can you provide an example of your patch in use?
   http://plnkr.co/edit/YX8pV8h6ShwaCJGWvGR9?p=preview
   The difference in usage can be found in the following files:
   - container-test-block-unpatched-tag.html
   - container-test-block-patched-tag.html
3. Is this a breaking change?
   No, without the new originscope attribute, riot works as it did before.
#### Content

The problem at stake is that yield tags are currently evaluated in the child scope they are placed in. But since the evaluated expressions come from a different tag/component this is very unintuitive. Furthermore, it creates complicated, unmaintainable code.

To not break anything, the originscope attribute is introduced:

<yield originscope="true"/>

When this attribute is present, the yield tag will be replaced by a riot-yield tag which inherits all properties from the tag which holds the html, which is in turn the template for the riot-yield tag. This way the inheritance does not affect the tag which holds the yield tag. This does not only work for properties, but also for named tags.

So without the patch it is very hard to access named fields e.g. (container-test-block-unpatched-tag.html):

`self.tags['basic-container-double'].tags['basic-container'].tags['basic-container']['input-three'].value = self.num`

With the patch this becomes very simple (container-test-block-patched-tag.html):

`self['input-three'].value = self.num`

I think this simplifies the usage and improves the overall code-quality of the developed components.

For riot 3.0 I would suggest to replace the existing yield implementation with something which behaives more like the riot-yield tag.

Please take a look at the demo and tell me what you think :-)
