### PR TITLE
packaging riot on server side is not possible

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -4,8 +4,8 @@ const
   path = require('path'),
   fs = require('fs'),
   hasRiotPath = !!process.env.RIOT,
-  riotPath = path.normalize(process.env.RIOT || path.join('..', '..', 'riot')),
-  riot = require(riotPath),
+  riotPath = path.normalize(process.env.RIOT || '../../riot'),
+  riot = (hasRiotPath) ? require(riotPath) : require('../../riot'),
   // simple-dom helper
   sdom = require('./sdom'),
   Module = require('module'),


### PR DESCRIPTION
webpack cannot require files with dynamic string

## __IMPORTANT: for all the pull requests use the `dev` branch__

### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?
i think there are no tests needed for this fix

2. Can you provide an example of your patch in use?
Just require('riot/lib/server') in a file (index.js) and try to build it with ncc(https://github.com/zeit/ncc):
ncc build index.js
-> ncc (webpack) cannot require files dynamically by variable

3. Is this a breaking change?
no

#### Content

Provide a short description about what you have changed:
It is not necessary to use path  -> path.join('..', '..', 'riot'). 
This patch removes the dynamically variable for the most common use case but still lets riot to be used with an environment variable if desired.