### PR TITLE
Update to pass nextOpts to shouldUpdate handler

### DIFF
--- a/lib/browser/tag/tag.js
+++ b/lib/browser/tag/tag.js
@@ -129,7 +129,9 @@ export default function Tag(impl = {}, conf = {}, innerHTML) {
    * @returns { Tag } the current tag instance
    */
   defineProperty(this, 'update', function tagUpdate(data) {
-    if (isFunction(this.shouldUpdate) && !this.shouldUpdate(data)) return this
+    var nextOpts = {}
+    updateOpts.apply(this, [isLoop, parent, isAnonymous, nextOpts, instAttrs])
+    if (isFunction(this.shouldUpdate) && !this.shouldUpdate(data, nextOpts)) return this
     const canTrigger = this.isMounted && !skipAnonymous
 
     // make sure the data passed will not override
@@ -139,7 +141,7 @@ export default function Tag(impl = {}, conf = {}, innerHTML) {
     // inherit properties from the parent, but only for isAnonymous tags
     if (isLoop && isAnonymous) inheritFrom.apply(this, [this.parent, propsInSyncWithParent])
     extend(this, data)
-    updateOpts.apply(this, [isLoop, parent, isAnonymous, opts, instAttrs])
+    extend(opts, nextOpts)
     if (canTrigger) this.trigger('update', data)
     update.call(this, expressions)
     if (canTrigger) this.trigger('updated')

--- a/test/specs/browser/core.spec.js
+++ b/test/specs/browser/core.spec.js
@@ -31,6 +31,7 @@ import '../../tag/treeview.tag'
 import '../../tag/events.tag'
 import '../../tag/runtime-event-listener-switch.tag'
 import '../../tag/should-update.tag'
+import '../../tag/should-update-opts.tag'
 import '../../tag/observable-attr.tag'
 import '../../tag/virtual-nested-unmount.tag'
 import '../../tag/virtual-conditional.tag'
@@ -900,6 +901,16 @@ describe('Riot core', function() {
     expect(tag.update()).to.be.ok
     expect(tag.count).to.be.equal(0)
     tag.update(true)
+    expect(tag.count).to.be.equal(1)
+    tag.unmount()
+  })
+
+  it('the "shouldUpdate" accepts nextOpts', function() {
+    injectHTML('<should-update-opts should-update="{ count === 0 }"></should-update-opts>')
+    var tag = riot.mount('should-update-opts')[0]
+    expect(tag.update()).to.be.ok
+    expect(tag.count).to.be.equal(1)
+    tag.update()
     expect(tag.count).to.be.equal(1)
     tag.unmount()
   })

--- a/test/tag/should-update-opts.tag
+++ b/test/tag/should-update-opts.tag
@@ -1,0 +1,13 @@
+<should-update-opts>
+  <p>{ count }</p>
+
+  this.count = 0
+
+  shouldUpdate(data, opts) {
+    return opts.shouldUpdate
+  }
+
+  this.on('update', function() {
+    this.count ++
+  })
+</should-update-opts>


### PR DESCRIPTION
This update makes it possible to prevent tag updates based on incoming opts.

ref: #2238
closes: #2238
