### PR TITLE
Ensure "value" attribute is never set

### DIFF
--- a/lib/browser/tag/update.js
+++ b/lib/browser/tag/update.js
@@ -208,9 +208,7 @@ export function updateExpression(expr) {
 
     if (attrName === 'value' && dom.value !== value) {
       dom.value = value
-    }
-
-    if (hasValue && value !== false) {
+    } else if (hasValue && value !== false) {
       setAttr(dom, attrName, value)
     }
 

--- a/test/specs/browser/riot/core.spec.js
+++ b/test/specs/browser/riot/core.spec.js
@@ -853,6 +853,20 @@ describe('Riot core', function() {
 
     tag.unmount()
   })
+  
+  it('does not set value attribute', function() {
+    
+    injectHTML('<input-values></input-values>')
+
+    var tag = riot.mount('input-values')[0]
+    expect(tag.refs.i.value).to.be.equal('hi')
+    expect(tag.refs.i.hasAttribute('value')).to.be.false
+    tag.update()
+    expect(tag.refs.i.value).to.be.equal('foo')
+    expect(tag.refs.i.hasAttribute('value')).to.be.false
+
+    tag.unmount()
+  });
 
   it('updates the value of input which has been changed from initial one #2096', function() {
 

--- a/test/specs/browser/riot/core.spec.js
+++ b/test/specs/browser/riot/core.spec.js
@@ -853,9 +853,9 @@ describe('Riot core', function() {
 
     tag.unmount()
   })
-  
+
   it('does not set value attribute', function() {
-    
+
     injectHTML('<input-values></input-values>')
 
     var tag = riot.mount('input-values')[0]
@@ -866,7 +866,7 @@ describe('Riot core', function() {
     expect(tag.refs.i.hasAttribute('value')).to.be.false
 
     tag.unmount()
-  });
+  })
 
   it('updates the value of input which has been changed from initial one #2096', function() {
 


### PR DESCRIPTION
#### Code

1. Have you added test(s) for your patch? If not, why not?
No, because I'm lazy and it's such a small change.  Let's see if this passes existing tests and discuss the change first.  Maybe this is a terrible idea?  I dunno...

2. Can you provide an example of your patch in use?
No (for same reasons as above).

3. Is this a breaking change?
No.  Users shouldn't really care about the "value" attribute itself, only the `value` DOM property.

#### Content

Provide a short description about what you have changed:
"value" attribute of DOM element is no longer set when the expression for the "value" attribute is updated; instead, only the `value` DOM property is updated.

Prior to this change, Riot sets both the "value" attribute and the `value` property on the DOM element.  As per @GianlucaGuarini, setting the "value" attribute is really quite pointless.  The other problem is that Riot does not automatically clear/remove the "value" attribute when the corresponding expression evaluates to a falsy value.  This inconsistent behavior when setting / deleting the "value" attribute is the reason why this PR even exists.   See issue #2427 for more info.