### PR TITLE
Removes SPM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,13 +96,5 @@
   },
   "main": "lib/server/index.js",
   "jsnext:main": "lib/index.js",
-  "browser": "riot.js",
-  "spm": {
-    "main": "riot.js",
-    "ignore": [
-      "test",
-      "lib",
-      "make"
-    ]
-  }
+  "browser": "riot.js"
 }


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?
No change on code.

2. Can you provide an example of your patch in use?
N/A

3. Is this a breaking change?
No.
(Strictly speaking, could be yes. But `spm` seems died more than one year ago. Actually, no effect)

SPM support were introduced at this commit 6ecb24a05ce592677f39aa1380302d49f0537c8e, but SPM itself has [discontinued 1 year ago](https://github.com/spmjs/spm/issues/1416).

- http://spmjs.io (couldn't reach)
- https://github.com/spmjs/spm

> spm 从 3.9 开始将不再管理组件的生命周期, 即不再有 spmjs.io. 所以相应的逻辑全部去除. 请使用 npm 来管理组件.

I can't read Chinese, sorry... here's the translation by Google Translate:

> Spm Starting from 3.9 will no longer manage the lifecycle of the components, that is, spmjs.io is no longer available. So the corresponding logic is completely removed. Use npm to manage the components.

R.I.P.