### PR TITLE
Included router mixin in libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
 - [Veronica - flux adaption for Riot](https://www.npmjs.com/package/veronica-x)
 - [Minimal Flux dispatcher pattern](https://gist.github.com/continuata/c605846751c09a5e94d12ae8c91cbf05)
 - [riot-format: a format library for riotjs, like angular $filter](https://github.com/joylei/riot-format)
+- [riot-view-router: a simple state based router mixin](https://github.com/neetjn/riot-view-router)
 
 ### Components
 - [Material UI](http://kysonic.github.io/riot-mui/)


### PR DESCRIPTION
I've included the riot-view-router mixin in the libraries / frameworks section.

Very minimal state based router based off of ui-router with lifecycle events, uses `pushState` and html5 history api.

Project: https://github.com/neetjn/riot-view-router

## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?


2. Can you provide an example of your patch in use?

  Post the link using one of our bug report templates:
  - [Bug Report Template](http://riotjs.com/examples/plunker/?app=bug-reporter) on plnkr (preferred)
  - [Bug Report Template](http://jsfiddle.net/gianlucaguarini/86m9uepL/) on jsFiddle


3. Is this a breaking change?


#### Content

Provide a short description about what you have changed:
