### PR TITLE
(chore) Enable syntax highlighting of tag files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tag linguist-language=HTML


### PR DESCRIPTION
(see: https://github.com/lildude/test-highlighting-override)

example:
![2017-03-15 8 56 09](https://cloud.githubusercontent.com/assets/4439005/23927488/5f09c852-095d-11e7-964f-4bc2aecac17b.png)

Thanks for this great lib.