### PR TITLE
Replace deprecated function with the Event constructor

### DIFF
--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -94,8 +94,7 @@ export function setCarrotPos(dom, pos) {
   range.select()
 }
 
-export function fireEvent(el, name) {
-  var e = document.createEvent('HTMLEvents')
-  e.initEvent(name, false, true)
+export function fireEvent(el, name, bubbles = false, cancelable = true) {
+  var e = new Event(name, {'bubbles': bubbles, 'cancelable': cancelable})
   el.dispatchEvent(e)
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -94,7 +94,7 @@ export function setCarrotPos(dom, pos) {
   range.select()
 }
 
-export function fireEvent(el, name, bubbles = false, cancelable = true) {
-  var e = new Event(name, {'bubbles': bubbles, 'cancelable': cancelable})
+export function fireEvent(el, name) {
+  var e = new Event(name, {'bubbles': false, 'cancelable': true})
   el.dispatchEvent(e)
 }

--- a/test/performance/todo-test.js
+++ b/test/performance/todo-test.js
@@ -1,10 +1,8 @@
 
 var i = 0,
   input = document.querySelector('form input'),
-  submitEvent = document.createEvent('Event'),
+  submitEvent = new Event('submit', {'bubbles': true, 'cancelable': true}),
   start = Date.now()
-
-submitEvent.initEvent('submit', true, true)
 
 for (; i < 50; i++) {
   var inputEvent = document.createEvent('Event')


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?
Minor changes in existing specs


2. Can you provide an example of your patch in use?
N/A

3. Is this a breaking change?
Nope

#### Content
Aloha humans (and bots)

It seems that `Event.initEvent()` has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent). Replaced it with the recommended way.