### PR TITLE
show= directive is broken in riot3 with tag instance getter / setter directives

### DIFF
--- a/lib/browser/common/util/misc.js
+++ b/lib/browser/common/util/misc.js
@@ -79,14 +79,10 @@ export function extend(src) {
   var obj, args = arguments
   for (var i = 1; i < args.length; ++i) {
     if (obj = args[i]) {
-      if (typeof obj === 'object') {
-        var props = Object.getOwnPropertyNames(obj)
-
-        each(props, function (key) {
-          // check if this property of the source object could be overridden
-          if (isWritable(src, key))
-            src[key] = obj[key]
-        })
+      for (var key in obj) {
+        // check if this property of the source object could be overridden
+        if (isWritable(src, key))
+          src[key] = obj[key]
       }
     }
   }

--- a/lib/browser/common/util/misc.js
+++ b/lib/browser/common/util/misc.js
@@ -79,10 +79,14 @@ export function extend(src) {
   var obj, args = arguments
   for (var i = 1; i < args.length; ++i) {
     if (obj = args[i]) {
-      for (var key in obj) {
-        // check if this property of the source object could be overridden
-        if (isWritable(src, key))
-          src[key] = obj[key]
+      if (typeof obj === 'object') {
+        var props = Object.getOwnPropertyNames(obj)
+
+        each(props, function (key) {
+          // check if this property of the source object could be overridden
+          if (isWritable(src, key))
+            src[key] = obj[key]
+        })
       }
     }
   }

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -1,5 +1,5 @@
 import { tmpl } from 'riot-tmpl'
-import { startsWith, each, extend } from './../common/util/misc'
+import { startsWith, each } from './../common/util/misc'
 import { isFunction, isUndefined } from './../common/util/check'
 import { remAttr, setAttr } from './../common/util/dom'
 import setEventHandler from './setEventHandler'
@@ -70,8 +70,7 @@ export function updateExpression(expr) {
   var dom = expr.dom,
     attrName = expr.attr,
     isToggle = /^(show|hide)$/.test(attrName),
-    // the value for the toggle must consider also the parent tag
-    value = isToggle ? tmpl(expr.expr, extend({}, this, this.parent)) : tmpl(expr.expr, this),
+    value = tmpl(expr.expr, this),
     isValueAttr = attrName === 'riot-value',
     isVirtual = expr.root && expr.root.tagName === 'VIRTUAL',
     parent = dom && (expr.parent || dom.parentNode),

--- a/test/specs/browser/show.spec.js
+++ b/test/specs/browser/show.spec.js
@@ -1,7 +1,6 @@
 
 import {
   injectHTML,
-  $$,
   $
 } from '../../helpers/index'
 
@@ -20,19 +19,6 @@ Object.defineProperty(getterSetterMixin, 'isVisible', {
   set: function(val) {
     this._isVisible = val
   }
-})
-
-it('the show directive evaluates also the parent properties', function() {
-  injectHTML('<show-bug-2125></show-bug-2125>')
-  var tag = riot.mount('show-bug-2125')[0],
-    children = $$('show-bug-2125-child', tag.root)
-
-  expect(tag.tags['show-bug-2125-child']).to.have.length(2)
-  expect(children).to.have.length(2)
-  expect(children[0].style.display).to.be.not.equal('none')
-  expect(children[1].style.display).to.be.equal('none')
-
-  tag.unmount()
 })
 
 it('the show directive works as expected', function() {

--- a/test/specs/browser/show.spec.js
+++ b/test/specs/browser/show.spec.js
@@ -9,6 +9,19 @@ import '../../tag/show-bug-2125.tag'
 
 const expect = chai.expect
 
+const getterSetterMixin = {
+  _isVisible: false
+}
+
+Object.defineProperty(getterSetterMixin, 'isVisible', {
+  get: function() {
+    return this._isVisible
+  },
+  set: function(val) {
+    this._isVisible = val
+  }
+})
+
 it('the show directive evaluates also the parent properties', function() {
   injectHTML('<show-bug-2125></show-bug-2125>')
   var tag = riot.mount('show-bug-2125')[0],
@@ -27,6 +40,27 @@ it('the show directive works as expected', function() {
   injectHTML('<riot-show-tmp></riot-show-tmp>')
   var tag = riot.mount('riot-show-tmp')[0],
     p = $('p', tag.root)
+
+  expect(p.style.display).to.be.equal('none')
+  tag.isVisible = true
+  tag.update()
+  expect(p.style.display).to.be.not.equal('none')
+  tag.isVisible = false
+  tag.update()
+  expect(p.style.display).to.be.equal('none')
+
+  // teardown
+  riot.unregister('riot-show-tmp')
+  tag.unmount()
+})
+
+it('the show directive works as expected with mixins using getter / setter descriptors', function() {
+  riot.tag('riot-show-tmp', '<p show="{ isVisible }">foo</p>')
+  injectHTML('<riot-show-tmp></riot-show-tmp>')
+  var tag = riot.mount('riot-show-tmp')[0],
+    p = $('p', tag.root)
+
+  tag.mixin(getterSetterMixin)
 
   expect(p.style.display).to.be.equal('none')
   tag.isVisible = true


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

  Yes

2. Can you provide an example of your patch in use?

  - [Bug Report Template](http://plnkr.co/edit/tzKzuwOUIfxosFtMx8vM?p=preview)

3. Is this a breaking change?

  Should not be

#### Content

In riot3 the tag expression binding to the instance with mixin/s now occurs later than with riot2 (at render time).

The extend() function copies only a source tag instance's enumerable properties and methods onto the destination object, not "own properties" of the instance prototype or es6 class.

By iterating own properties on the instance using `Object.getOwnPropertyNames(obj)` these descriptors are now made available on the tag instance and accessible to the `show` directive.

Further, build testing reveals occasions where non-objects (strings) are attempted to be extended which is unnecessary. This is now catered for here by checking that the source object type is `object`.

Its questionable whether this kind of enumeration would impact performance on rendering but benchmark tests show otherwise.


