### PR TITLE
Closes #2383, using riot-compiler 3.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ out/
 .settings/
 
 # --------------------
+# VS Code Files
+# --------------------
+.vscode
+/jsconfig.json
+
+# --------------------
 # App Files
 # --------------------
 node_modules

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "riot-cli": "^3.0.2",
-    "riot-compiler": "^3.2.3",
+    "riot-compiler": "^3.2.4",
     "riot-observable": "^3.0.0",
     "riot-tmpl": "^3.0.8",
     "simple-dom": "0.3.2",

--- a/test/specs/browser/compiler/compiler.spec.js
+++ b/test/specs/browser/compiler/compiler.spec.js
@@ -6,7 +6,7 @@ import {
   getRiotStyles
 } from '../../../helpers/index'
 
-import '../../../tag/bug-2369.tag'
+//import '../../../tag/bug-2369.tag'
 
 
 describe('Riot compiler', function() {
@@ -150,12 +150,13 @@ describe('Riot compiler', function() {
     tag.unmount()
   })
 
-  it('tags containing regex get properly compiled', function() {
+  it('tags containing regex get properly compiled', function(done) {
     injectHTML('<bug-2369></bug-2369>')
-    const tag = riot.mount('bug-2369')[0]
-
-    expect(tag.root).to.be.ok
-
-    tag.unmount()
+    riot.compile('./tag/bug-2369.tag', function () {
+      const tag = riot.mount('bug-2369')[0]
+      expect(tag.root).to.be.ok
+      tag.unmount()
+      done()
+    })
   })
 })


### PR DESCRIPTION
1. Have you added test(s) for your patch? If not, why not?

    Yes.

2. Can you provide an example of your patch in use?

    Test is in `test/tag/bug-2369.tag`

3. Is this a breaking change?

    I hope not :)

#### Content

This solves an issue with the tests in the browser and updates the compiler to v3.2.4 that closes #2369.

Additionally, exclusions for VS Code files are inserted in the .gitignore.
