### PR TITLE
Component CSS should be overwritten when component re-added

### DIFF
--- a/src/core/css-manager.js
+++ b/src/core/css-manager.js
@@ -36,9 +36,7 @@ export default {
    * @returns {Object} self
    */
   add(name, css) {
-    if (!CSS_BY_NAME.has(name)) {
-      CSS_BY_NAME.set(name, css)
-    }
+    CSS_BY_NAME.set(name, css)
 
     this.inject()
     return this


### PR DESCRIPTION

1. Have you added test(s) for your patch? If not, why not?

No, I don't know how to make them.

2. Can you provide an example of your patch in use?

It's messy to provide a complete project webpack enabled project.

3. Is this a breaking change?

I think this is the more expected behavior, since otherwise hot reload doesn't work.

#### Content

Set / replace CSS even if old CSS already exists for component. 