### PR TITLE
Fix #2084: export all as default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,3 @@
+import * as riot from './riot'
+export default riot // export all as default, too. #2084
+export * from './riot'

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "rollup-plugin-buble": "^0.14.0",
     "rollup-plugin-commonjs": "^5.0.5",
     "rollup-plugin-node-resolve": "^2.0.0",
-    "rollup-plugin-riot": "^1.0.0-alpha.1",
+    "rollup-plugin-riot": "^1.0.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
     "uglify-js": "latest"
@@ -95,7 +95,7 @@
     "riot": "node_modules/riot-cli/lib/index.js"
   },
   "main": "lib/server/index.js",
-  "jsnext:main": "lib/riot.js",
+  "jsnext:main": "lib/index.js",
   "browser": "riot.js",
   "spm": {
     "main": "riot.js",


### PR DESCRIPTION
#### 1. Have you added test(s) for your patch? If not, why not?

I could add a test later. Or we could merge this soon as a hot fix for ES6 users, I think. This change has no effect for existing codes.

#### Content

See #2084

