### PR TITLE
Removed riotux to Mockstate and included riotx in libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
 
 ### Libraries / Frameworks
 - [Flux- like event controller for Riot](https://github.com/jimsparkman/RiotControl)
-- [riotux - Simple Event Controller for Riot.js](https://github.com/luisvinicius167/riotux)
+- [Mockstate - Simple Event Controller for Riot.js](https://github.com/luisvinicius167/mockstate)
 - [flux-riot framework](https://github.com/mingliangfeng/flux-riot)
 - [Cheftjs - chinese framework for Riot](https://github.com/cheft/cheftjs)
 - [Veronica - flux adaption for Riot](https://www.npmjs.com/package/veronica-x)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ HTML syntax is the de facto language on the web and it's designed for building u
 
 ### Libraries / Frameworks
 - [Flux- like event controller for Riot](https://github.com/jimsparkman/RiotControl)
-- [Mockstate - Simple Event Controller for Riot.js](https://github.com/luisvinicius167/mockstate)
 - [flux-riot framework](https://github.com/mingliangfeng/flux-riot)
 - [Cheftjs - chinese framework for Riot](https://github.com/cheft/cheftjs)
 - [Veronica - flux adaption for Riot](https://www.npmjs.com/package/veronica-x)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ HTML syntax is the de facto language on the web and it's designed for building u
 - [Minimal Flux dispatcher pattern](https://gist.github.com/continuata/c605846751c09a5e94d12ae8c91cbf05)
 - [riot-format: a format library for riotjs, like angular $filter](https://github.com/joylei/riot-format)
 - [riot-view-router: a simple state based router mixin](https://github.com/neetjn/riot-view-router)
+- [riotx - Centralized State Management for riot.js](https://github.com/cam-inc/riotx)
 
 ### Components
 - [Material UI](http://kysonic.github.io/riot-mui/)


### PR DESCRIPTION
1. __Removed riotux to Mockstate__

The riotux library was renamed to mockstate and did not use riot.

repo: https://github.com/luisvinicius167/mockstate

2.  __and included riotx in libraries section__

I've included the `riotx` in the libraries / frameworks section.
This is a state management library for riot.js.

repo: https://github.com/cam-inc/riotx


## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?


2. Can you provide an example of your patch in use?

  Post the link using one of our bug report templates:
  - [Bug Report Template](http://riotjs.com/examples/plunker/?app=bug-reporter) on plnkr (preferred)
  - [Bug Report Template](http://jsfiddle.net/gianlucaguarini/86m9uepL/) on jsFiddle


3. Is this a breaking change?


#### Content

Provide a short description about what you have changed:
