### PR TITLE
feat: Add the keepRootElement argument to the unmount method

### DIFF
--- a/riot.d.ts
+++ b/riot.d.ts
@@ -64,7 +64,7 @@ export type InstalledPluginsSet = Set<ComponentEnhancer>
 export function register<P, S>(componentName: string, shell: RiotComponentShell<P, S>): RegisteredComponentsMap
 export function unregister(componentName: string): RegisteredComponentsMap
 export function mount<P = object, S = object>(selector: string, componentName: string, initialProps?: P): RiotComponent<P, S>[]
-export function unmount(selector: string):HTMLElement[]
+export function unmount(selector: string, keepRootElement: boolean):HTMLElement[]
 export function install(plugin: ComponentEnhancer):InstalledPluginsSet
 export function uninstall(plugin: ComponentEnhancer):InstalledPluginsSet
 export function component<P , S>(shell: RiotComponentShell<P, S>):(el: HTMLElement, initialProps?: P) => RiotComponent<P, S>

--- a/src/riot.js
+++ b/src/riot.js
@@ -54,12 +54,13 @@ export function mount(selector, initialProps, name) {
 /**
  * Sweet unmounting helper function for the DOM node mounted manually by the user
  * @param   {string|HTMLElement} selector - query for the selection or a DOM element
+ * @param   {boolean|null} keepRootElement - if true keep the root element
  * @returns {Array} list of nodes unmounted
  */
-export function unmount(selector) {
+export function unmount(selector, keepRootElement) {
   return $(selector).map(element => {
     if (element[DOM_COMPONENT_INSTANCE_PROPERTY]) {
-      element[DOM_COMPONENT_INSTANCE_PROPERTY].unmount()
+      element[DOM_COMPONENT_INSTANCE_PROPERTY].unmount(keepRootElement)
     }
     return element
   })

--- a/test/specs/core.spec.js
+++ b/test/specs/core.spec.js
@@ -260,31 +260,28 @@ describe('Riot core api', () => {
     })
 
     it('custom components can be unmounted by tag keeping the root element', () => {
-      const destroyedSpy = spy()
+      const element1 = document.createElement('div')
+      const element2 = document.createElement('div')
+
+      document.body.appendChild(element1)
+      document.body.appendChild(element2)
+
       riot.register('my-component-red', {
-        css: 'my-component-red { color: red; }',
-        exports: {
-          onUnmounted() {
-            destroyedSpy()
-          }
-        }
+        css: 'my-component-red { color: red; }'
       })
       riot.register('my-component-green', {
-        css: 'my-component-green { color: green; }',
-        exports: {
-          onUnmounted() {
-            destroyedSpy()
-          }
-        }
+        css: 'my-component-green { color: green; }'
       })
-      const element = document.createElement('div')
 
-      riot.mount(element, {}, 'my-component-red')
-      riot.unmount(element, true)
-      riot.mount(element, {}, 'my-component-green')
-      riot.unmount(element, true)
+      riot.mount(element1, {}, 'my-component-red')
+      riot.mount(element2, {}, 'my-component-green')
+      riot.unmount(element1, true)
+      riot.unmount(element2)
 
-      expect(destroyedSpy).to.have.been.calledTwice
+      expect(document.body.contains(element1)).to.be.ok
+      expect(document.body.contains(element2)).to.be.not.ok
+
+      element2.parentNode.removeChild(element2)
       riot.unregister('my-component-red')
       riot.unregister('my-component-green')
     })

--- a/test/specs/core.spec.js
+++ b/test/specs/core.spec.js
@@ -266,24 +266,20 @@ describe('Riot core api', () => {
       document.body.appendChild(element1)
       document.body.appendChild(element2)
 
-      riot.register('my-component-red', {
-        css: 'my-component-red { color: red; }'
-      })
-      riot.register('my-component-green', {
-        css: 'my-component-green { color: green; }'
-      })
+      riot.register('my-component-1', SimpleComponent)
+      riot.register('my-component-2', SimpleComponent)
 
-      riot.mount(element1, {}, 'my-component-red')
-      riot.mount(element2, {}, 'my-component-green')
+      riot.mount(element1, {}, 'my-component-1')
+      riot.mount(element2, {}, 'my-component-2')
       riot.unmount(element1, true)
       riot.unmount(element2)
 
       expect(document.body.contains(element1)).to.be.ok
       expect(document.body.contains(element2)).to.be.not.ok
 
-      element2.parentNode.removeChild(element2)
-      riot.unregister('my-component-red')
-      riot.unregister('my-component-green')
+      element1.parentNode.removeChild(element1)
+      riot.unregister('my-component-1')
+      riot.unregister('my-component-2')
     })
 
     it('custom components be also functions', () => {

--- a/test/specs/core.spec.js
+++ b/test/specs/core.spec.js
@@ -259,6 +259,36 @@ describe('Riot core api', () => {
       riot.unregister('my-component')
     })
 
+    it('custom components can be unmounted by tag keeping the root element', () => {
+      const destroyedSpy = spy()
+      riot.register('my-component-red', {
+        css: 'my-component-red { color: red; }',
+        exports: {
+          onUnmounted() {
+            destroyedSpy()
+          }
+        }
+      })
+      riot.register('my-component-green', {
+        css: 'my-component-green { color: green; }',
+        exports: {
+          onUnmounted() {
+            destroyedSpy()
+          }
+        }
+      })
+      const element = document.createElement('div')
+
+      riot.mount(element, {}, 'my-component-red')
+      riot.unmount(element, true)
+      riot.mount(element, {}, 'my-component-green')
+      riot.unmount(element, true)
+
+      expect(destroyedSpy).to.have.been.calledTwice
+      riot.unregister('my-component-red')
+      riot.unregister('my-component-green')
+    })
+
     it('custom components be also functions', () => {
       const mountedSpy = spy()
       const MyComponent = {


### PR DESCRIPTION
This feature adds the keepRootElement argument to the riot.unmount method.

1. Have you added test(s) for your patch? If not, why not?

Yes, i've added a test for this feature, but i'm not sure if it is okay, please take a look at it first.

2. Can you provide an example of your patch in use?

No i couldn't create the the example, if it's needed i can create it.

3. Is this a breaking change?
No.

If you find any problems let me know, and i will fix according to your suggestions.
Thanks
Hugo D.