### PR TITLE
Improved typescript support

### DIFF
--- a/riot.d.ts
+++ b/riot.d.ts
@@ -8,7 +8,6 @@ import {
 } from '@riotjs/dom-bindings'
 
 // Internal Types and shortcuts
-export type Nil = null | undefined
 export type RegisteredComponentsMap = Map<string, () => RiotComponent>
 export type ComponentEnhancer = <Props = any, State = any>(component: RiotComponent<Props, State>) => RiotComponent<Props, State>
 export type InstalledPluginsSet = Set<ComponentEnhancer>
@@ -40,22 +39,22 @@ export interface RiotComponent<Props = any, State = any> {
     newState?: Partial<State>,
     parentScope?: object
   ): RiotComponent<Props, State>
-  unmount(keepRootElement: boolean): RiotComponent<Props, State>
+  unmount(keepRootElement?: boolean): RiotComponent<Props, State>
 
   // Helpers
-  $(selector: string): Element | Nil
+  $(selector: string): Element | null
   $$(selector: string): Element[]
 
   // state handling methods
-  shouldUpdate?(newProps: Props, currentProps: Props): boolean
+  shouldUpdate?(newProps: Props, oldProps: Props): boolean
 
   // lifecycle methods
-  onBeforeMount?(currentProps: Props, currentState: State): void
-  onMounted?(currentProps: Props, currentState: State): void
-  onBeforeUpdate?(currentProps: Props, currentState: State): void
-  onUpdated?(currentProps: Props, currentState: State): void
-  onBeforeUnmount?(currentProps: Props, currentState: State): void
-  onUnmounted?(currentProps: Props, currentState: State): void
+  onBeforeMount?(props: Props, state: State): void
+  onMounted?(props: Props, state: State): void
+  onBeforeUpdate?(props: Props, state: State): void
+  onUpdated?(props: Props, state: State): void
+  onBeforeUnmount?(props: Props, state: State): void
+  onUnmounted?(props: Props, state: State): void
 }
 
 // The Riot component object without the internals
@@ -85,16 +84,16 @@ export interface PureComponentFactoryFunction<InitialProps = any, Context = any>
 
 // This object interface is created anytime a riot file will be compiled into javascript
 export interface RiotComponentWrapper<Component = RiotComponent> {
-  readonly css?: string | Nil
-  readonly exports?: RiotComponentFactoryFunction<Component> | Component | Nil
-  readonly name?: string | Nil
+  readonly css?: string | null
+  readonly exports?: RiotComponentFactoryFunction<Component> | Component | null
+  readonly name?: string | null
 
-  template(
+  template?(
     template: (template: string, bindings?: BindingData<Component>[]) => TemplateChunk<Component>,
     expressionTypes: Record<keyof typeof ExpressionType, number>,
     bindingTypes: Record<keyof typeof BindingType, number>,
     getComponent: (componentName: string) => any
-  ): TemplateChunk<Component>
+  ): TemplateChunk<Component> | null
 }
 
 // Interface for components factory functions
@@ -107,7 +106,7 @@ export interface RiotComponentFactoryFunction<Component> {
 export function register<Props, State>(componentName: string, wrapper: RiotComponentWrapper<RiotComponent<Props, State>>): RegisteredComponentsMap
 export function unregister(componentName: string): RegisteredComponentsMap
 export function mount<Props, State>(selector: string | HTMLElement, initialProps?: Props, componentName?: string): RiotComponent<Props, State>[]
-export function unmount(selector: string | HTMLElement, keepRootElement: boolean): HTMLElement[]
+export function unmount(selector: string | HTMLElement, keepRootElement?: boolean): HTMLElement[]
 export function install(plugin: ComponentEnhancer): InstalledPluginsSet
 export function uninstall(plugin: ComponentEnhancer): InstalledPluginsSet
 export function component<Props, State, Component = RiotComponent<Props, State>>(wrapper: RiotComponentWrapper<Component>): (

--- a/riot.d.ts
+++ b/riot.d.ts
@@ -1,28 +1,35 @@
 import {
   SlotBindingData,
   TemplateChunk,
+  BindingData,
   AttributeExpressionData,
   ExpressionType,
-  BindingType,
-  template
+  BindingType
 } from '@riotjs/dom-bindings'
 
 // Internal Types and shortcuts
 export type Nil = null | undefined
-export type RegisteredComponentsMap = Map<string, () => RiotComponent<any, any>>
-export type ComponentEnhancer = <Props = object, State = object>(component: RiotComponent<Props, State>) => RiotComponent<Props, State>
+export type RegisteredComponentsMap = Map<string, () => RiotComponent>
+export type ComponentEnhancer = <Props = any, State = any>(component: RiotComponent<Props, State>) => RiotComponent<Props, State>
 export type InstalledPluginsSet = Set<ComponentEnhancer>
 export type RiotComponentsMap = {
-  [key: string]: RiotComponentShell<any, any>
+  [key: string]: RiotComponentWrapper
+}
+export type AutobindObjectMethods<Object, This> = {
+  [K in keyof Object]: Object[K] extends (...args: any) => any ? (this: This, ...args: Parameters<Object[K]>) => ReturnType<Object[K]> : Object[K]
 }
 
-// This interface is only exposed and any Riot component will receive the following properties
-export interface RiotCoreComponent<Props = object, State = object> {
+export interface RiotComponent<Props = any, State = any> {
   // automatically generated on any component instance
   readonly props: Props
   readonly root: HTMLElement
   readonly name?: string
   readonly slots: SlotBindingData[]
+
+  // mutable state property
+  state: State
+  // optional alias to map the children component names
+  components?: RiotComponentsMap
 
   mount(
     element: HTMLElement,
@@ -36,9 +43,25 @@ export interface RiotCoreComponent<Props = object, State = object> {
   unmount(keepRootElement: boolean): RiotComponent<Props, State>
 
   // Helpers
-  $(selector: string): HTMLElement
-  $$(selector: string): [HTMLElement]
+  $(selector: string): Element | Nil
+  $$(selector: string): Element[]
+
+  // state handling methods
+  shouldUpdate?(newProps: Props, currentProps: Props): boolean
+
+  // lifecycle methods
+  onBeforeMount?(currentProps: Props, currentState: State): void
+  onMounted?(currentProps: Props, currentState: State): void
+  onBeforeUpdate?(currentProps: Props, currentState: State): void
+  onUpdated?(currentProps: Props, currentState: State): void
+  onBeforeUnmount?(currentProps: Props, currentState: State): void
+  onUnmounted?(currentProps: Props, currentState: State): void
 }
+
+// The Riot component object without the internals
+// The internal attributes will be handled by the framework
+export type RiotComponentWithoutInternals<Component extends RiotComponent> = Omit<Component, 'props' | 'root' | 'name' | 'slots' | 'mount' | 'update' | 'unmount' | '$' | '$$'>
+export type RiotComponentWithoutInternalsAndInitialState<Component extends RiotComponent> = Omit<RiotComponentWithoutInternals<Component>, 'state'>
 
 // Riot Pure Component interface that should be used together with riot.pure
 export interface RiotPureComponent<Context = object> {
@@ -52,7 +75,7 @@ export interface RiotPureComponent<Context = object> {
   unmount(keepRootElement: boolean): RiotPureComponent<Context>
 }
 
-export interface PureComponentFactoryFunction<InitialProps = object, Context = object> {
+export interface PureComponentFactoryFunction<InitialProps = any, Context = any> {
   ({
      slots,
      attributes,
@@ -61,62 +84,49 @@ export interface PureComponentFactoryFunction<InitialProps = object, Context = o
 }
 
 // This object interface is created anytime a riot file will be compiled into javascript
-export interface RiotComponentShell<Props = object, State = object, ComponentExport = RiotComponentExport<Props, State>> {
+export interface RiotComponentWrapper<Component = RiotComponent> {
   readonly css?: string | Nil
-  readonly exports?: RiotComponentExportFactoryFunction<ComponentExport> | ComponentExport | Nil
+  readonly exports?: RiotComponentFactoryFunction<Component> | Component | Nil
   readonly name?: string | Nil
 
   template(
-    templateFn: (...params: Parameters<typeof template>) => TemplateChunk<RiotComponent<Props, State>>,
+    template: (template: string, bindings?: BindingData<Component>[]) => TemplateChunk<Component>,
     expressionTypes: Record<keyof typeof ExpressionType, number>,
     bindingTypes: Record<keyof typeof BindingType, number>,
     getComponent: (componentName: string) => any
-  ): TemplateChunk<RiotComponent<Props, State>>
+  ): TemplateChunk<Component>
 }
 
 // Interface for components factory functions
-export interface RiotComponentExportFactoryFunction<ComponentExport = RiotComponentExport> {
-  (): ComponentExport
+export interface RiotComponentFactoryFunction<Component> {
+  (): Component
   components?: RiotComponentsMap
-}
-
-// Interface that can be used to create the components export
-export interface RiotComponentExport<Props = object, State = object> {
-  // optional on the component object
-  state?: State
-
-  // optional alias to map the children component names
-  components?: RiotComponentsMap
-
-  // state handling methods
-  shouldUpdate?(newProps: Props, currentProps: Props): boolean
-
-  // lifecycle methods
-  onBeforeMount?(currentProps: Props, currentState: State): void
-  onMounted?(currentProps: Props, currentState: State): void
-  onBeforeUpdate?(currentProps: Props, currentState: State): void
-  onUpdated?(currentProps: Props, currentState: State): void
-  onBeforeUnmount?(currentProps: Props, currentState: State): void
-  onUnmounted?(currentProps: Props, currentState: State): void
-
-  [key: string]: any
-}
-
-// All the RiotComponent Public interface properties are optional
-export interface RiotComponent<Props = object, State = object> extends RiotCoreComponent<Props, State>, RiotComponentExport<Props, State> {
 }
 
 // Riot public API
-export function register<Props, State>(componentName: string, shell: RiotComponentShell<Props, State>): RegisteredComponentsMap
+export function register<Props, State>(componentName: string, wrapper: RiotComponentWrapper<RiotComponent<Props, State>>): RegisteredComponentsMap
 export function unregister(componentName: string): RegisteredComponentsMap
 export function mount<Props, State>(selector: string | HTMLElement, initialProps?: Props, componentName?: string): RiotComponent<Props, State>[]
 export function unmount(selector: string | HTMLElement, keepRootElement: boolean): HTMLElement[]
 export function install(plugin: ComponentEnhancer): InstalledPluginsSet
 export function uninstall(plugin: ComponentEnhancer): InstalledPluginsSet
-export function component<Props, State>(shell: RiotComponentShell<Props, State>): (
+export function component<Props, State, Component = RiotComponent<Props, State>>(wrapper: RiotComponentWrapper<Component>): (
   el: HTMLElement,
   initialProps?: Props,
   meta?: { slots: SlotBindingData[]; attributes: AttributeExpressionData[]; parentScope: any; }
-) => RiotComponent<Props, State>
-export function pure<InitialProps = object, Context = object, FactoryFunction = PureComponentFactoryFunction<InitialProps, Context>>(func: FactoryFunction): FactoryFunction
+) => Component
+
+export function pure<InitialProps = any, Context = any, FactoryFunction = PureComponentFactoryFunction<InitialProps, Context>>(func: FactoryFunction): FactoryFunction
+
 export const version: string
+
+// typescript specific methods
+export function withTypes<Component extends RiotComponent,
+  ComponentFactory = RiotComponentFactoryFunction<AutobindObjectMethods<RiotComponentWithoutInternals<Component>, Component>>
+  >(fn: ComponentFactory): () => Component
+export function withTypes<Component extends RiotComponent,
+  ComponentFactory = RiotComponentFactoryFunction<AutobindObjectMethods<RiotComponentWithoutInternalsAndInitialState<Component>, Component>>
+  >(fn: ComponentFactory): () => Component
+export function withTypes<Component extends RiotComponent, ComponentObjectWithInitialState = RiotComponentWithoutInternals<Component>>(component: AutobindObjectMethods<ComponentObjectWithInitialState, Component>): Component
+export function withTypes<Component extends RiotComponent, ComponentObjectWithoutInitialState = RiotComponentWithoutInternalsAndInitialState<Component>>(component: AutobindObjectMethods<ComponentObjectWithoutInitialState, Component>): Component
+

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -89,7 +89,7 @@ const MOCKED_TEMPLATE_INTERFACE = {
 
 /**
  * Performance optimization for the recursive components
- * @param  {RiotComponentShell} componentShell - riot compiler generated object
+ * @param  {RiotComponentWrapper} componentWrapper - riot compiler generated object
  * @returns {Object} component like interface
  */
 const memoizedCreateComponent = memoize(createComponent)
@@ -135,11 +135,11 @@ function createCoreAPIMethods(mapFunction) {
 /**
  * Factory function to create the component templates only once
  * @param   {Function} template - component template creation function
- * @param   {RiotComponentShell} componentShell - riot compiler generated object
+ * @param   {RiotComponentWrapper} componentWrapper - riot compiler generated object
  * @returns {TemplateChunk} template chunk object
  */
-function componentTemplateFactory(template, componentShell) {
-  const components = createSubcomponents(componentShell.exports ? componentShell.exports.components : {})
+function componentTemplateFactory(template, componentWrapper) {
+  const components = createSubcomponents(componentWrapper.exports ? componentWrapper.exports.components : {})
 
   return template(
     createTemplate,
@@ -147,7 +147,7 @@ function componentTemplateFactory(template, componentShell) {
     bindingTypes,
     name => {
       // improve support for recursive components
-      if (name === componentShell.name) return memoizedCreateComponent(componentShell)
+      if (name === componentWrapper.name) return memoizedCreateComponent(componentWrapper)
       // return the registered components
       return components[name] || COMPONENTS_IMPLEMENTATION_MAP.get(name)
     }
@@ -191,18 +191,18 @@ function createPureComponent(pureFactoryFunction, { slots, attributes, props, cs
 
 /**
  * Create the component interface needed for the @riotjs/dom-bindings tag bindings
- * @param   {RiotComponentShell} componentShell - riot compiler generated object
- * @param   {string} componentShell.css - component css
- * @param   {Function} componentShell.template - function that will return the dom-bindings template function
- * @param   {Object} componentShell.exports - component interface
- * @param   {string} componentShell.name - component name
+ * @param   {RiotComponentWrapper} componentWrapper - riot compiler generated object
+ * @param   {string} componentWrapper.css - component css
+ * @param   {Function} componentWrapper.template - function that will return the dom-bindings template function
+ * @param   {Object} componentWrapper.exports - component interface
+ * @param   {string} componentWrapper.name - component name
  * @returns {Object} component like interface
  */
-export function createComponent(componentShell) {
-  const {css, template, exports, name} = componentShell
+export function createComponent(componentWrapper) {
+  const {css, template, exports, name} = componentWrapper
   const templateFn = template ? componentTemplateFactory(
     template,
-    componentShell
+    componentWrapper
   ) : MOCKED_TEMPLATE_INTERFACE
 
   return ({slots, attributes, props}) => {

--- a/src/riot.js
+++ b/src/riot.js
@@ -118,6 +118,13 @@ export function pure(func) {
   return func
 }
 
+/**
+ * no-op function needed to add the proper types to your component via typescript
+ * @param {Function|Object} component - component default export
+ * @returns {Function|Object} returns exactly what it has received
+ */
+export const withTypes = component => component
+
 /** @type {string} current riot version */
 export const version = 'WIP'
 

--- a/test/specs/compiler.spec.js
+++ b/test/specs/compiler.spec.js
@@ -13,6 +13,7 @@ describe('Riot compiler api', () => {
       'uninstall',
       'component',
       'pure',
+      'withTypes',
       'version',
       '__',
       // compiler API

--- a/test/specs/public-api.spec.js
+++ b/test/specs/public-api.spec.js
@@ -14,6 +14,7 @@ describe('Riot public api', () => {
       'uninstall',
       'component',
       'pure',
+      'withTypes',
       'version',
       '__'
     ])

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -24,7 +24,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -33,9 +33,9 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
@@ -60,7 +60,7 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "files": [
-    "typing.spec.ts"
+  "include": [
+    "typing/**/*",
   ]
 }

--- a/test/typing/component-function-export.spec.ts
+++ b/test/typing/component-function-export.spec.ts
@@ -1,0 +1,94 @@
+import {RiotComponentWrapper} from '../../riot'
+import {RiotComponent, withTypes} from '../../riot'
+import ConditionalSlot from './conditional-slot.riot'
+
+export type ConditionalSlotProps = {
+
+}
+
+export type ConditionalSlotState = {
+  mustShowSlot: boolean
+}
+
+export type ConditionalSlotComponent = RiotComponent<ConditionalSlotProps, ConditionalSlotState>
+
+export default {
+  'css': null,
+
+  'exports': withTypes<ConditionalSlotComponent>(() => ({
+    state: {
+      mustShowSlot: false
+    },
+
+    components: {
+      ConditionalSlot
+    }
+  })),
+  'template': function(
+    template,
+    expressionTypes,
+    bindingTypes,
+    getComponent
+  ) {
+    return template(
+      '<conditional-slot expr1="expr1"></conditional-slot>',
+      [
+        {
+          'type': bindingTypes.TAG,
+          'getComponent': getComponent,
+
+          'evaluate': function(
+            _scope
+          ) {
+            return 'conditional-slot';
+          },
+
+          'slots': [
+            {
+              'id': 'default',
+              'html': '<p>Hello there</p><b expr2="expr2"></b>',
+
+              'bindings': [
+                {
+                  'type': bindingTypes.IF,
+
+                  'evaluate': function(
+                    _scope
+                  ) {
+                    return _scope.state.mustShowSlot;
+                  },
+
+                  'redundantAttribute': 'expr2',
+                  'selector': '[expr2]',
+
+                  'template': template(
+                    'I am visible',
+                    []
+                  )
+                }
+              ]
+            }
+          ],
+
+          'attributes': [
+            {
+              'type': expressionTypes.ATTRIBUTE,
+              'name': 'is-visible',
+
+              'evaluate': function(
+                _scope
+              ) {
+                return _scope.state.mustShowSlot;
+              }
+            }
+          ],
+
+          'redundantAttribute': 'expr1',
+          'selector': '[expr1]'
+        }
+      ]
+    );
+  },
+
+  'name': 'conditional-slot-parent'
+} as RiotComponentWrapper<ConditionalSlotComponent>;

--- a/test/typing/component-object-export.spec.ts
+++ b/test/typing/component-object-export.spec.ts
@@ -1,0 +1,153 @@
+import {RiotComponentWrapper, RiotComponent, withTypes} from '../../riot'
+
+export interface RandomComponentState {
+  number: number | null;
+  logs: { text: string }[];
+}
+
+export interface RandomComponentProps {
+  title: string;
+}
+
+
+export interface RandomComponent extends RiotComponent<RandomComponentProps, RandomComponentState> {
+  generate(event: MouseEvent): void
+
+  clearLogs(): void
+
+  state: RandomComponentState
+}
+
+const Random = withTypes<RandomComponent>({
+  state: {
+    number: null,
+    logs: []
+  },
+
+  generate(event) {
+    this.update({
+      number: Math.floor(Math.random() * 10000),
+      logs: this.state.logs.concat({
+        text: `Generate button clicked. Event type is ${event.type}`
+      })
+    })
+  },
+
+  clearLogs(): void {
+    this.update({
+      logs: []
+    })
+  }
+})
+
+export default {
+  'css': undefined,
+  'exports': Random,
+  'template': function (
+    template,
+    expressionTypes,
+    bindingTypes,
+    getComponent
+  ) {
+    return template(
+      '<h3 expr1="expr1"> </h3><button expr2="expr2">\n    Generate\n  </button><h1 expr3="expr3"> </h1><logs expr4="expr4"></logs>',
+      [
+        {
+          'redundantAttribute': 'expr1',
+          'selector': '[expr1]',
+
+          'expressions': [
+            {
+              'type': expressionTypes.TEXT,
+              'childNodeIndex': 0,
+
+              'evaluate': function (
+                _scope
+              ) {
+                return _scope.props.title;
+              }
+            }
+          ]
+        },
+        {
+          'redundantAttribute': 'expr2',
+          'selector': '[expr2]',
+
+          'expressions': [
+            {
+              'type': expressionTypes.EVENT,
+              'name': 'onclick',
+
+              'evaluate': function (
+                _scope
+              ) {
+                return _scope.generate;
+              }
+            }
+          ]
+        },
+        {
+          'redundantAttribute': 'expr3',
+          'selector': '[expr3]',
+
+          'expressions': [
+            {
+              'type': expressionTypes.TEXT,
+              'childNodeIndex': 0,
+
+              'evaluate': function (
+                _scope
+              ) {
+                return [
+                  _scope.state.number
+                ].join(
+                  ''
+                );
+              }
+            }
+          ]
+        },
+        {
+          'type': bindingTypes.TAG,
+          'getComponent': getComponent,
+
+          'evaluate': function (
+            _scope
+          ) {
+            return 'logs';
+          },
+
+          'slots': [],
+
+          'attributes': [
+            {
+              'type': expressionTypes.ATTRIBUTE,
+              'name': 'logs',
+
+              'evaluate': function (
+                _scope
+              ) {
+                return _scope.state.logs;
+              }
+            },
+            {
+              'type': expressionTypes.EVENT,
+              'name': 'onclear',
+
+              'evaluate': function (
+                _scope
+              ) {
+                return _scope.clearLogs;
+              }
+            }
+          ],
+
+          'redundantAttribute': 'expr4',
+          'selector': '[expr4]'
+        }
+      ]
+    );
+  },
+
+  'name': 'random'
+} as RiotComponentWrapper<RandomComponent>;

--- a/test/typing/public-api.spec.ts
+++ b/test/typing/public-api.spec.ts
@@ -1,12 +1,12 @@
 import {
-  RiotComponentShell,
   RiotComponent,
   mount,
   unmount,
   register,
   unregister,
-} from '../riot'
-import { template } from '@riotjs/dom-bindings'
+  version,
+  RiotComponentWrapper
+} from '../../riot'
 
 interface TodoItem {
   summary: string
@@ -22,17 +22,11 @@ interface TodoState {
   doShowDoneItems: boolean
 }
 
-interface TodoComponentShell extends RiotComponentShell<TodoProps, TodoState> {
-}
-
 interface TodoComponent extends RiotComponent<TodoProps, TodoState> {
 }
 
-//  equivalent to `import todo from "todo"`
-const todo: TodoComponentShell = {
-  template(template, expressionTypes, bindingTypes, getComponent) {
-    return template('Hello')
-  }
+const wrapper: RiotComponentWrapper<TodoComponent> =  {
+
 }
 
 const component: TodoComponent = mount<TodoProps, TodoState>('todo', {
@@ -43,3 +37,10 @@ const component: TodoComponent = mount<TodoProps, TodoState>('todo', {
 
 component.update({ doShowDoneItems: false }, { })
 component.unmount(true)
+
+const el = document.createElement('div')
+unmount(el)
+register('todo', wrapper)
+unregister('todo')
+
+el.innerHTML = version

--- a/test/typing/shims-riot.d.ts
+++ b/test/typing/shims-riot.d.ts
@@ -1,0 +1,8 @@
+declare module '*.riot' {
+  // @ts-ignore
+  import {RiotComponetWrapper, RiotComponent} from '../../riot'
+
+  const componentWrapper: RiotComponetWrapper<RiotComponent>
+
+  export default componentWrapper
+}


### PR DESCRIPTION
This PR is a breaking change and adds the `withTypes` method in order to get a better typescript support to Riot.js components.

The new method allows us writing components as follows:

```riot
<my-component>
  <p>{ state.greeting }{ props.username }</p>

  <!--
    Notice that lang="ts" does actually nothing.
    It's just needed to let your IDE interpret the above code as typescript.
    The riot compiler will ignore it
  -->
  <script lang="ts">
    import {withTypes, RiotComponent} from 'riot'

    export type MyComponentProps = {
      username: string
    }

    export type MyComponentState = {
      message: string
    }

    export type MyComponent = RiotComponent<MyComponentProps, MyComponentState>

    export default withTypes<MyComponent>({
      state: {
        message: 'hello'
      }
    })
  </script>
</my-component>
```

This is a breaking change that requires a new RIot and Compiler release.

