### PR TITLE
Added: test for #3024

### DIFF
--- a/test/components/default-content-slot.riot
+++ b/test/components/default-content-slot.riot
@@ -1,0 +1,16 @@
+<default-content-slot>
+  <slot text={'Four.'}>
+    One.
+    <span>{state.text}</span>
+    <template if={true}>Three.</template>
+    { text }
+  </slot>
+
+  <script>
+    export default {
+      state: {
+        text: 'Two.'
+      }
+    }
+  </script>
+</default-content-slot>

--- a/test/components/issue-3014.riot
+++ b/test/components/issue-3014.riot
@@ -1,7 +1,0 @@
-<issue-3014>
-  <slot>
-    <template if={true}>
-      Default content
-    </template>
-  </slot>
-</issue-3014>

--- a/test/specs/slots.spec.js
+++ b/test/specs/slots.spec.js
@@ -10,7 +10,7 @@ import NestedSlot from '../components/nested-slot.riot'
 import ParentWithSlotsComponent from '../components/parent-with-slots.riot'
 import SimpleSlot from '../components/simple-slot.riot'
 import TemplateSlot from '../components/template-slot.riot'
-import Issue3014SlotFallback from '../components/issue-3014.riot'
+import DefaultContentSlot from '../components/default-content-slot.riot'
 
 import { expect } from 'chai'
 
@@ -189,12 +189,18 @@ describe('slots', () => {
     component.unmount()
   })
 
-  it('slots fallback expressions can be properly rendered (https://github.com/riot/riot/issues/3014)', () => {
-    const element = document.createElement('issue-3014')
-    const component = riot.component(Issue3014SlotFallback)(element)
+  it('slots fallback expressions can be properly rendered and have access to own component context (https://github.com/riot/riot/issues/3014, https://github.com/riot/riot/issues/3024)', () => {
+    const element = document.createElement('default-content-slot')
+    const component = riot.component(DefaultContentSlot)(element)
 
-    expect(normalizeInnerHTML(component.root.innerHTML)).to.be.equal(
-      'Default content',
+    expect(component.root.textContent.replace(/\s+/g, '')).to.be.equal(
+        'One.Two.Three.Four.',
+    )
+
+    component.update()
+
+    expect(component.root.textContent.replace(/\s+/g, '')).to.be.equal(
+        'One.Two.Three.Four.',
     )
 
     component.unmount()


### PR DESCRIPTION
The issue itself is caused by the following code:

```
  // this function is only meant to fix an edge case
  // https://github.com/riot/riot/issues/2842
  const getRealParent = (scope, parentScope) => scope[PARENT_KEY_SYMBOL] || parentScope;
```

A future call to `this.getTemplateScope(scope, realParent)` returns the `realParent` context. However, when dealing with default slot content, we should use `scope` instead of calling `getRealParent`