### PR TITLE
Allow access to parent before onBeforeMount() call

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -348,6 +348,7 @@ export function enhanceComponentAPI(component, {slots, attributes, props}) {
     runPlugins(
       defineProperties(isObject(component) ? Object.create(component) : component, {
         mount(element, state = {}, parentScope) {
+          this[PARENT_KEY_SYMBOL] = parentScope
           this[ATTRIBUTES_KEY_SYMBOL] = createAttributeBindings(element, attributes).mount(parentScope)
 
           defineProperty(this, PROPS_KEY, Object.freeze({
@@ -370,7 +371,6 @@ export function enhanceComponentAPI(component, {slots, attributes, props}) {
 
           // before mount lifecycle event
           this[ON_BEFORE_MOUNT_KEY](this[PROPS_KEY], this[STATE_KEY])
-          this[PARENT_KEY_SYMBOL] = parentScope
           // mount the template
           this[TEMPLATE_KEY_SYMBOL].mount(element, this, parentScope)
           this[ON_MOUNTED_KEY](this[PROPS_KEY], this[STATE_KEY])

--- a/test/components/parent-context-child.riot
+++ b/test/components/parent-context-child.riot
@@ -1,0 +1,35 @@
+<parent-context-child>
+  <script>
+    import {PARENT_KEY_SYMBOL} from '@riotjs/util/constants'
+
+    export default {
+      callParent(from) {
+        this[PARENT_KEY_SYMBOL].test.add(from);
+      },
+
+      onBeforeMount() {
+        this.callParent('onBeforeMount')
+      },
+
+      onMounted() {
+        this.callParent('onMounted')
+      },
+
+      onBeforeUpdate() {
+        this.callParent('onBeforeUpdate')
+      },
+
+      onUpdated() {
+        this.callParent('onUpdated')
+      },
+
+      onBeforeUnmount() {
+        this.callParent('onBeforeUnmount')
+      },
+
+      onUnmounted() {
+        this.callParent('onUnmounted')
+      }
+    }
+  </script>
+</parent-context-child>

--- a/test/components/parent-context.riot
+++ b/test/components/parent-context.riot
@@ -1,0 +1,15 @@
+<parent-context>
+  <parent-context-child></parent-context-child>
+
+  <script>
+    import parentContextChild from './parent-context-child.riot'
+
+    export default {
+      components: {
+        parentContextChild,
+      },
+
+      test: new Set()
+    }
+  </script>
+</parent-context>

--- a/test/specs/lifecycle-events.spec.js
+++ b/test/specs/lifecycle-events.spec.js
@@ -8,6 +8,7 @@ import InvalidPureCssComponent from '../components/invalid-pure-css-component.ri
 import InvalidPureHtmlComponent from '../components/invalid-pure-html-component.riot'
 import NativeAttributes from '../components/native-attributes.riot'
 import NativeInlineEvents from '../components/native-inline-events.riot'
+import ParentContext from '../components/parent-context.riot'
 import ParentValueProp from '../components/parent-value-prop.riot'
 import PureComponent from '../components/pure-component.riot'
 import PureObject from '../components/pure-object.riot'
@@ -242,5 +243,15 @@ describe('lifecycle events', () => {
     expect(h1.innerHTML).to.be.equal('above the commentbelow the comment')
 
     component.unmount()
+  })
+
+  it('child components have access to the parent scope throughout their entire lifecycle', () => {
+    const element = document.createElement('parent-context')
+    const component = riot.component(ParentContext)(element)
+
+    component.update()
+    component.unmount()
+
+    expect([...component.test]).to.eql(['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onUpdated', 'onBeforeUnmount', 'onUnmounted'])
   })
 })


### PR DESCRIPTION
### Answer the following depending on the type of change you want to merge
#### Code

1. Have you added test(s) for your patch? If not, why not?
Nothing to test

2. Can you provide an example of your patch in use?
Demo (bug with 5.4.1):
https://codesandbox.io/s/riotjs-5-provide-inject-bug-oub7z?file=/index.html
Demo (no bug, patched 5.4.1)
https://codesandbox.io/s/riotjs-5-provide-inject-k9m6u?file=/index.html

3. Is this a breaking change?
No

#### Content

Provide a short description about what you have changed:

Hello. I tried to make behavior similar to vue setup and provide / inject (https://v3.vuejs.org/guide/composition-api-provide-inject.html#scenario-background). I need `setup` to be executed before any `onBeforeMount` until the component is rendered. In this case, I can in the `setup` inject the data provided in the parent component and for this I need to have access to the parent before the component is rendered. I noticed that the link to the parent is at the very beginning of the mount method of the components and I did not find any reason why it cannot be raised higher. In this case, what I want to do is working as expected.