### PR TITLE
Jspm17 upgrade

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -4,7 +4,7 @@ const
   path = require('path'),
   fs = require('fs'),
   hasRiotPath = !!process.env.RIOT,
-  riotPath = path.normalize(process.env.RIOT || path.resolve(__dirname, '..', '..', 'riot')),
+  riotPath = path.normalize(process.env.RIOT || path.join('..', '..', 'riot')),
   riot = require(riotPath),
   // simple-dom helper
   sdom = require('./sdom'),
@@ -51,8 +51,10 @@ function riotRequire(filename, opts) {
 }
 
 // allow to require('some.tag')
-require.extensions['.tag'] = function(module, filename) {
-  loadAndCompile(filename, {}, module)
+if (require.extensions) {
+  require.extensions['.tag'] = function(module, filename) {
+    loadAndCompile(filename, {}, module)
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -87,46 +87,6 @@
   "bin": {
     "riot": "node_modules/riot-cli/lib/index.js"
   },
-  "jspm": {
-    "main": "lib/server/index.js",
-    "format": "cjs",
-    "meta": {
-      "*": {
-        "globals": {
-          "process": "process"
-        }
-      },
-      "*.json": {
-        "format": "json"
-      },
-      "lib/browser/*": {
-        "format": "esm"
-      },
-      "lib/riot+compiler.js": {
-        "format": "esm"
-      },
-      "lib/riot.js": {
-        "format": "esm"
-      },
-      "lib/settings.js": {
-        "format": "esm"
-      },
-      "riot.min.js": {
-        "format": "amd"
-      },
-      "lib/server/index.js": {
-        "deps": [
-          "../../riot"
-        ]
-      }
-    },
-    "map": {
-      "./lib/server": "./lib/server/index.js",
-      "./lib/server/index.js": {
-        "browser": "./riot.js"
-      }
-    }
-  },
   "main": "lib/server/index.js",
   "module": "lib/riot.js",
   "jsnext:main": "lib/riot.js",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,46 @@
   "bin": {
     "riot": "node_modules/riot-cli/lib/index.js"
   },
+  "jspm": {
+    "main": "lib/server/index.js",
+    "format": "cjs",
+    "meta": {
+      "*": {
+        "globals": {
+          "process": "process"
+        }
+      },
+      "*.json": {
+        "format": "json"
+      },
+      "lib/browser/*": {
+        "format": "esm"
+      },
+      "lib/riot+compiler.js": {
+        "format": "esm"
+      },
+      "lib/riot.js": {
+        "format": "esm"
+      },
+      "lib/settings.js": {
+        "format": "esm"
+      },
+      "riot.min.js": {
+        "format": "amd"
+      },
+      "lib/server/index.js": {
+        "deps": [
+          "../../riot"
+        ]
+      }
+    },
+    "map": {
+      "./lib/server": "./lib/server/index.js",
+      "./lib/server/index.js": {
+        "browser": "./riot.js"
+      }
+    }
+  },
   "main": "lib/server/index.js",
   "module": "lib/riot.js",
   "jsnext:main": "lib/riot.js",


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

This should be a non-functional change in every case except when using JSPM, and I do not know of a reasonable way to write a unit test for 'are we using JSPM/System.js' without making life real ugly.

2. Can you provide an example of your patch in use?

The bug illustrated by https://github.com/michael-simon/riot-jspm-issue-2530 is what this patch is meant to resolve. When using this branch, along with the package file in 
https://github.com/jspm/registry/pull/1071, the bug is no longer evident.

3. Is this a breaking change?

It should not be breaking in any use case I can see: 
* detecting if require.extensions exists should be fine (if it doesn't, we can't use .tag files in requires, and wouldn't have been able to before this change either)
* using relative pathing instead of absolute pathing to find the riot.js in the base directory as default should always work.

#### Content

I have made two minor changes to lib/server/index.js to enable the usage of JSPM 0.17 on the server side: making the pathing for the riot require relative and not absolute in the case where env.RIOT is not set, and making it so that require.extensions[.tag] is not set when require.extensions does not exist (as it does not exist once SystemJS gets its hooks into the require system.) This is coupled with a change in the jspm/registry repo, https://github.com/jspm/registry/pull/1071 , that correctly identifies that lib/server/index.js has a direct requirement on riot.js .
