### PR TITLE
Better SSR support, closes #1998

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -12,9 +12,11 @@ riot.parsers = compiler.parsers
 // allow to require('some.tag')
 require.extensions['.tag'] = function(module, filename) {
   var src = riot.compile(require('fs').readFileSync(filename, 'utf8'))
+  var preTag = src.substring(0, src.indexOf('riot.tag'))
+  var tagDefinition = src.substring(src.indexOf('riot.tag'))
   module._compile(
-    'var riot = require(process.env.RIOT || "riot/riot.js");module.exports =' + src
-  , filename)
+    'var riot = require(process.env.RIOT || "riot/riot.js");' + preTag + ';module.exports =' + tagDefinition
+    , filename)
 }
 
 // simple-dom helper

--- a/test/importedtag/imported-tag.tag
+++ b/test/importedtag/imported-tag.tag
@@ -1,0 +1,3 @@
+<imported-tag>
+	<span>I am imported</span>
+</imported-tag>

--- a/test/specs/server/node.js
+++ b/test/specs/server/node.js
@@ -121,4 +121,9 @@ describe('Node/io.js', function() {
     expect($('textarea[name="txta2"]').val()).to.be('')
   })
 
+  it('render subsequent tags, when required from parent tag', function() {
+    var tag = riot.render('import-tag')
+    expect(tag).to.be('<import-tag><imported-tag><span>I am imported</span></imported-tag></import-tag>')
+  })
+
 })

--- a/test/tag/import-tag.tag
+++ b/test/tag/import-tag.tag
@@ -1,0 +1,5 @@
+var importedTag = require('../importedtag/imported-tag.tag');
+<import-tag>
+	<imported-tag>
+	</imported-tag>
+</import-tag>


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?
Yes *render subsequent tags, when required from parent tag*

2. Can you provide an example of your patch in use?
No, This affects server side rendering code.

3. Is this a breaking change?
No

#### Content
Today for server side rendering we do require tag files individually. BUT if the tag itself require some subsequent tags and try to import/require them at the top, riot's require definition starts throwing error, this will solve it

https://github.com/riot/riot/issues/1998

