### PR TITLE
Fix issue where this.pristine does not exist

### DIFF
--- a/riot+compiler.js
+++ b/riot+compiler.js
@@ -1268,7 +1268,7 @@ var IfExpr = {
   update: function update() {
     var newValue = tmpl(this.expr, this.tag);
 
-    if (newValue && !this.current) { // insert
+    if (newValue && !this.current && this.pristine) { // insert
       this.current = this.pristine.cloneNode(true);
       this.stub.parentNode.insertBefore(this.current, this.stub);
 

--- a/riot.csp.js
+++ b/riot.csp.js
@@ -7818,7 +7818,7 @@ var IfExpr = {
   update: function update() {
     var newValue = csp_tmpl_1(this.expr, this.tag);
 
-    if (newValue && !this.current) { // insert
+    if (newValue && !this.current && this.pristine) { // insert
       this.current = this.pristine.cloneNode(true);
       this.stub.parentNode.insertBefore(this.current, this.stub);
 

--- a/riot.js
+++ b/riot.js
@@ -1268,7 +1268,7 @@ var IfExpr = {
   update: function update() {
     var newValue = tmpl(this.expr, this.tag);
 
-    if (newValue && !this.current) { // insert
+    if (newValue && !this.current && this.pristine) { // insert
       this.current = this.pristine.cloneNode(true);
       this.stub.parentNode.insertBefore(this.current, this.stub);
 

--- a/test/performance/riot.3.0.7.js
+++ b/test/performance/riot.3.0.7.js
@@ -1256,7 +1256,7 @@ var IfExpr = {
   update: function update() {
     var newValue = tmpl(this.expr, this.tag);
 
-    if (newValue && !this.current) { // insert
+    if (newValue && !this.current && this.pristine) { // insert
       this.current = this.pristine.cloneNode(true);
       this.stub.parentNode.insertBefore(this.current, this.stub);
 


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

No. No additional testing was needed. 

2. Can you provide an example of your patch in use?

Not really anything I can provide an example for. 

3. Is this a breaking change?

No

#### Content

I added a check for `this.pristine` within the `update()` call for IfExpr. We found in some cases `this.pristine` was not available and caused an error to be thrown. We initially thought it was a jQuery issue, since the error seemed to indicate that, but after backtracing, we found the actual issue stemmed from this.

I am not sure if this is the actual fix, but it seemed to make our problem go away. I'll try and see if I can make a small scale demo of the issue.