### PR TITLE
#2 nested ref by yield append to defined tag's refs.

### DIFF
--- a/lib/browser/common/global-variables.js
+++ b/lib/browser/common/global-variables.js
@@ -18,6 +18,7 @@ const
   // Riot Directives
   REF_DIRECTIVES = ['data-ref', 'ref'],
   IS_DIRECTIVE = 'data-is',
+  REFERRER_DIRECTIVE = 'data-referrer',
   CONDITIONAL_DIRECTIVE = 'if',
   LOOP_DIRECTIVE = 'each',
   LOOP_NO_REORDER_DIRECTIVE = 'no-reorder',

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -2,16 +2,36 @@ import IfExpr from './if'
 import RefExpr from './ref'
 import _each from './each'
 import { tmpl } from 'riot-tmpl'
-import { 
-  CONDITIONAL_DIRECTIVE, 
+import {
+  CONDITIONAL_DIRECTIVE,
   LOOP_DIRECTIVE,
   IS_DIRECTIVE,
+  REFERRER_DIRECTIVE,
   REF_DIRECTIVES
 } from './../common/global-variables'
 import { isBoolAttr } from './../common/util/check'
-import { walkNodes, getAttr } from './../common/util/dom'
+import { walkNodes, getAttr, setAttr } from './../common/util/dom'
 import { each, contains } from './../common/util/misc'
 import { getTag, initChildTag } from './../common/util/tags'
+
+/**
+ * Walk the tag DOM to detect the 'ref' attribute and set 'referrer' attribute
+ * @this Tag
+ * @param   { HTMLElement } root - root tag where we will start digging the 'ref' attribute
+ */
+export function parseRefAttribute(root) {
+  // if tag has REF_DIRECTIVES attribute then set _riot_id to REFERRER_DIRECTIVE attribute
+  walkNodes(root, (dom, ctx) => {
+    let type = dom.nodeType
+    if (type !== 1) return ctx // not an element
+    REF_DIRECTIVES.forEach((name) => {
+      if (getAttr(dom, name) && !getAttr(dom, REFERRER_DIRECTIVE)){
+        setAttr(dom, REFERRER_DIRECTIVE, this._riot_id)
+      }
+    })
+    return ctx
+  }, true)
+}
 
 /**
  * Walk the tag DOM to detect the expressions to evaluate

--- a/lib/browser/tag/ref.js
+++ b/lib/browser/tag/ref.js
@@ -1,6 +1,7 @@
 import { tmpl } from 'riot-tmpl'
 import { isBlank } from './../common/util/check'
-import { setAttr, remAttr } from './../common/util/dom'
+import { setAttr, remAttr, getAttr } from './../common/util/dom'
+import { REFERRER_DIRECTIVE } from './../common/global-variables'
 
 import {
   getImmediateCustomParentTag,
@@ -28,6 +29,18 @@ export default {
     if (!this.firstRun && value === this.value) return
 
     var customParent = this.parent && getImmediateCustomParentTag(this.parent)
+
+    // lookup customParent by referrer attribute
+    if (customParent) {
+      var referrer = Number(getAttr(this.dom, REFERRER_DIRECTIVE))
+      if (referrer) {
+        while (customParent._riot_id!==referrer) {
+          var parentParent = customParent.parent
+          if (!parentParent) break // maybe error.....
+          customParent = getImmediateCustomParentTag(parentParent)
+        }
+      }
+    }
 
     // if the referenced element is a custom tag, then we set the tag itself, rather than DOM
     var tagOrDom = this.tag || this.dom

--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -1,5 +1,5 @@
 import observable from 'riot-observable'
-import { parseExpressions, parseAttributes } from './parse'
+import { parseRefAttribute, parseExpressions, parseAttributes } from './parse'
 import RefExpr from './ref'
 import update from './update'
 import mkdom from './mkdom'
@@ -233,6 +233,9 @@ export default function Tag(impl, conf, innerHTML) {
     if (impl.fn) impl.fn.call(this, opts)
 
     this.trigger('before-mount')
+
+    // parse ref attribute to set referrer
+    parseRefAttribute.call(this, dom)
 
     // parse layout after init. fn may calculate args for nested custom tags
     parseExpressions.apply(this, [dom, expressions, false])

--- a/test/specs/browser/core.spec.js
+++ b/test/specs/browser/core.spec.js
@@ -23,6 +23,7 @@ import '../../tag/prevent-update.tag'
 import '../../tag/expression-eval-count.tag'
 import '../../tag/multi-named.tag'
 import '../../tag/named-data-ref.tag'
+import '../../tag/nested-ref.tag'
 import '../../tag/input-number.tag'
 import '../../tag/input-values.tag'
 import '../../tag/input-updated.tag'
@@ -1100,6 +1101,15 @@ describe('Riot core', function() {
     injectHTML('<named-data-ref></named-data-ref>')
     var tag = riot.mount('named-data-ref')[0]
     expect(tag.refs.greeting.value).to.be.equal('Hello')
+
+    tag.unmount()
+  })
+
+  it('gets the reference by nested', function() {
+    injectHTML('<nested-ref></nested-ref>')
+    var tag = riot.mount('nested-ref')[0]
+    expect(tag.refs.greeting1.value).to.be.equal('Hello1')
+    expect(tag.refs.greeting2.value).to.be.equal('Hello2')
 
     tag.unmount()
   })

--- a/test/tag/nested-ref.tag
+++ b/test/tag/nested-ref.tag
@@ -1,0 +1,14 @@
+<nested-ref>
+    <nested-ref-sub>
+        <input ref="greeting1" type="text" value="Hello1">
+    </nested-ref-sub>
+    <nested-ref-sub>
+        <nested-ref-sub>
+            <input data-ref="greeting2" type="text" value="Hello2">
+        </nested-ref-sub>
+    </nested-ref-sub>
+</nested-ref>
+
+<nested-ref-sub>
+    <yield/>
+</nested-ref-sub>


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?

yes

2. Can you provide an example of your patch in use?

http://embed.plnkr.co/lPsLXJwasPTzGb7WwO6H/

see console.

3. Is this a breaking change?

yes

Provide a short description about what you have changed:

```html
      <nested-ref>
        <nested-ref-sub ref=nested>
          <input ref="greeting1" type="text" value="Hello1">
        </nested-ref-sub>
        <nested-ref-sub>
          <nested-ref-sub>
            <input data-ref="greeting2" type="text" value="Hello2">
          </nested-ref-sub>
        </nested-ref-sub>
      </nested-ref>

      <nested-ref-sub>
        <yield/>
      </nested-ref-sub>
```

Change ref's context from 'yield' to defined.
So, easy to access by refs.

```JavaScript
      var tag = riot.mount('nested-ref')[0];
//      console.log("Before");
//      console.log(tag.tags['nested-ref-sub'][0].refs.greeting1.value);
//      console.log(tag.tags['nested-ref-sub'][1].tags['nested-ref-sub'].refs.greeting2.value);
      console.log("After");
      console.log(tag.refs.greeting1.value);
      console.log(tag.refs.greeting2.value);
```

1. parse the dom: if the node has a ref attribute then set tag._riot_id to the 'data-referrer' attribute.
2. update ref: lookup custom-tag by 'data-referrer' attribute (this is tag._riot_id where ref attribute is defined.)
