### PR TITLE
use record as default props and state

### DIFF
--- a/riot.d.ts
+++ b/riot.d.ts
@@ -14,6 +14,9 @@ import {
 } from '@riotjs/dom-bindings'
 
 // Internal Types and shortcuts
+export type DefaultProps = Record<PropertyKey, any>;
+export type DefaultState = Record<PropertyKey, any>;
+
 export type RegisteredComponentsMap = Map<
   string,
   ({
@@ -23,10 +26,13 @@ export type RegisteredComponentsMap = Map<
   }: {
     slots?: TagSlotData[]
     attributes?: AttributeExpressionData[]
-    props?: any
+    props?: DefaultProps
   }) => RiotComponent
 >
-export type ComponentEnhancer = <Props = any, State = any>(
+export type ComponentEnhancer = <
+  Props extends DefaultProps = DefaultProps,
+  State extends DefaultState = DefaultState
+>(
   component: RiotComponent<Props, State>,
 ) => RiotComponent<Props, State>
 export type InstalledPluginsSet = Set<ComponentEnhancer>
@@ -41,9 +47,6 @@ export type AutobindObjectMethods<Object, Component extends RiotComponent> = {
       ) => ReturnType<Object[K]>
     : Object[K]
 }
-
-export type DefaultProps = Record<PropertyKey, any>;
-export type DefaultState = Record<PropertyKey, any>;
 
 export interface RiotComponent<
   Props extends DefaultProps = DefaultProps,
@@ -114,7 +117,7 @@ export interface RiotPureComponent<Context = object> {
 }
 
 export interface PureComponentFactoryFunction<
-  InitialProps = any,
+  InitialProps extends DefaultProps = DefaultProps,
   Context = any,
 > {
   ({
@@ -152,14 +155,20 @@ export interface RiotComponentFactoryFunction<Component> {
 }
 
 // Riot public API
-export declare function register<Props, State>(
+export declare function register<
+  Props extends DefaultProps,
+  State extends DefaultState
+>(
   componentName: string,
   wrapper: RiotComponentWrapper<RiotComponent<Props, State>>,
 ): RegisteredComponentsMap
 export declare function unregister(
   componentName: string,
 ): RegisteredComponentsMap
-export declare function mount<Props, State>(
+export declare function mount<
+  Props extends DefaultProps,
+  State extends DefaultState
+>(
   selector: string | HTMLElement,
   initialProps?: Props,
   componentName?: string,
@@ -173,8 +182,8 @@ export declare function uninstall(
   plugin: ComponentEnhancer,
 ): InstalledPluginsSet
 export declare function component<
-  Props,
-  State,
+  Props extends DefaultProps,
+  State extends DefaultState,
   Component = RiotComponent<Props, State>,
 >(
   wrapper: RiotComponentWrapper<Component>,
@@ -189,7 +198,7 @@ export declare function component<
 ) => Component
 
 export declare function pure<
-  InitialProps = any,
+  InitialProps extends DefaultProps = DefaultProps,
   Context = any,
   FactoryFunction = PureComponentFactoryFunction<InitialProps, Context>,
 >(func: FactoryFunction): FactoryFunction

--- a/riot.d.ts
+++ b/riot.d.ts
@@ -42,7 +42,13 @@ export type AutobindObjectMethods<Object, Component extends RiotComponent> = {
     : Object[K]
 }
 
-export interface RiotComponent<Props = any, State = any> {
+export type DefaultProps = Record<string, any>;
+export type DefaultState = Record<PropertyKey, any>;
+
+export interface RiotComponent<
+  Props extends DefaultProps = DefaultProps,
+  State extends DefaultState = DefaultState
+> {
   // automatically generated on any component instance
   readonly props: Props
   readonly root: HTMLElement

--- a/riot.d.ts
+++ b/riot.d.ts
@@ -42,7 +42,7 @@ export type AutobindObjectMethods<Object, Component extends RiotComponent> = {
     : Object[K]
 }
 
-export type DefaultProps = Record<string, any>;
+export type DefaultProps = Record<PropertyKey, any>;
 export type DefaultState = Record<PropertyKey, any>;
 
 export interface RiotComponent<

--- a/test/typing/with-types-infer.ts
+++ b/test/typing/with-types-infer.ts
@@ -9,3 +9,13 @@ export const Component = withTypes({
     this.onClick()
   },
 })
+
+export const Component2 = withTypes({
+  onClick() {
+    this.update({ clicked: true })
+  },
+  onMounted() {
+    this.state = 2
+    this.onClick()
+  },
+})


### PR DESCRIPTION
### Answer the following depending on the type of change you want to merge

#### Code

1. Have you added test(s) for your patch? If not, why not?

No, I'm not sure how. I tried checking the test files but I didn't understand where I should put a test for the failure cases.

2. Can you provide an example of your patch in use?

Taking as example the "with-types-infer" test file, the following should work:
```typescript
import { withTypes } from '../../riot'

export const Component = withTypes({
  onClick() {
    this.update({ clicked: true })
  },
  onMounted() {
    this.state = { clicked: false }
    this.onClick()
  },
})
```

but the following should not:
```typescript
import { withTypes } from '../../riot'

export const Component = withTypes({
  onClick() {
    this.update({ clicked: true })
  },
  onMounted() {
    this.state = 2;
    this.onClick()
  },
})
```

In the current implementation the second example doesn't provide an error.
This patch fixes this behavior, since the state I think is expected to be an record.

I also apply the change to the default props type since it is sure to be a record instead any.

3. Is this a breaking change?

It shouldn't but I'm not sure...

#### Content

I replaced "any" with "Record" types for the default values of state and props in RiotComponent