### PR TITLE
fix redraw when loop context-type swap

### DIFF
--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -183,6 +183,8 @@ export default function _each(dom, parent, expr) {
         Object.keys(items).map(function (key) {
           return mkitem(expr, items[key], key)
         }) : []
+    } else {
+      hasKeys = false
     }
 
     if (ifExpr) {

--- a/test/specs/browser/each.spec.js
+++ b/test/specs/browser/each.spec.js
@@ -27,6 +27,7 @@ import '../../tag/loop-cols.tag'
 import '../../tag/loop-child.tag'
 import '../../tag/loop-combo.tag'
 import '../../tag/loop-reorder.tag'
+import '../../tag/loop-swap-type.tag'
 import '../../tag/loop-manip.tag'
 import '../../tag/loop-object.tag'
 import '../../tag/loop-tag-instances.tag'
@@ -1258,6 +1259,24 @@ describe('Riot each', function() {
     expect(els2[1].innerHTML).to.be.equal('White cold drink')
     tag2.unmount()
 
+  })
+
+  it('redraws correctly after items type is swapped from array to object and back', function () {
+    injectHTML('<loop-swap-type></loop-swap-type>')
+    var tag = riot.mount('loop-swap-type')[0]
+
+    tag.swap()
+    tag.update()
+    var els = tag.root.children
+    expect(els[0].innerHTML).to.be.equal('3')
+    expect(els[1].innerHTML).to.be.equal('4')
+
+    tag.swap()
+    tag.update()
+    els = tag.root.children
+    expect(els[0].innerHTML).to.be.equal('1')
+    expect(els[1].innerHTML).to.be.equal('2')
+    tag.unmount()
   })
 
   it('still loops with reserved property names #1526', function() {

--- a/test/tag/loop-swap-type.tag
+++ b/test/tag/loop-swap-type.tag
@@ -1,0 +1,22 @@
+<loop-swap-type>
+  <div each="{ item in current }">{ item.num }</div>
+
+  var arr = [
+    { num: 1 },
+    { num: 2 }
+  ]
+
+  var obj = {
+    0: { num: 3 },
+    1: { num: 4 }
+  }
+
+  this.current = arr
+  this.swap = function () {
+    if (Array.isArray(this.current)) {
+      this.current = obj
+    } else {
+      this.current = arr
+    }
+  }
+</loop-swap-type>


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__
This is against `next` because of changes in #1420 

#### Code

1. Have you added test(s) for your patch? If not, why not?
Yes.

2. Can you provide an example of your patch in use?
This is almost exactly the same as the reported issue's fiddle: [example](http://plnkr.co/edit/5VRjdKGOSywDQ31WCOyp?p=preview) 

3. Is this a breaking change?
No.

#### Content

Provide a short description about what you have changed:

Addresses the bug reported in #2027. At loop update, `hasKeys` was only being set if the context was not an array. If you swapped the context like arr->obj->arr then `hasKeys` would still be true, leading to the rest of the update not being performed correctly and the DOM remaining unchanged. 