### PR TITLE
Closes #2132: data-src attr for script tag

### DIFF
--- a/lib/browser/compiler/index.js
+++ b/lib/browser/compiler/index.js
@@ -65,7 +65,7 @@ function compileScripts (fn, xopt) {
       var
         script = scripts[i],
         opts = extend({template: getAttr(script, 'template')}, xopt),
-        url = getAttr(script, 'src')
+        url = getAttr(script, 'src') || getAttr(script, 'data-src')
 
       url ? GET(url, compileTag, opts) : compileTag(script.innerHTML, opts)
     }


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?
No. There's no good way to add a test for it, in our current setup.
(We need to introduce `webdriver.io` or `nightmare` or something)

2. Can you provide an example of your patch in use?

This allows users to use `data-src` attr instead of `src`:

```html
<script data-src="timer.tag" type="riot/tag"></script>
```

3. Is this a breaking change?

No.

See #2132.