### PR TITLE
Fix mount function definition

### DIFF
--- a/riot.d.ts
+++ b/riot.d.ts
@@ -63,7 +63,7 @@ export type InstalledPluginsSet = Set<ComponentEnhancer>
 
 export function register<P, S>(componentName: string, shell: RiotComponentShell<P, S>): RegisteredComponentsMap
 export function unregister(componentName: string): RegisteredComponentsMap
-export function mount<P = object, S = object>(selector: string, componentName: string, initialProps?: P): RiotComponent<P, S>[]
+export function mount<P = object, S = object>(selector: string, initialProps?: P, componentName: string): RiotComponent<P, S>[]
 export function unmount(selector: string, keepRootElement: boolean):HTMLElement[]
 export function install(plugin: ComponentEnhancer):InstalledPluginsSet
 export function uninstall(plugin: ComponentEnhancer):InstalledPluginsSet

--- a/riot.d.ts
+++ b/riot.d.ts
@@ -63,7 +63,7 @@ export type InstalledPluginsSet = Set<ComponentEnhancer>
 
 export function register<P, S>(componentName: string, shell: RiotComponentShell<P, S>): RegisteredComponentsMap
 export function unregister(componentName: string): RegisteredComponentsMap
-export function mount<P = object, S = object>(selector: string, initialProps?: P, componentName: string): RiotComponent<P, S>[]
+export function mount<P = object, S = object>(selector: string, initialProps?: P, componentName?: string): RiotComponent<P, S>[]
 export function unmount(selector: string, keepRootElement: boolean):HTMLElement[]
 export function install(plugin: ComponentEnhancer):InstalledPluginsSet
 export function uninstall(plugin: ComponentEnhancer):InstalledPluginsSet

--- a/test/typing.spec.ts
+++ b/test/typing.spec.ts
@@ -32,11 +32,11 @@ const todo: TodoComponentShell = {
   template() {}
 }
 
-const component: TodoComponent = mount<TodoProps, TodoState>('todo', 'todo', {
+const component: TodoComponent = mount<TodoProps, TodoState>('todo', {
   initialItems: [
     { summary: 'buy eggs', done: false }
   ]
-})[0]
+}, 'todo')[0]
 
 component.update({ doShowDoneItems: false }, { })
 component.unmount(true)


### PR DESCRIPTION
Hi, 
There was an wrong in the definition for TypeScript of mount function.
But this is bad fix. The second argument can be omitted. 
I feel that the definition before correction is appropriate.
However, this is the same as the implemented mount function. 
I feel some discord with this.
I threw this pull request as a problem presentation.
If you are doing this for a reason, discard this pull request.

Thanks for reading!

* Have you added test(s) for your patch? If not, why not?
<s>No. Because it is a definition file modification.</s> 
 Executed npm test and confirmed no error.
* Can you provide an example of your patch in use?
No.
* Is this a breaking change?
No.