### PR TITLE
updated: fix abondened styles of unregister tags

### DIFF
--- a/lib/browser/tag/core.js
+++ b/lib/browser/tag/core.js
@@ -66,7 +66,7 @@ export function tag(name, tmpl, css, attrs, fn) {
     if (isFunction(css))
       fn = css
     else
-      styleManager.add(css)
+      styleManager.add(css, name)
   }
 
   name = name.toLowerCase()
@@ -214,6 +214,7 @@ export function update() {
 }
 
 export function unregister(name) {
+  styleManager.remove(name)
   return delete __TAG_IMPL[name]
 }
 

--- a/lib/browser/tag/styleManager.js
+++ b/lib/browser/tag/styleManager.js
@@ -58,5 +58,14 @@ export default {
     /* istanbul ignore next */
     if (cssTextProp) cssTextProp.cssText = style
     else styleNode.innerHTML = style
+  },
+
+  /**
+   * Remove a tag style of injected DOM later.
+   * @param {String} name a registered tagname
+   */
+  remove(name) {
+    delete byName[name]
+    needsInject = true
   }
 }

--- a/test/specs/browser/riot/core.spec.js
+++ b/test/specs/browser/riot/core.spec.js
@@ -227,6 +227,27 @@ describe('Riot core', function() {
     node.parentNode.removeChild(node)
   })
 
+  it('remove style of unregistered tags out of document', function() {
+    injectHTML('<riot-tmp-with-style></riot-tmp-with-style>')
+
+    try {
+      riot.tag('riot-tmp-with-style', '<p>hello</p>', 'riot-tmp-with-style { font-size: 1rem; }')
+
+      riot.mount('*') // ensure <style> updated
+
+      riot.unregister('riot-tmp-with-style')
+
+      riot.mount('*') // ensure <style> updated
+
+      $$('head style').forEach(style => {
+        expect(style.textContent).not.to.contain('riot-tmp-with-style')
+      })
+    } finally {
+      const node = $('riot-tmp-with-style')
+      node.parentNode.removeChild(node)
+    }
+  })
+
   it('an <option> tag having the attribute "selected" should be the value of the parent <select> tag', function() {
     injectHTML('<tmp-select-tag></tmp-select-tag>')
 


### PR DESCRIPTION
Mentioned PR at #2576 to fix.

Please do what works for you.
I'm also looking forward to riot v4!

#### Code

1. Have you added test(s) for your patch? If not, why not?

Yes.

2. Can you provide an example of your patch in use?

http://plnkr.co/edit/IBZvLZLwGA9pYm4CpOsC?p=preview

3. Is this a breaking change?

Possibly, no, but I'm not sure of difference between `add(css)` that `tag()` uses and `add(css, name)` that `tag2()` uses.

#### Content

Provide a short description about what you have changed:

`riot.unregister()` remove the styles of unregistered tags.
I also changed their adding into using name option, which is required to complete that work.
