### PR TITLE
Fix event listener on wrong parent

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -264,7 +264,8 @@ export default function Tag(impl, conf, innerHTML) {
     }
     // otherwise we need to wait that the parent "mount" or "updated" event gets triggered
     else {
-      getImmediateCustomParentTag(this.parent).one(!this.parent.isMounted ? 'mount' : 'updated', () => {
+      var ptag = getImmediateCustomParentTag(this.parent)
+      ptag.one(!ptag.isMounted ? 'mount' : 'updated', () => {
         this.trigger('mount')
       })
     }


### PR DESCRIPTION
Fixes #2249 

#### Code

1. Have you added test(s) for your patch? If not, why not?
- Looks like it's not needed this part of the app should already be tested

2. Can you provide an example of your patch in use?
- https://github.com/riot/riot/issues/2249

3. Is this a breaking change?
- No

#### Content

Provide a short description about what you have changed:
- The check for `isMounted` was done on the wrong parent and thus caused some cases where a child's `before-mount` was triggered, but never its `mount`