### PR TITLE
Relative Pathing and checking for require.extensions

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -4,7 +4,7 @@ const
   path = require('path'),
   fs = require('fs'),
   hasRiotPath = !!process.env.RIOT,
-  riotPath = path.normalize(process.env.RIOT || path.resolve(__dirname, '..', '..', 'riot')),
+  riotPath = path.normalize(process.env.RIOT || path.join('..', '..', 'riot')),
   riot = require(riotPath),
   // simple-dom helper
   sdom = require('./sdom'),
@@ -51,8 +51,10 @@ function riotRequire(filename, opts) {
 }
 
 // allow to require('some.tag')
-require.extensions['.tag'] = function(module, filename) {
-  loadAndCompile(filename, {}, module)
+if (require.extensions) {
+  require.extensions['.tag'] = function(module, filename) {
+    loadAndCompile(filename, {}, module)
+  }
 }
 
 /**


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

No, as they should be non-functional changes and thereby be caught by existing tests.

2. Can you provide an example of your patch in use?

My only example is related to JSPM and riot/2530, which this appears to resolve. https://github.com/michael-simon/riot-jspm-issue-2530

3. Is this a breaking change?

No, as the only thing it would do that is different is turn an error case (where require.extensions didn't exist, so you couldn't set [.tag] on it) into a case where the code runs and silently doesn't allow you to require files with the .tag extension. The other change for relative pathing shouldn't break anything.

#### Content

Provide a short description about what you have changed:

In lib/server/index.js, we use path.resolve(__dirname, '..', '..', 'riot') to access the relative path of riot.js . path.join('..', '..', 'riot') seems more appropriate for a relative path inside a module.

Additionally in lib/server/index.js , we attempt to modify require.extensions[.tag], however, that is not ideal both because someone might have already replqced require (eg: SystemJS) and/or because require.extensions is deprecated. For now, putting an if (require.extensions) around the code at least guards us from a runtime exception, although this may not be the ideal solution because we don't have a replacement for the fact that .tag files won't be able to be required like this. But maybe that's okay because if you are in this problem state, you are using something like Webpack or JSPM which has their own loader for .tag files?