### PR TITLE
Fixed rollup server side (cjs) transpilation.

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -111,6 +111,7 @@ render.tag = function(tagName, opts) {
 module.exports = exports.default = Object.assign(riot, {
   // allow to require('riot').compile
   compile: compiler.compile,
+  default: riot,
   parsers: compiler.parsers,
   require: riotRequire,
   render,

--- a/test/specs/server/index.js
+++ b/test/specs/server/index.js
@@ -16,6 +16,11 @@ describe('Node', function() {
     return js.replace(/@version/, '1.0.0')
   }
 
+  it('has default.render', function(done) {
+    expect(typeof riot.default.render).to.be.equal('function')
+    done()
+  })
+
   it('require tags', function(done) {
     glob('../../tag/*.tag', { cwd: __dirname }, function (err, tags) {
       expect(err).to.be.equal(null)


### PR DESCRIPTION
Fixes https://github.com/riot/riot/issues/2212

1. Have you added test(s) for your patch? If not, why not?

Yes

2. Can you provide an example of your patch in use?

https://censible-companies-staging.herokuapp.com/companies/000C7F-E

3. Is this a breaking change?

No

#### Content

Provide a short description about what you have changed:

added default to lib/server/index.js export hash
