### PR TITLE
fix nested slot yield.

### DIFF
--- a/lib/browser/common/util/tags.js
+++ b/lib/browser/common/util/tags.js
@@ -64,12 +64,12 @@ export function moveChildTag(tagName, newPos) {
  * Create a new child tag including it correctly into its parent
  * @param   { Object } child - child tag implementation
  * @param   { Object } opts - tag options containing the DOM node where the tag will be mounted
- * @param   { String } innerHTML - inner html of the child node
+ * @param   { Object } dom - the child DOM node
  * @param   { Object } parent - instance of the parent tag including the child custom tag
  * @returns { Object } instance of the new child tag just created
  */
-export function initChildTag(child, opts, innerHTML, parent) {
-  var tag = new Tag(child, opts, innerHTML),
+export function initChildTag(child, opts, dom, parent) {
+  var tag = new Tag(child, opts, parseYield(dom)),
     tagName = opts.tagName || getTagName(opts.root, true),
     ptag = getImmediateCustomParentTag(parent)
   // fix for the parent attribute in the looped elements
@@ -205,6 +205,28 @@ export function arrayishRemove(obj, key, value, ensureArray) {
 }
 
 /**
+ * Parse yield tag
+ * @param   { Object } dom - dom node where the tag will be mounted
+ * @returns { Object } yield map
+ */
+export function parseYield(dom) {
+  var map = {},
+    node = dom.firstChild
+  while (node) {
+    var next = node.nextSibling
+    if (node.nodeType===1 && node.tagName==='YIELD') {
+      var to = node.getAttribute('to')
+      map[to] = map[to] || node.innerHTML.trim()
+      dom.removeChild(node)
+    }
+    node = next
+  }
+
+  map[''] = (dom.innerHTML || '').trim()
+  return map
+}
+
+/**
  * Mount a tag creating new Tag instance
  * @param   { Object } root - dom node where the tag will be mounted
  * @param   { String } tagName - name of the riot tag we want to mount
@@ -217,7 +239,7 @@ export function mountTo(root, tagName, opts, ctx) {
     implClass = __TAG_IMPL[tagName].class,
     tag = ctx || (implClass ? Object.create(implClass.prototype) : {}),
     // cache the inner HTML to fix #855
-    innerHTML = root._innerHTML = root._innerHTML || root.innerHTML
+    innerHTML = root._innerHTML = root._innerHTML || parseYield(root)
 
   // clear the inner html
   root.innerHTML = ''

--- a/lib/browser/tag/each.js
+++ b/lib/browser/tag/each.js
@@ -20,6 +20,7 @@ import {
   arrayishAdd,
   arrayishRemove,
   makeVirtual,
+  parseYield,
   moveVirtual
 } from './../common/util/tags'
 
@@ -213,7 +214,7 @@ export default function _each(dom, parent, expr) {
           root: dom.cloneNode(isAnonymous),
           item,
           index: i,
-        }, dom.innerHTML)
+        }, parseYield(dom))
 
         // mount the tag
         tag.mount()

--- a/lib/browser/tag/mkdom.js
+++ b/lib/browser/tag/mkdom.js
@@ -15,7 +15,6 @@ import {
 const
   reHasYield  = /<yield\b/i,
   reYieldAll  = /<yield\s*(?:\/>|>([\S\s]*?)<\/yield\s*>|>)/ig,
-  reYieldSrc  = /<yield\s+to=['"]([^'">]*)['"]\s*>([\S\s]*?)<\/yield\s*>/ig,
   reYieldDest = /<yield\s+from=['"]?([-\w]+)['"]?\s*(?:\/>|>([\S\s]*?)<\/yield\s*>)/ig,
   rootEls = { tr: 'tbody', th: 'tr', td: 'tr', col: 'colgroup' },
   tblTags = IE_VERSION && IE_VERSION < 10 ? RE_SPECIAL_TAGS : RE_SPECIAL_TAGS_NO_OPTION,
@@ -54,24 +53,16 @@ function specialTags(el, tmpl, tagName) {
   Replace the yield tag from any tag template with the innerHTML of the
   original tag in the page
 */
-function replaceYield(tmpl, html) {
+function replaceYield(tmpl, src) {
   // do nothing if no yield
   if (!reHasYield.test(tmpl)) return tmpl
-
-  // be careful with #1343 - string on the source having `$1`
-  var src = {}
-
-  html = html && html.replace(reYieldSrc, function (_, ref, text) {
-    src[ref] = src[ref] || text   // preserve first definition
-    return ''
-  }).trim()
 
   return tmpl
     .replace(reYieldDest, function (_, ref, def) {  // yield with from - to attrs
       return src[ref] || def || ''
     })
     .replace(reYieldAll, function (_, def) {        // yield without any "from"
-      return html || def || ''
+      return src[''] || def || ''
     })
 }
 

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -79,7 +79,7 @@ export function parseExpressions(root, expressions, mustIncludeRoot) {
         parent.children.push(tag) // no return, anonymous tag, keep parsing
       } else {
         var conf = {root: dom, parent: this, hasImpl: true}
-        parent.children.push(initChildTag(tagImpl, conf, dom.innerHTML, this))
+        parent.children.push(initChildTag(tagImpl, conf, dom, this))
         return false
       }
     }

--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -55,7 +55,7 @@ export function updateDataIs(expr, parent, tagName) {
 
   expr.impl = __TAG_IMPL[tagName]
   conf = {root: expr.dom, parent: parent, hasImpl: true, tagName: tagName}
-  expr.tag = initChildTag(expr.impl, conf, expr.dom.innerHTML, parent)
+  expr.tag = initChildTag(expr.impl, conf, expr.dom, parent)
   each(expr.attrs, a => setAttr(expr.tag.root, a.name, a.value))
   expr.tagName = tagName
   expr.tag.mount()

--- a/test/specs/browser/riot/transclusion.spec.js
+++ b/test/specs/browser/riot/transclusion.spec.js
@@ -11,6 +11,7 @@ import '../../../tag/inner-html.tag'
 import '../../../tag/yield-no-slash.tag'
 import '../../../tag/yield-multi.tag'
 import '../../../tag/yield-multi2.tag'
+import '../../../tag/yield-multi3.tag'
 import '../../../tag/yield-from-default.tag'
 import '../../../tag/yield-nested.tag'
 
@@ -70,11 +71,9 @@ describe('Riot transclusion', function() {
       '      <li>Option 2</li>',
       '    </ul>',
       '  </yield>',
-      '  <div>',
       '    <yield to="toggle"><span class="icon"></span></yield>',
       '    <yield to="hello">Hello</yield><yield to="world">World</yield>',
       '    <yield to="hello">dummy</yield>',
-      '  </div>',
       '</yield-multi2>'
     ]
     injectHTML(html.join('\n'))
@@ -85,6 +84,35 @@ describe('Riot transclusion', function() {
     tag.unmount()
   })
 
+  it('<yield> from/to multi-transclusion nested ', function() {
+    var html = [
+      '<yield-multi3>',
+      '  <yield to="header">',
+      '    <span>header1</span>',
+      '  </yield>',
+      '  <yield-multi3>',
+      '    <yield to="header">',
+      '      <span>header2</span>',
+      '    </yield>',
+      '    <span>content</span>',
+      '  </yield-multi3>',
+      '</yield-multi3>'
+    ]
+    injectHTML(html.join('\n'))
+    expect($('yield-multi3')).not.to.be.equal(null)
+    var tag = riot.mount('yield-multi3', {})[0]
+    html = [
+      '<div class="header"><span>header1</span></div>',
+      '<div class="content">',
+      '<yield-multi3>',
+      '<div class="header"><span>header2</span></div>',
+      '<div class="content"><span>content</span></div>',
+      '</yield-multi3>',
+      '</div>'
+    ].join('')
+    expect(normalizeHTML(tag.root.innerHTML)).to.be.equal(html)
+    tag.unmount()
+  })
 
   it('<yield from> name can be unquoted, without <yield to> default to its content', function () {
     var html = [

--- a/test/tag/yield-multi3.tag
+++ b/test/tag/yield-multi3.tag
@@ -1,0 +1,4 @@
+<yield-multi3>
+  <div class="header"><yield from="header" /></div>
+  <div class="content"><yield /></div>
+</yield-multi3>


### PR DESCRIPTION
1. Have you added test(s) for your patch?

  Yes.
  BUT comment is bloken.....

2. Can you provide an example of your patch in use?

old: http://plnkr.co/edit/5jCnKV93z0wAmpjkDYp9?p=preview
new: http://plnkr.co/edit/drOMHJ0TgMslyM4yld9p?p=preview

* nested yield(header2) is appear.

3. Is this a breaking change?

   a little.

  - parse yield(to-attribute) block logic move to up.
  - change parameter from String to Object(parsed yield map). call sequence (mountTo -> new Tag() -> mkdom -> replaceYield)
  - initChildTag's I/F is changed.


I judged it difficult to interpret the yield block with regular expressions. 
Therefore, I decided to parse the yield block from the DOM. 

```
<yield to="header">Header Value</yield>
Content
```

```
{
  "header": "HeaderValue",
  "": "Content"
}
```

As a result, the following specification changes have occurred.

- yield block must be child. not grandchild.

Valid:<yield from="header"/> replace to "Header Value"
```
<yield to="header">Header Value</yield>
```

In valid: NOT slotted-yield so <yield /> replace to "<div>...</div>
```
<div><yield to="header">Header Value</yield></div>
```
