### PR TITLE
Fix: double backslashes on riot path when doing server-side rendering

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -3,7 +3,7 @@
 const
   path = require('path'),
   fs = require('fs'),
-  riotPath = process.env.RIOT || path.resolve(__dirname, '../../riot'),
+  riotPath = process.env.RIOT || path.resolve(__dirname, '../../riot').replace(/\\/g, '\\\\'),
   riot = require(riotPath),
   // simple-dom helper
   sdom = require('./sdom'),


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?
This introduces changes to lib/server/index.js, not to riot core itself.

2. Can you provide an example of your patch in use?
It does not modify existing usage in any way.

  Post the link using one of our bug report templates:
  - [Bug Report Template](http://riotjs.com/examples/plunker/?app=bug-reporter) on plnkr (preferred)
  - [Bug Report Template](http://jsfiddle.net/cognitom/wf7bkvur/) on jsFiddle


3. Is this a breaking change?
No

#### Content

Provide a short description about what you have changed:

Server-side rendering injects a require to riot path in tags ([here](https://github.com/riot/riot/blob/master/lib/server/index.js#L28)).

The use of `path.resolve()` (line 6 of the same file)  to get the path to riot uses single backslashes as path separator on Windows, which breaks when trying to interprete the require to riot.

This fix doubles all backslashes in the path returned by path.resolve(), to ensure a usable path on Windows systems. There is no impact on other OS.