### PR TITLE
Supports `module` field for ES6 bundle systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "riot": "node_modules/riot-cli/lib/index.js"
   },
   "main": "lib/server/index.js",
+  "module": "lib/riot.js",
   "jsnext:main": "lib/riot.js",
   "browser": "riot.js"
 }


### PR DESCRIPTION
We already supported `jsnext`, but recently `module` has been getting more popular. This PR will add the field `module` to `package.json`

See more detail and discussion here:
https://github.com/rollup/rollup/wiki/pkg.module

#### 1. Have you added test(s) for your patch? If not, why not?

N/A

#### 2. Can you provide an example of your patch in use?

Here's an example use case in [Rollup](http://rollupjs.org/):

```javascript
// rollup.config.js

// old 
export default {
  plugins: [
    riot(),
    nodeResolve({ jsnext: true }),
    buble()
  ]
}

// new
export default {
  plugins: [
    riot(),
    nodeResolve(),
    buble()
  ]
}
```

#### 3. Is this a breaking change?

No, but a kind of new feature, so it needs a `minor` release.