### PR TITLE
parentnode check on virtual replace

### DIFF
--- a/lib/browser/common/util/tags/replace-virtual.js
+++ b/lib/browser/common/util/tags/replace-virtual.js
@@ -7,6 +7,7 @@ import makeVirtual from './make-virtual'
  * @param { ref } the dom reference location
  */
 export default function makeReplaceVirtual(tag, ref) {
+  if (!ref.parentNode) { return }
   const frag = createFragment()
   makeVirtual.call(tag, frag)
   ref.parentNode.replaceChild(frag, ref)

--- a/riot.js
+++ b/riot.js
@@ -1578,6 +1578,7 @@
    * @param { ref } the dom reference location
    */
   function makeReplaceVirtual(tag, ref) {
+    if (!ref.parentNode) { return }
     var frag = createFragment();
     makeVirtual.call(tag, frag);
     ref.parentNode.replaceChild(frag, ref);

--- a/test/specs/browser/riot/core.spec.js
+++ b/test/specs/browser/riot/core.spec.js
@@ -1621,4 +1621,18 @@ describe('Riot core', function() {
 
     tag.unmount()
   })
+
+  it('does not attempt to makeReplaceVirtual when parentNode no longer exists in DOM (issue 2614)', function () {
+    riot.tag('riot-unmountable', '<virtual ref="virtual">Hi</virtual>')
+    injectHTML('<riot-unmountable></riot-unmountable>')
+    const tag = riot.mount('riot-unmountable')[0]
+    const virt = tag.refs.virtual
+
+    // unmount the tag; virt.root.parentNode will now be null
+    tag.unmount()
+    riot.util.tags.makeReplaceVirtual(virt, virt.root)
+
+    // getting to this point proves makeReplaceVirtual returned early (i.e., did not error)
+    expect(true).to.be.true
+  })
 })


### PR DESCRIPTION
## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?


2. Can you provide an example of your patch in use?

  Post the link using one of our bug report templates:
  - [Bug Report Template](http://riot.js.org/examples/plunker/?app=bug-reporter) on plnkr (preferred)
  - [Bug Report Template](http://jsfiddle.net/gianlucaguarini/86m9uepL/) on jsFiddle


3. Is this a breaking change?


#### Content

Provide a short description about what you have changed: Makes a basic check on presence of `ref.parentNode` before continuing with execution of virtual tag replacement.

https://github.com/riot/riot/issues/2614
