### PR TITLE
Fix: Backslash not escaped when requiring riot at top of tag

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -26,7 +26,7 @@ function loadAndCompile(filename, opts, context) {
 
   // here we will use template strings in riot@3.0.0
   context._compile(`
-    var riot = require('${ riotPath }')
+    var riot = require('${ riotPath.replace(/\\/g, '\\\\') }')
     ${ preTag }
     module.exports = ${ tagDefinition }
   `, filename)


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?
  Unable to add tests as problem only exists in a Windows environment

2. Can you provide an example of your patch in use?
  Error pre-fix: 

```
Error: Cannot find module 'C:UsersVengeanceDownloadsDevelopmentJavaScriptNode.  jseden
  ode_modules iot iot'

  - module.js:470 Function.Module._resolveFilename
    module.js:470:15

  - module.js:418 Function.Module._load
    module.js:418:25

  - module.js:498 Module.require
    module.js:498:17

  - module.js:20 require
    internal/module.js:20:19

  - users-admin.tag:2 Object.<anonymous>
    C:/Users/Vengeance/Downloads/Development/JavaScript/Node.js/eden/app/cache/v    iews/users-admin.tag:2:16

  - module.js:571 Module._compile
    module.js:571:32

  - index.js:28 loadAndCompile
    [eden]/[riot]/lib/server/index.js:28:11
```

  Post-fix: No error is present and riot begins to render as normal. 


3. Is this a breaking change?
  For Windows, yes it is, as windows uses '\\' for path separation.

#### Content

Changed './lib/server/index.js' to sanitize backslashes for requiring riot at the top of tag files.