### PR TITLE
Feature/deferred unmount

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -181,6 +181,7 @@ export default function _each(dom, parent, expr) {
       frag,
       placeholder
 
+    console.log(oldItems, items);
 
     root = ref.parentNode
 

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -1,4 +1,4 @@
-import { isArray } from './../common/util/check'
+import { isArray, isFunction } from './../common/util/check'
 import { remAttr, getAttr, getOuterHTML, createDOMPlaceholder, safeInsert, createFrag } from './../common/util/dom'
 import { defineProperty, each } from './../common/util/misc'
 import { tmpl } from 'riot-tmpl'
@@ -44,23 +44,22 @@ function mkitem(expr, key, val, base) {
 
 /**
  * Unmount the redundant tags
- * @param   { Array } items - array containing the current items to loop
+ * @param   { Array } toKeep - array containing the items we want to keep
  * @param   { Array } tags - array containing all the children tags
  * @param   { String } tagName - key used to identify the type of tag
  * @param   { Object } parent - parent tag to remove the child from
  */
-function unmountRedundant(items, tags, tagName, parent) {
-
-  var i = tags.length,
-    j = items.length,
-    t
-
-  while (i > j) {
-    t = tags[--i]
-    tags.splice(i, 1)
-    t.unmount()
-    arrayishRemove(parent.tags, tagName, t, true)
-  }
+function unmountRedundant(toKeep, tags, tagName, parent) {
+  // maintain order for beforeUnmount function
+  each(tags, function(tag, i) {
+    if (tag === undefined) return // fix for each function not reevaluating the length
+    if (!~toKeep.indexOf(tag)) {
+      var t = tags.splice(i, 1)[0]
+      t.unmount()
+      arrayishRemove(parent.tags, tagName, t, true)
+      return false
+    }
+  })
 }
 
 /**
@@ -161,7 +160,8 @@ export default function _each(dom, parent, expr) {
     hasKeys,
     isLoop = true,
     isAnonymous = !__TAG_IMPL[tagName],
-    isVirtual = dom.tagName === 'VIRTUAL'
+    isVirtual = dom.tagName === 'VIRTUAL',
+    toKeep = []
 
   // parse the each expression
   expr = tmpl.loopKeys(expr)
@@ -180,8 +180,6 @@ export default function _each(dom, parent, expr) {
       parentNode,
       frag,
       placeholder
-
-    console.log(oldItems, items);
 
     root = ref.parentNode
 
@@ -215,7 +213,7 @@ export default function _each(dom, parent, expr) {
       var
         _mustReorder = mustReorder && typeof item === T_OBJECT && !hasKeys,
         oldPos = oldItems.indexOf(item),
-        pos = ~oldPos && _mustReorder ? oldPos : i,
+        pos = ~oldPos && (_mustReorder || isFunction(tags[oldPos].beforeUnmount) ) ? oldPos : i,
         // does a tag exist in this position?
         tag = tags[pos]
 
@@ -271,16 +269,21 @@ export default function _each(dom, parent, expr) {
       tag._item = item
       // cache the real parent tag internally
       defineProperty(tag, '_parent', parent)
+
+      toKeep.push(tag)
     })
 
     // remove the redundant tags
-    unmountRedundant(items, tags, tagName, parent)
+    unmountRedundant(toKeep, tags, tagName, parent)
 
     // #1374 FireFox bug in <option selected={expression}>
     if (isOption && FIREFOX && !root.multiple) updateSelect(root)
 
     // clone the items array
     oldItems = items.slice()
+
+    // empty the items we are keeping
+    toKeep = []
 
     if (frag) {
       root.insertBefore(frag, ref)

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -44,22 +44,37 @@ function mkitem(expr, key, val, base) {
 
 /**
  * Unmount the redundant tags
- * @param   { Array } toKeep - array containing the items we want to keep
+ * @param   { Array } items - see maintainOrder param
  * @param   { Array } tags - array containing all the children tags
  * @param   { String } tagName - key used to identify the type of tag
  * @param   { Object } parent - parent tag to remove the child from
+ * @param   { Boolean } maintainOrder - if true, param items contains items
+ *     to keep. If false (default), param items contains current items to loop
+ *     through.
  */
-function unmountRedundant(toKeep, tags, tagName, parent) {
-  // maintain order for beforeUnmount function
-  each(tags, function(tag, i) {
-    if (tag === undefined) return // fix for each function not reevaluating the length
-    if (!~toKeep.indexOf(tag)) {
-      var t = tags.splice(i, 1)[0]
+function unmountRedundant(items, tags, tagName, parent, maintainOrder) {
+  if (maintainOrder) {
+    each(tags, function(tag, i) {
+      if (tag === undefined) return // fix for each function not reevaluating the length
+      if (!~items.indexOf(tag)) {
+        var t = tags.splice(i, 1)[0]
+        t.unmount()
+        arrayishRemove(parent.tags, tagName, t, true)
+        return false
+      }
+    })
+  } else {
+    var i = tags.length,
+      j = items.length,
+      t
+
+    while (i > j) {
+      t = tags[--i]
+      tags.splice(i, 1)
       t.unmount()
       arrayishRemove(parent.tags, tagName, t, true)
-      return false
     }
-  })
+  }
 }
 
 /**
@@ -270,11 +285,12 @@ export default function _each(dom, parent, expr) {
       // cache the real parent tag internally
       defineProperty(tag, '_parent', parent)
 
-      toKeep.push(tag)
+      if (isFunction(tag.beforeUnmount))
+        toKeep.push(tag)
     })
 
     // remove the redundant tags
-    unmountRedundant(toKeep, tags, tagName, parent)
+    unmountRedundant(toKeep.length ? toKeep : items, tags, tagName, parent, toKeep.length)
 
     // #1374 FireFox bug in <option selected={expression}>
     if (isOption && FIREFOX && !root.multiple) updateSelect(root)

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -258,50 +258,61 @@ export default function Tag(impl, conf, innerHTML) {
    * @param { Boolean } mustKeepRoot - if it's true the root node will not be removed
    */
   defineProperty(this, 'unmount', function tagUnmount(mustKeepRoot) {
-    var el = this.root,
-      p = el.parentNode,
-      ptag,
-      tagIndex = __VIRTUAL_DOM.indexOf(this)
 
     this.trigger('before-unmount')
 
-    // remove this tag instance from the global virtualDom variable
-    if (~tagIndex)
-      __VIRTUAL_DOM.splice(tagIndex, 1)
+    var unmount = function(mustKeepRoot){
 
-    if (p) {
+      var el = this.root,
+        p = el.parentNode,
+        ptag,
+        tagIndex = __VIRTUAL_DOM.indexOf(this)
 
-      if (parent) {
-        ptag = getImmediateCustomParentTag(parent)
-        arrayishRemove(ptag.tags, tagName, this)
+      // remove this tag instance from the global virtualDom variable
+      if (~tagIndex)
+        __VIRTUAL_DOM.splice(tagIndex, 1)
+
+      if (p) {
+
+        if (parent) {
+          ptag = getImmediateCustomParentTag(parent)
+          arrayishRemove(ptag.tags, tagName, this)
+        }
+
+        else
+          while (el.firstChild) el.removeChild(el.firstChild)
+
+        if (!mustKeepRoot)
+          p.removeChild(el)
+        else
+          // the riot-tag and the data-is attributes aren't needed anymore, remove them
+          remAttr(p, RIOT_TAG_IS)
+
       }
 
-      else
-        while (el.firstChild) el.removeChild(el.firstChild)
+      if (this._internal.virts) {
+        each(this._internal.virts, (v) => {
+          if (v.parentNode) v.parentNode.removeChild(v)
+        })
+      }
 
-      if (!mustKeepRoot)
-        p.removeChild(el)
-      else
-        // the riot-tag and the data-is attributes aren't needed anymore, remove them
-        remAttr(p, RIOT_TAG_IS)
+      // allow expressions to unmount themselves
+      unmountAll(expressions)
+      each(instAttrs, a => a.expr && a.expr.unmount && a.expr.unmount())
 
+      this.trigger('unmount')
+      this.off('*')
+      this.isMounted = false
+
+      delete this.root._tag
+
+    }.bind(this, mustKeepRoot);
+
+    if(isFunction(this.beforeUnmount)){
+      this.beforeUnmount.call(this, unmount);
+    }else{
+      unmount();
     }
-
-    if (this._internal.virts) {
-      each(this._internal.virts, (v) => {
-        if (v.parentNode) v.parentNode.removeChild(v)
-      })
-    }
-
-    // allow expressions to unmount themselves
-    unmountAll(expressions)
-    each(instAttrs, a => a.expr && a.expr.unmount && a.expr.unmount())
-
-    this.trigger('unmount')
-    this.off('*')
-    this.isMounted = false
-
-    delete this.root._tag
 
   })
 }

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -261,8 +261,7 @@ export default function Tag(impl, conf, innerHTML) {
 
     this.trigger('before-unmount')
 
-    var unmount = function(mustKeepRoot){
-
+    var unmount = function(mustKeepRoot) {
       var el = this.root,
         p = el.parentNode,
         ptag,
@@ -306,12 +305,12 @@ export default function Tag(impl, conf, innerHTML) {
 
       delete this.root._tag
 
-    }.bind(this, mustKeepRoot);
+    }.bind(this, mustKeepRoot)
 
-    if(isFunction(this.beforeUnmount)){
-      this.beforeUnmount.call(this, unmount);
-    }else{
-      unmount();
+    if (isFunction(this.beforeUnmount)) {
+      this.beforeUnmount.call(this, unmount)
+    } else {
+      unmount()
     }
 
   })

--- a/test/specs/browser/core.spec.js
+++ b/test/specs/browser/core.spec.js
@@ -19,6 +19,7 @@ import '../../tag/preserve-attr.tag'
 import '../../tag/svg-attr.tag'
 import '../../tag/named-child.tag'
 import '../../tag/deferred-mount.tag'
+import '../../tag/deferred-unmount.tag'
 import '../../tag/prevent-update.tag'
 import '../../tag/expression-eval-count.tag'
 import '../../tag/multi-named.tag'
@@ -524,6 +525,29 @@ describe('Riot core', function() {
     expect(mountingOrder.join()).to.be.equal(correctMountingOrder.join())
 
     tag.unmount()
+  })
+
+  it('defer unmounting of children', function(done) {
+
+    injectHTML('<deferred-unmount></deferred-unmount>')
+
+    var tag = riot.mount('deferred-unmount')[0]
+    expect(tag.beforeUnmountCalled).to.be.equal(false)
+    expect(tag.isMounted).to.be.equal(true)
+    tag.unmount()
+
+    // should still be mounted
+    setTimeout(function() {
+      expect(tag.beforeUnmountCalled).to.be.equal(true)
+      expect(tag.isMounted).to.be.equal(true)
+    }, 1)
+
+    // should be unmounted
+    setTimeout(function() {
+      expect(tag.beforeUnmountCalled).to.be.equal(true)
+      expect(tag.isMounted).to.be.equal(false)
+      done()
+    }, 20)
   })
 
 

--- a/test/tag/deferred-unmount.tag
+++ b/test/tag/deferred-unmount.tag
@@ -1,0 +1,11 @@
+<deferred-unmount>
+  <p>Defer me</p>
+
+  this.beforeUnmountCalled = false;
+  this.beforeUnmount = function(cb){
+    this.beforeUnmountCalled = true;
+    setTimeout(function(){
+      cb();
+    }.bind(this), 10);
+  }
+</deferred-unmount>


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

This was branched off the 'next' branch so it won't auto-merge into the dev branch.

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

Yes. core-spec.js -> `defer unmounting of children` using `deferred-unmount` tag

2. Can you provide an example of your patch in use?

Here is a crude example
  - [Demo](http://plnkr.co/edit/OKxtoc4fWqy0Xu4BtFhO?p=preview) on plnkr (preferred)


3. Is this a breaking change?

  No, ~~~but there is a performance hit. Specifically in /Users/senica/projects/riot/lib/browser/tag/each.js in the unmountRedundant function. If this change were to get merged in, it might be prudent to keep the original code and add this as an option by passing in toKeep and items into the unmountRedundant function and figure out how to handle the unmount from there.~~~ I added the original code back in and just made an exception for the beforeUnmount function

#### Content

Provide a short description about what you have changed:

I'd love to get feedback on this. One of my qualms with front-end libraries (angular, react, riot, etc) is the flexibility it takes away from the user experience when it comes to user notifications of changing data. More specifically when data goes away. Riot has a wonderful feature called `each` that can take an array and magically display elements based on that data. When that data changes (an item is removed) the dom abruptly changes to reflect that change. It leaves the user having to process for a second what just happened.

When items are mounted, we do not have this issue. We can start the element as some predefined state and use the `mount` event to animate and alter the dom to show the user that something is happening or has happened to the data.

Currently, we do not have a way to do this with unmounting items (unless great care is taken). If the data that is bound, or creates the dom element is removed, the item just disappears. There is a process that can be taken where the data handler over-reaches into the dom component and animates before actually removing the data that is bound to the dom element, but with large apps, this becomes quite cumbersome.

This patch, gives a new function to the tag instance called `beforeUnmount`. The reason I did a new function instead of modifying the event handler is because, as I understood it, with 3.0.x you can use any event handler you wish...? It made it much easier to add a new function to the tag. If this function is defined on a tag, when the tag is unmounted (either by calling unmount directly, or by modifying the underlying data), `beforeUnmount` is passed a callback and *MUST* call the callback when the tag is actually ready to be unmounted.

Thoughts?
