### PR TITLE
Add hot reloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test-karma:
 	@ TEST_FOLDER=compiler $(KARMA) start test/karma.conf.js
 	# Test only riot.js and generate the coverage
 	@ TEST_FOLDER=browser $(KARMA) start test/karma.conf.js
+	@ TEST_FOLDER=hot-reload $(KARMA) start test/karma.conf.js
 
 test-coveralls:
 	@ RIOT_COV=1 cat ./coverage/report-lcov/lcov.info | $(COVERALLS)
@@ -66,6 +67,7 @@ raw:
 	# Default builds UMD
 	@ $(ROLLUP) lib/riot.js --config $(CONFIG)rollup.config.js > $(DIST)riot.js
 	@ $(ROLLUP) lib/riot+compiler.js --config $(CONFIG)rollup.config.js > $(DIST)riot+compiler.js
+	@ $(ROLLUP) lib/riot-hot-reload.js --config $(CONFIG)rollup.config.js > $(DIST)riot-hot-reload.js
 	# Chrome Security Policy build
 	@ $(ROLLUP) lib/riot.js --config $(CONFIG)rollup.config.csp.js > $(DIST)riot.csp.js
 

--- a/lib/riot-hot-reload.js
+++ b/lib/riot-hot-reload.js
@@ -1,0 +1,43 @@
+var nonState = 'isMounted _internal parent opts _parent refs tags'.split(' ')
+
+var reload = function(name) {
+  riot.util.styleManager.inject()
+
+  var elems = document.querySelectorAll(name + ', [data-is=' + name + ']')
+  for(var i=0; i < elems.length; i++) {
+    var el = elems[i], oldTag = el._tag, v
+    reload.trigger('before-unmount', oldTag)
+    oldTag.unmount(true) // detach the old tag
+
+    // reset the innerHTML and attributes to how they were before mount
+    el.innerHTML = oldTag._internal.innerHTML;
+    (oldTag._internal.origAttrs || []).map(function(attr) {
+      el.setAttribute(attr.name, attr.value)
+    })
+
+    // copy options for creating the new tag
+    var newOpts = {}
+    for(key in oldTag.opts) {
+      newOpts[key] = oldTag.opts[key]
+    }
+    newOpts.parent = oldTag.parent
+
+    // create the new tag
+    reload.trigger('before-mount', newOpts, oldTag)
+    var newTag = riot.mount(el, newOpts)[0]
+
+    // copy state from the old to new tag
+    for(var key in oldTag) {
+      v = oldTag[key]
+      if (~nonState.indexOf(key)) continue
+      if (v instanceof HTMLElement) continue // ignore refs
+      if (typeof(v) === 'function') continue // ignore the tag's functions
+      newTag[key] = v
+    }
+    newTag.update()
+    reload.trigger('after-mount', newTag, oldTag)
+  }
+}
+
+riot.observable(reload)
+riot.util.hotReloader = reload

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -2,6 +2,12 @@ const expect = chai.expect
 
 export const IE_VERSION = (window && window.document || {}).documentMode | 0
 
+export function makeTag(name, tmpl, css, attrs, fn) {
+  riot.tag2(name, tmpl, css, attrs, fn)
+  injectHTML(`<${name} />`)
+  return riot.mount(name)[0]
+}
+
 // this export function is needed to run the tests also on ie8
 // ie8 returns some weird strings when we try to get the innerHTML of a tag
 export function normalizeHTML(html) {
@@ -38,6 +44,15 @@ export function getRiotStyles(riot) {
   // util.injectStyle must add <style> in head, not in body -- corrected
   var stag = riot.util.styleNode || document.querySelector('style')
   return normalizeHTML(stag.styleSheet ? stag.styleSheet.cssText : stag.innerHTML)
+}
+
+export function removeAllTags() {
+  var curr = document.body.children[0]
+  while(curr) {
+    var nxt = curr.nextSibling
+    if(curr._tag) curr._tag.unmount()
+    curr = nxt
+  }
 }
 
 /**

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,6 +5,7 @@ const saucelabsBrowsers = require('./saucelabs-browsers').browsers,
   // split the riot+compiler tests from the normal riot core tests
   testFiles = `./specs/${process.env.TEST_FOLDER}/**/*.spec.js`,
   needsCompiler = process.env.TEST_FOLDER === 'compiler',
+  needsHotReload = process.env.TEST_FOLDER === 'hot-reload',
   preprocessors = {}
 
 var browsers = ['PhantomJS'] // this is not a constant
@@ -38,8 +39,9 @@ module.exports = function(conf) {
         included: false
       },
       needsCompiler ? RIOT_WITH_COMPILER_PATH : RIOT_PATH,
+      needsHotReload ? '../dist/riot/riot-hot-reload.js' : null,
       testFiles
-    ],
+    ].filter(s => !!s),
     // logLevel: conf.LOG_DEBUG,
     concurrency: 2,
     sauceLabs: {

--- a/test/specs/hot-reload/index.spec.js
+++ b/test/specs/hot-reload/index.spec.js
@@ -1,0 +1,35 @@
+import {
+  makeTag,
+  expectHTML,
+  injectHTML,
+  removeAllTags
+} from '../../helpers/index'
+
+// const expect = chai.expect
+
+describe('hot reloading', () => {
+  afterEach(removeAllTags)
+
+  it('replaces tags html', () => {
+    var t = makeTag('test', '<p>First</p>')
+    expectHTML(t).to.be.equal('<p>First</p>')
+
+    riot.tag2('test', '<p>Second</p>')
+    expectHTML(t).to.be.equal('<p>Second</p>')
+  })
+
+  it('preseves state', () => {
+    var t = makeTag('test', '{val}', '', {}, function() { this.val = 1})
+    expectHTML(t).to.be.equal('1')
+  })
+
+  it('supports yield', () => {
+    riot.tag2('test', '<p><yield/></p>')
+    injectHTML('<test>Hello</test>')
+    var t = riot.mount('test')[0]
+    expectHTML(t).to.be.equal('<p>Hello</p>')
+
+    riot.tag2('test', '<i><yield/></i>')
+    expectHTML(t).to.be.equal('<i>Hello</i>')
+  })
+})


### PR DESCRIPTION
When a tag gets re-defined (eg `riot.tag2`), the hot reloader looks through DOM, finds every instance of that tag, and replaces it.

Replacing tags goes through the full lifecycle: the old instance is un-mounted, and the new instance calls the constructor and mount callbacks. Hot reloading will preserve the tag's original attributes, yields, and state.

If you need to do anything custom before or after the reload, you can use the callbacks:
```
riot.util.hotReloader.on('before-unmount', () => /* some cleanup */)
riot.util.hotReloader.on('after-mount', () => /* some setup */)
```
This is useful when you have 3rd party libraries that do DOM manipulation.

Here's a gist on using it with Gulp:
https://gist.github.com/rogueg/4d48d32bd678aba784455ef8685c4494