### PR TITLE
Updated framework comparison to match Inferno v4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | React + Map and Set Polyfills                  | 16.1.0          | 41.817kb             |
 | Web Components Polyfill                        | 0.7.24          | 33.68kb              |
 | Vue                                            | 2.5.13          | 31.41kb              |
-| Inferno + Map, Set, WeakMap, Promise Polyfills | 3.10.1          | 25.83kb              |
+| Inferno                                        | 4.0.2           | 7.98kb               |
 | __Riot__                                       | 3.8.1           | 10.42kb              |
 | Preact                                         | 8.2.6           | 3.45kb               |
 


### PR DESCRIPTION
Inferno v4 no longer uses any ES6 features. Browser support can be seen here:
https://github.com/infernojs/inferno#browser-support  (basically it is IE9+)